### PR TITLE
Fixed initial execution engine test

### DIFF
--- a/FSharp.Data.GraphQL.sln
+++ b/FSharp.Data.GraphQL.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".paket", ".paket", "{63297B98-5CED-492C-A5B7-A5B4F73CF142}"
 	ProjectSection(SolutionItems) = preProject
@@ -34,6 +34,8 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{ED8079DD-2B06-4030-9F0F-DC548F98E1C4}"
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FSharp.Data.GraphQL.Tests", "tests\FSharp.Data.GraphQL.Tests\FSharp.Data.GraphQL.Tests.fsproj", "{54AAFE43-FA5F-485A-AD40-0240165FC633}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{B0C25450-74BF-40C2-9E02-09AADBAE2C2F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/FSharp.Data.GraphQL/Ast.fs
+++ b/src/FSharp.Data.GraphQL/Ast.fs
@@ -36,7 +36,7 @@ and Selection =
     | FragmentSpread of FragmentSpread
     /// 2.2.6.2 Inline Fragments
     | InlineFragment of FragmentDefinition
-    member x.Directives with get() =
+    member x.Directives =
         match x with
         | Field f -> f.Directives
         | FragmentSpread s -> s.Directives
@@ -52,7 +52,7 @@ and Field =
         Directives: Directive list
         SelectionSet: Selection list
     }
-    member x.AliasOrName with get() = 
+    member x.AliasOrName = 
         match x.Alias with
         | Some alias -> alias
         | None -> x.Name
@@ -115,7 +115,7 @@ and Directive =
         Name: string
         Arguments: Argument list
     }
-    member x.If with get () = x.Arguments |> List.find (fun arg -> arg.Name = "if")
+    member x.If = x.Arguments |> List.find (fun arg -> arg.Name = "if")
 
 // Type System Definition
 

--- a/src/FSharp.Data.GraphQL/Schema.fs
+++ b/src/FSharp.Data.GraphQL/Schema.fs
@@ -68,7 +68,7 @@ type Schema(query: GraphQLType, ?mutation: GraphQLType) =
                 match x with
                 | :? 'T as t -> coerceOutput t
                 | _ -> None)
-            CoerceValue = coerceValue >> box
+            CoerceValue = coerceValue >> Option.map box
         }
         
     /// GraphQL type for user defined enums
@@ -90,7 +90,7 @@ type Schema(query: GraphQLType, ?mutation: GraphQLType) =
         | Some i -> implements o i
 
     /// Single field defined inside either object types or interfaces
-    static member Field (name: string, schema: GraphQLType, resolve: 'Object * Map<string, obj> * ResolveInfo -> 'Value, ?description: string, ?arguments: ArgumentDefinition list): FieldDefinition = {
+    static member Field (name: string, schema: GraphQLType, resolve: 'Object * Args * ResolveInfo -> 'Value, ?description: string, ?arguments: ArgumentDefinition list): FieldDefinition = {
         Name = name
         Description = description
         Type = schema
@@ -102,7 +102,7 @@ type Schema(query: GraphQLType, ?mutation: GraphQLType) =
     }
     
     /// Single field defined inside either object types or interfaces
-    static member Field (name: string, schema: GraphQLType, resolve: 'Object * Map<string, obj> -> 'Value, ?description: string, ?arguments: ArgumentDefinition list): FieldDefinition =
+    static member Field (name: string, schema: GraphQLType, resolve: 'Object * Args -> 'Value, ?description: string, ?arguments: ArgumentDefinition list): FieldDefinition =
         {
             Name = name
             Description = description


### PR DESCRIPTION
- Resolve args have been changed from map to separate class. `Arg` method can now resolve argument value just like `Map.tryFind`, but it also will try to perform necessary cast.
- Example execution test have been fixed and it's now passing.
- Some of the function, that previously were boxing options, now return `obj option` instead.
