### PR TITLE
Mutations and async

### DIFF
--- a/src/FSharp.Data.GraphQL/Execution.fs
+++ b/src/FSharp.Data.GraphQL/Execution.fs
@@ -293,8 +293,8 @@ let private evaluate (schema: #ISchema) doc operation variables root =
         // at the moment both execution procedures works the same
         // ultimately only difference is that mutation requires to 
         // maintain order of executed resolve invocations, while query doesn't
-        let groupedFieldSet = collectFields ctx schema.Query operation.SelectionSet  (ref [])
-        executeFields ctx schema.Query ctx.RootValue groupedFieldSet
+        let groupedFieldSet = collectFields ctx schema.Mutation.Value operation.SelectionSet  (ref [])
+        executeFields ctx schema.Mutation.Value ctx.RootValue groupedFieldSet
     | Query ->
         let groupedFieldSet = collectFields ctx schema.Query operation.SelectionSet  (ref [])
         executeFields ctx schema.Query ctx.RootValue groupedFieldSet

--- a/tests/FSharp.Data.GraphQL.Tests/Helpers.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/Helpers.fs
@@ -17,7 +17,10 @@ let throws<'e when 'e :> exn> (action : unit -> unit) = Assert.Throws<'e>(action
 let sync = Async.RunSynchronously
 let field name typedef (resolve : 'a -> 'b) = Define.Field(name = name, schema = typedef, resolve = (fun _ a -> resolve a))
 let fieldA name typedef args (resolve : ResolveFieldContext -> 'a -> 'b) = 
-    Define.Field(name = name, schema = typedef, arguments = args, resolve = resolve)
+    Define.Field(name = name, schema = typedef, arguments = args, resolve = resolve)    
+let asyncField name typedef (resolve : 'a -> Async<'b>) = Define.AsyncField(name = name, schema = typedef, resolve = (fun _ a -> resolve a))
+let asyncFieldA name typedef args (resolve : ResolveFieldContext -> 'a -> Async<'b>) = 
+    Define.AsyncField(name = name, schema = typedef, arguments = args, resolve = resolve)
 let arg name typedef = Define.Argument(name, typedef)
 let objdef name fields = Define.ObjectType(name, fields)
 

--- a/tests/FSharp.Data.GraphQL.Tests/IntrospectionTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/IntrospectionTests.fs
@@ -18,7 +18,7 @@ let ``Introspection executes an introspection query`` () =
     ]
     let schema = Schema(root)
     let (Object raw) = root
-    let result = schema.Execute(parse introspectionQuery, raw)
+    let result = sync <| schema.AsyncExecute(parse introspectionQuery, raw)
     noErrors result
     let expected: Map<string,obj> =
         Map.ofList<string, obj> [

--- a/tests/FSharp.Data.GraphQL.Tests/MutationTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/MutationTests.fs
@@ -18,11 +18,11 @@ type Root =
     }
     member x.ChangeImmediatelly num = 
         x.NumberHolder.Number <- num
-        x.NumberHolder.Number
+        x.NumberHolder
     member x.ChangeAsync num = 
         async { 
             x.NumberHolder.Number <- num 
-            return x.NumberHolder.Number
+            return x.NumberHolder
         }    
     member x.ChangeFail(num): int = 
         failwith "Cannot change number"
@@ -69,6 +69,7 @@ let ``Execute: Handles mutation execution ordering: evaluates mutations serially
         "fourth", upcast Map.ofList [ "theNumber", 4 :> obj]
         "fifth",  upcast Map.ofList [ "theNumber", 5 :> obj]
     ]
+    noErrors mutationResult
     equals expected mutationResult.Data.Value
     
 [<Fact>]

--- a/tests/FSharp.Data.GraphQL.Tests/MutationTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/MutationTests.fs
@@ -19,14 +19,14 @@ type Root =
     member x.ChangeImmediatelly num = 
         x.NumberHolder.Number <- num
         x.NumberHolder
-    member x.ChangeAsync num = 
+    member x.AsyncChange num = 
         async { 
             x.NumberHolder.Number <- num 
             return x.NumberHolder
         }    
     member x.ChangeFail(num): int = 
         failwith "Cannot change number"
-    member x.ChangeFailAsync(num): Async<int> = 
+    member x.AsyncChangeFail(num): Async<int> = 
         async { 
             return failwith "Cannot change number"
         }
@@ -36,9 +36,9 @@ let schema = Schema(
     query = objdef "Query" [ field "numberHolder" NumberHolder (fun x -> x.NumberHolder) ],
     mutation = objdef "Mutation" [
         fieldA "immediatelyChangeTheNumber" NumberHolder [arg "newNumber" Int] (fun ctx (x:Root) -> x.ChangeImmediatelly(ctx.Arg("newNumber").Value))
-        fieldA "promiseToChangeTheNumber" NumberHolder [arg "newNumber" Int] (fun ctx (x:Root) -> x.ChangeAsync(ctx.Arg("newNumber").Value))
+        asyncFieldA "promiseToChangeTheNumber" NumberHolder [arg "newNumber" Int] (fun ctx (x:Root) -> x.AsyncChange(ctx.Arg("newNumber").Value))
         fieldA "failToChangeTheNumber" NumberHolder [arg "newNumber" Int] (fun ctx (x:Root) -> x.ChangeFail(ctx.Arg("newNumber").Value))
-        fieldA "promiseAndFailToChangeTheNumber" NumberHolder [arg "newNumber" Int] (fun ctx (x:Root) -> x.ChangeFailAsync(ctx.Arg("newNumber").Value))
+        asyncFieldA "promiseAndFailToChangeTheNumber" NumberHolder [arg "newNumber" Int] (fun ctx (x:Root) -> x.AsyncChangeFail(ctx.Arg("newNumber").Value))
     ])
 
 [<Fact>]
@@ -61,7 +61,7 @@ let ``Execute: Handles mutation execution ordering: evaluates mutations serially
       }
     }"""
 
-    let mutationResult = schema.Execute(parse query, {NumberHolder = {Number = 6}})
+    let mutationResult = sync <| schema.AsyncExecute(parse query, {NumberHolder = {Number = 6}})
     let expected: Map<string, obj> = Map.ofList [
         "first",  upcast Map.ofList [ "theNumber", 1 :> obj]
         "second", upcast Map.ofList [ "theNumber", 2 :> obj]
@@ -95,7 +95,8 @@ let ``Execute: Handles mutation execution ordering: evaluates mutations correctl
       }
     }"""
 
-    let mutationResult = schema.Execute(parse query, {NumberHolder = {Number = 6}})
+    let data = {NumberHolder = {Number = 6}}
+    let mutationResult = sync <| schema.AsyncExecute(parse query, data)
     let expected: Map<string, obj> = Map.ofList [
         "first",  upcast Map.ofList [ "theNumber", 1 :> obj]
         "second", upcast Map.ofList [ "theNumber", 2 :> obj]


### PR DESCRIPTION
- Fixed existing mutation execution - mutation tests are now passing.
- Introduced F# `Async` in existing code - right now most of the operations are working in async fashion:
  - Field resolution on queries is performed in parallel
  - Field resolution on mutations is performed in sync (this is GraphQL spec requirement)
- Each field resolution is now isolated - any failure during resolve function application won't cause the whole query/mutation to fail. Instead null will be returned and error message will be collected and attached to the returned execution response.
