### PR TITLE
Sample GraphQL server

### DIFF
--- a/FSharp.Data.GraphQL.sln
+++ b/FSharp.Data.GraphQL.sln
@@ -37,6 +37,11 @@ Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FSharp.Data.GraphQL.Tests",
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{B0C25450-74BF-40C2-9E02-09AADBAE2C2F}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "graphiql", "graphiql", "{5DC4AE38-2814-4E36-9E75-95AA1FC384EB}"
+	ProjectSection(SolutionItems) = preProject
+		samples\graphiql\server.fsx = samples\graphiql\server.fsx
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -59,5 +64,6 @@ Global
 		{83F16175-43B1-4C90-A1EE-8E351C33435D} = {A6A6AF7D-D6E3-442D-9B1E-58CC91879BE1}
 		{8E6D5255-776D-4B61-85F9-73C37AA1FB9A} = {A6A6AF7D-D6E3-442D-9B1E-58CC91879BE1}
 		{54AAFE43-FA5F-485A-AD40-0240165FC633} = {ED8079DD-2B06-4030-9F0F-DC548F98E1C4}
+		{5DC4AE38-2814-4E36-9E75-95AA1FC384EB} = {B0C25450-74BF-40C2-9E02-09AADBAE2C2F}
 	EndGlobalSection
 EndGlobal

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,5 +1,7 @@
 source https://nuget.org/api/v2
 nuget FParsec
+nuget Newtonsoft.Json
+nuget Suave
 
 group Build
   source https://nuget.org/api/v2

--- a/paket.lock
+++ b/paket.lock
@@ -2,6 +2,10 @@ NUGET
   remote: https://www.nuget.org/api/v2
   specs:
     FParsec (1.0.2)
+    FSharp.Core (4.0.0.1)
+    Newtonsoft.Json (8.0.3)
+    Suave (1.1.2)
+      FSharp.Core (>= 3.1.2.5)
 
 GROUP Build
 NUGET
@@ -15,10 +19,10 @@ NUGET
       FSharpVSPowerTools.Core (>= 2.3 < 2.4)
     FSharpVSPowerTools.Core (2.3)
       FSharp.Compiler.Service (>= 2.0.0.3)
-    Microsoft.Bcl (1.1.10) - framework: net10, net11, net20, net30, net35, net40, net40-full
+    Microsoft.Bcl (1.1.10) - framework: net10, net11, net20, net35, net40, net40
       Microsoft.Bcl.Build (>= 1.0.14)
-    Microsoft.Bcl.Build (1.0.21) - import_targets: false, framework: net10, net11, net20, net30, net35, net40, net40-full
-    Microsoft.Net.Http (2.2.29) - framework: net10, net11, net20, net30, net35, net40, net40-full
+    Microsoft.Bcl.Build (1.0.21) - import_targets: false, framework: net10, net11, net20, net35, net40, net40
+    Microsoft.Net.Http (2.2.29) - framework: net10, net11, net20, net35, net40, net40
       Microsoft.Bcl (>= 1.1.10)
       Microsoft.Bcl.Build (>= 1.0.14)
     Octokit (0.19)

--- a/samples/graphiql/server.fsx
+++ b/samples/graphiql/server.fsx
@@ -1,0 +1,167 @@
+#r "../../packages/Suave/lib/net40/Suave.dll"
+#r "../../packages/Newtonsoft.Json/lib/net40/Newtonsoft.Json.dll"
+#r "../../src/FSharp.Data.GraphQL/bin/Debug/FSharp.Data.GraphQL.dll"
+
+open System
+
+// Data
+type Episode = 
+    | NewHope = 1
+    | Empire = 2
+    | Jedi = 3
+
+type Human = 
+    { Id : string
+      Name : string option
+      Friends : string list
+      AppearsIn : Episode list
+      HomePlanet : string option }
+
+type Droid = 
+    { Id : string
+      Name : string option
+      Friends : string list
+      AppearsIn : Episode list
+      PrimaryFunction : string option }
+
+let humans = 
+    [ { Id = "1000"
+        Name = Some "Luke Skywalker"
+        Friends = [ "1002"; "1003"; "2000"; "2001" ]
+        AppearsIn = [ Episode.NewHope; Episode.Empire; Episode.Jedi ]
+        HomePlanet = Some "Tatooine" }
+      { Id = "1001"
+        Name = Some "Darth Vader"
+        Friends = [ "1004" ]
+        AppearsIn = [ Episode.NewHope; Episode.Empire; Episode.Jedi ]
+        HomePlanet = Some "Tatooine" }
+      { Id = "1002"
+        Name = Some "Han Solo"
+        Friends = [ "1000"; "1003"; "2001" ]
+        AppearsIn = [ Episode.NewHope; Episode.Empire; Episode.Jedi ]
+        HomePlanet = None }
+      { Id = "1003"
+        Name = Some "Leia Organa"
+        Friends = [ "1000"; "1002"; "2000"; "2001" ]
+        AppearsIn = [ Episode.NewHope; Episode.Empire; Episode.Jedi ]
+        HomePlanet = Some "Alderaan" }
+      { Id = "1004"
+        Name = Some "Wilhuff Tarkin"
+        Friends = [ "1001" ]
+        AppearsIn = [ Episode.NewHope ]
+        HomePlanet = None } ]
+
+let droids = 
+    [ { Id = "2000"
+        Name = Some "C-3PO"
+        Friends = [ "1000"; "1002"; "1003"; "2001" ]
+        AppearsIn = [ Episode.NewHope; Episode.Empire; Episode.Jedi ]
+        PrimaryFunction = Some "Protocol" }
+      { Id = "2001"
+        Name = Some "R2-D2"
+        Friends = [ "1000"; "1002"; "1003" ]
+        AppearsIn = [ Episode.NewHope; Episode.Empire; Episode.Jedi ]
+        PrimaryFunction = Some "Astromech" } ]
+
+let getHuman id = humans |> List.find (fun human -> human.Id = id)
+let getDroid id = droids |> List.find (fun droid -> droid.Id = id)
+
+// Schema definition
+open FSharp.Data.GraphQL
+open FSharp.Data.GraphQL.Types
+open FSharp.Data.GraphQL.Execution
+
+let EpisodeType = Define.Enum(
+    name = "Episode",
+    description = "One of the films in the Star Wars Trilogy",
+    options = [
+        Define.EnumValue("NEWHOPE", Episode.NewHope, "Released in 1977.")
+        Define.EnumValue("EMPIRE", Episode.Empire, "Released in 1980.")
+        Define.EnumValue("JEDI", Episode.Jedi, "Released in 1983.")])
+
+let rec CharacterType = Define.Interface(
+    name = "Character",
+    description = "A character in the Star Wars Trilogy",
+    resolveType = (fun o ->
+        match o with
+        | :? Human -> HumanType
+        | :? Droid -> DroidType
+        | _ -> failwithf "Value of type '%s' is not a Character type" (o.GetType().FullName)),
+    fields = fun () -> [
+        Define.Field("id", NonNull String, "The id of the character.")
+        Define.Field("name", String, "The name of the character.")
+        Define.Field("friends", ListOf String, "The friends of the character, or an empty list if they have none.")
+        Define.Field("appearsIn", ListOf EpisodeType, "Which movies they appear in.")])
+
+and HumanType = Define.Object(
+    name = "Human",
+    description = "A humanoid creature in the Star Wars universe.",
+    interfaces = [ CharacterType ],
+    isTypeOf = (fun o -> o :? Human),
+    fields = [
+        Define.Field("id", NonNull String, "The id of the human.")
+        Define.Field("name", String, "The name of the human.")
+        Define.Field("friends", ListOf String, "The friends of the human, or an empty list if they have none.")
+        Define.Field("appearsIn", ListOf EpisodeType, "Which movies they appear in.")
+        Define.Field("homePlanet", String, "The home planet of the human, or null if unknown.")])
+        
+and DroidType = Define.Object(
+    name = "Droid",
+    description = "A mechanical creature in the Star Wars universe.",
+    interfaces = [ CharacterType ],
+    isTypeOf = (fun o -> o :? Droid),
+    fields = [
+        Define.Field("id", NonNull String, "The id of the droid.")
+        Define.Field("name", String, "The name of the Droid.")
+        Define.Field("friends", ListOf String, "The friends of the Droid, or an empty list if they have none.")
+        Define.Field("appearsIn", ListOf EpisodeType, "Which movies they appear in.")
+        Define.Field("primaryFunction", String, "The primary function of the droid.")])
+
+let Query = Define.Object(
+    name = "Query",
+    fields = [
+        Define.Field("hero", CharacterType, args = [ Define.Arg("id", String) ], resolve = fun ctx _ -> getHuman (ctx.Arg("id").Value))
+        Define.Field("droid", CharacterType, args = [ Define.Arg("id", String) ], resolve = fun ctx _ -> getDroid (ctx.Arg("id").Value))])
+
+let schema = Schema(Query)
+
+// server initialization
+open Suave
+open Suave.Operators
+open Newtonsoft.Json
+
+type OptionConverter() =
+    inherit JsonConverter()
+    
+    override x.CanConvert(t) = 
+        t.IsGenericType && t.GetGenericTypeDefinition() = typedefof<option<_>>
+
+    override x.WriteJson(writer, value, serializer) =
+        let value = 
+            if value = null then null
+            else 
+                let _,fields = Microsoft.FSharp.Reflection.FSharpValue.GetUnionFields(value, value.GetType())
+                fields.[0]  
+        serializer.Serialize(writer, value)
+
+    override x.ReadJson(reader, t, existingValue, serializer) = failwith "Not supported"
+    
+let settings = JsonSerializerSettings()
+settings.Converters <- [| OptionConverter() :> JsonConverter |]
+settings.ContractResolver <- Newtonsoft.Json.Serialization.CamelCasePropertyNamesContractResolver()
+let json o = JsonConvert.SerializeObject(o, settings)
+    
+let graphiql : WebPart =
+    fun http ->
+        async {
+            match http.request.fieldData "query" with
+            | Choice1Of2 query ->
+                let! result = schema.AsyncExecute(query)   
+                return! http |> Successful.OK (json result)
+            | Choice2Of2 err ->
+                return! http |> ServerErrors.INTERNAL_ERROR err
+        }
+
+startWebServer defaultConfig (graphiql >=> Writers.setMimeType "application/json")
+// Example:
+// curl --form 'query={ hero(id: "1000") { id, name, appearsIn } }' http://localhost:8083/

--- a/src/FSharp.Data.GraphQL/FSharp.Data.GraphQL.fsproj
+++ b/src/FSharp.Data.GraphQL/FSharp.Data.GraphQL.fsproj
@@ -82,7 +82,7 @@
   -->
   <Import Project="..\..\.paket\paket.targets" />
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1')">
       <ItemGroup>
         <Reference Include="FParsec">
           <HintPath>..\..\packages\FParsec\lib\net40-client\FParsec.dll</HintPath>

--- a/src/FSharp.Data.GraphQL/Introspection.fs
+++ b/src/FSharp.Data.GraphQL/Introspection.fs
@@ -63,7 +63,7 @@ let __DirectiveLocation = Define.Enum(
 let mutable __Type = Define.Object(
     name = "__Type",
     description = """The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum. Depending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.""",
-    fields = [
+    fields = fun () -> [
         Define.Field("kind", NonNull __TypeKind, resolve = graphQLKind)
         Define.Field("name", NonNull String, resolve = fun _ t ->
             match t with
@@ -75,11 +75,10 @@ let mutable __Type = Define.Object(
         Define.Field("description", String)
     ])
    
-open System.Reflection
 let __InputValue = Define.Object(
     name = "__InputValue",
     description = "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.",
-    fields = [
+    fields = fun () -> [
         Define.Field("name", NonNull String)
         Define.Field("description", String)
         Define.Field("type", NonNull __Type)
@@ -94,7 +93,7 @@ let __InputValue = Define.Object(
 let __Field = Define.Object(
     name = "__Field",
     description = "Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.",
-    fields = [
+    fields = fun () -> [
         Define.Field("name", NonNull String)
         Define.Field("description", String)
         Define.Field("args", NonNull(ListOf (NonNull __InputValue)))
@@ -106,7 +105,7 @@ let __Field = Define.Object(
 let __EnumValue = Define.Object(
     name = "__EnumValue",
     description = "One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.",
-    fields = [
+    fields = fun () -> [
         Define.Field("name", NonNull String)
         Define.Field("description", String)
         Define.Field("isDeprecated", NonNull Boolean, resolve = fun _ (e: EnumValue) -> Option.isSome e.DeprecationReason)
@@ -148,7 +147,7 @@ __Type <-  mergeFields __Type [
 let __Directive = Define.Object(
     name = "__Directive",
     description = """A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document. In some cases, you need to provide options to alter GraphQL’s execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.""",
-    fields = [
+    fields = fun () -> [
         Define.Field("name", NonNull String)
         Define.Field("description", String)
         Define.Field("locations", NonNull (ListOf (NonNull __DirectiveLocation)), resolve = fun _ (directive: DirectiveDef) -> flagsToList directive.Locations)
@@ -163,7 +162,7 @@ let __Directive = Define.Object(
 let __Schema = Define.Object(
     name = "__Schema",
     description = "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.",
-    fields = [
+    fields = fun () -> [
         Define.Field("types", NonNull (ListOf (NonNull __Type)), description = "A list of all types supported by this server.", resolve = fun _ (schema: ISchema) -> (schema :> System.Collections.Generic.IEnumerable<NamedDef>))
         Define.Field("queryType", NonNull __Type, description = "The type that query operations will be rooted at.", resolve = fun _ (schema: ISchema) -> schema.Query)
         Define.Field("mutationType", __Type, description = "If this server supports mutation, the type that mutation operations will be rooted at.", resolve = fun _ (schema: ISchema) -> schema.Mutation)

--- a/src/FSharp.Data.GraphQL/Relay.fs
+++ b/src/FSharp.Data.GraphQL/Relay.fs
@@ -23,7 +23,7 @@ type Connection<'Node> =
 let Edge nodeType = Define.Object(
     name = nodeType.ToString() + "Edge",
     description = "An edge in a connection from an object to another object of type " + nodeType.ToString(),
-    fields = [
+    fields = fun () -> [
         Define.Field("cursor", NonNull String, fun _ edge -> edge.Cursor, "A cursor for use in pagination")
         Define.Field("node", nodeType, fun _ edge -> edge.Node, "The item at the end of the edge")
     ]) 
@@ -31,7 +31,7 @@ let Edge nodeType = Define.Object(
 let PageInfo = Define.Object(
     name = "PageInfo",
     description = "Information about pagination in a connection.",
-    fields = [
+    fields = fun () -> [
         Define.Field("hasNextPage", NonNull Boolean, fun _ pageInfo -> pageInfo.HasNextPage, "When paginating forwards, are there more items?")
         Define.Field("hasPreviousPage", NonNull Boolean, fun _ pageInfo -> pageInfo.HasPreviousPage, "When paginating backwards, are there more items?")
         Define.Field("startCursor", String, fun _ pageInfo -> pageInfo.StartCursor, "When paginating backwards, the cursor to continue.")
@@ -41,7 +41,7 @@ let PageInfo = Define.Object(
 let ConnectionType nodeType = Define.Object(
     name = nodeType.ToString(),
     description = "A connection from an object to a list of objects of type " + nodeType.ToString(),
-    fields = [
+    fields = fun () -> [
         Define.Field("totalCount", Int, fun _ conn -> conn.TotalCount , """A count of the total number of objects in this connection, ignoring pagination. 
                     This allows a client to fetch the first five objects by passing \"5\" as the argument 
                     to `first`, then fetch the total count so it could display \"5 of 83\", for example. 

--- a/src/FSharp.Data.GraphQL/Schema.fs
+++ b/src/FSharp.Data.GraphQL/Schema.fs
@@ -42,7 +42,12 @@ type Schema(query: ObjectDef, ?mutation: ObjectDef, ?types: NamedDef list, ?dire
             addOrReturn typedef.Name typedef ns' 
         | List (Named innerdef) -> insert ns innerdef 
         | NonNull (Named innerdef) -> insert ns innerdef
-        | InputObject innerdef -> insert ns innerdef
+        | InputObject objdef -> 
+            let ns' = addOrReturn objdef.Name typedef ns
+            objdef.Fields
+            |> List.collect (fun x -> (x.Type :> TypeDef) :: (x.Args |> List.map (fun a -> a.Type)))
+            |> List.filter (fun (Named x) -> not (Map.containsKey x.Name ns'))
+            |> List.fold (fun n (Named t) -> insert n t) ns'
         
     let initialTypes: NamedDef list = [ 
         Int

--- a/src/FSharp.Data.GraphQL/TypeSystem.fs
+++ b/src/FSharp.Data.GraphQL/TypeSystem.fs
@@ -120,28 +120,18 @@ and EnumDef =
 and [<CustomEquality; NoComparison>] ObjectDef = 
     { Name : string
       Description : string option
-      mutable Fields : FieldDef list
-      mutable Implements : InterfaceDef list
-      mutable IsTypeOf : (obj -> bool) option }
+      Fields : FieldDef list
+      Implements : InterfaceDef list
+      IsTypeOf : (obj -> bool) option }
 
     interface TypeDef
     interface OutputDef
     interface CompositeDef
     interface NamedDef with
         member x.Name = x.Name
-    
-    member x.AddField(field : FieldDef) = 
-        match List.tryFind<FieldDef> (fun f -> f.Name = field.Name) x.Fields with
-        | Some _ -> 
-            let msg = 
-                sprintf 
-                    "Cannot merge field %A into object type %s, because it already has field %A sharing the same name." 
-                    field x.Name x
-            raise (GraphQLException msg)
-        | None -> x.Fields <- x.Fields @ [ field ]
-    
+        
     interface IEquatable<ObjectDef> with
-        member x.Equals f = x.Name = f.Name && x.Description = f.Description && x.Fields = f.Fields
+        member x.Equals f = x.Name = f.Name && x.Fields = f.Fields
     
     override x.Equals y = 
         match y with
@@ -174,7 +164,7 @@ and [<CustomEquality; NoComparison>] FieldDef =
       DeprecationReason : string option }
     
     interface IEquatable<FieldDef> with
-        member x.Equals f = x.Name = f.Name && x.Description = f.Description && x.Type = f.Type && x.Args = f.Args
+        member x.Equals f = x.Name = f.Name && x.Type = f.Type && x.Args = f.Args
     
     override x.Equals y = 
         match y with
@@ -199,8 +189,8 @@ and [<CustomEquality; NoComparison>] FieldDef =
 and [<CustomEquality; NoComparison>]InterfaceDef = 
     { Name : string
       Description : string option
-      mutable Fields : FieldDef list
-      mutable ResolveType: (obj -> ObjectDef) option }
+      Fields : FieldDef list
+      ResolveType: (obj -> ObjectDef) option }
 
     interface TypeDef
     interface OutputDef
@@ -210,7 +200,7 @@ and [<CustomEquality; NoComparison>]InterfaceDef =
         member x.Name = x.Name
       
     interface IEquatable<InterfaceDef> with
-        member x.Equals f = x.Name = f.Name && x.Description = f.Description && x.Fields = f.Fields
+        member x.Equals f = x.Name = f.Name && x.Fields = f.Fields
     
     override x.Equals y = 
         match y with
@@ -401,14 +391,23 @@ module SchemaDefinitions =
         match x with
         | :? string as y -> Some(StringValue y)
         | _ -> None
+        
+    /// Check if provided obj value is an Option and extract its wrapped value as object if possible
+    let (|Option|_|) (x: obj) =
+        let t = x.GetType()
+        if t.IsGenericType && t.GetGenericTypeDefinition() = typedefof<option<_>> 
+        then
+            let _,fields = Microsoft.FSharp.Reflection.FSharpValue.GetUnionFields(x, t)
+            Some (fields.[0])
+        else None
     
     let internal coerceStringValue (x : obj) : string option = 
         match x with
         | null -> None
-        | :? bool as b -> 
-            Some(if b then "true"
-                 else "false")
-        | other -> Some(other.ToString())
+        | :? string as s -> Some s
+        | :? bool as b -> Some(if b then "true" else "false")
+        | Option o -> Some(o.ToString())
+        | _ -> Some(x.ToString())
     
     let private coerceIntInput = 
         function 
@@ -694,20 +693,34 @@ module SchemaDefinitions =
               DeprecationReason = deprecationReason }
         
         /// GraphQL custom object type
-        static member Object(name : string, fields : FieldDef list, ?description : string, 
-                                 ?interfaces : InterfaceDef list, ?isTypeOf : obj -> bool) : ObjectDef = 
+        static member Object(name : string, fields : unit -> FieldDef list, ?description : string, ?interfaces : InterfaceDef list, ?isTypeOf : obj -> bool) : ObjectDef = 
             let o = 
                 { Name = name
-                         Description = description
-                         Fields = fields
-                         Implements = []
-                         IsTypeOf = isTypeOf }
+                  Description = description
+                  Fields = fields()
+                  Implements = []
+                  IsTypeOf = isTypeOf }
+            match interfaces with
+            | None -> o
+            | Some i -> implements o i
+
+        /// GraphQL custom object type
+        static member Object(name : string, fields : FieldDef list, ?description : string, ?interfaces : InterfaceDef list, ?isTypeOf : obj -> bool) : ObjectDef = 
+            let o = 
+                { Name = name
+                  Description = description
+                  Fields = fields
+                  Implements = []
+                  IsTypeOf = isTypeOf }
             match interfaces with
             | None -> o
             | Some i -> implements o i
             
         /// GraphQL custom input object type
-        static member InputObject(name : string, fields : FieldDef list) : InputObjectDef = { Name = name; Fields = fields}
+        static member InputObject(name : string, fields : unit -> FieldDef list) : InputObjectDef = { Name = name; Fields = fields() }
+        
+        /// GraphQL custom input object type
+        static member InputObject(name : string, fields : FieldDef list) : InputObjectDef = { Name = name; Fields = fields }
         
         /// Single field defined inside either object types or interfaces
         static member Field(name : string, typedef : OutputDef, resolve : ResolveFieldContext -> 'Object -> 'Value, ?description : string, ?args : ArgDef list, ?deprecationReason : string) : FieldDef = 
@@ -751,6 +764,13 @@ module SchemaDefinitions =
                   match defaultValue with
                   | Some value -> Some(upcast value)
                   | None -> None }
+        
+        /// GraphQL custom interface type. It's needs to be implemented object types and should not be used alone.
+        static member Interface(name : string, fields : unit -> FieldDef list, ?description : string, ?resolveType: obj -> ObjectDef) : InterfaceDef = 
+            { Name = name
+              Description = description
+              Fields = fields()
+              ResolveType = resolveType }
         
         /// GraphQL custom interface type. It's needs to be implemented object types and should not be used alone.
         static member Interface(name : string, fields : FieldDef list, ?description : string, ?resolveType: obj -> ObjectDef) : InterfaceDef = 

--- a/src/FSharp.Data.GraphQL/TypeSystem.fs
+++ b/src/FSharp.Data.GraphQL/TypeSystem.fs
@@ -60,7 +60,7 @@ and ResolveFieldContext =
       Args : Map<string, obj>
       Operation : OperationDefinition
       Fragments : FragmentDefinition list
-      Variables : Map<string, obj option> }
+      Variables : Map<string, obj> }
     member x.Arg(name : string) : 't option = 
         match Map.tryFind name x.Args with
         | Some o -> Some(o :?> 't)
@@ -602,7 +602,7 @@ module SchemaDefinitions =
                   Type = NonNull Boolean
                   DefaultValue = None } ] }
     
-    let rec internal coerceAstValue (variables : Map<string, obj option>) (value : Value) : obj = 
+    let rec internal coerceAstValue (variables : Map<string, obj>) (value : Value) : obj = 
         match value with
         | IntValue i -> upcast i
         | StringValue s -> upcast s
@@ -615,7 +615,7 @@ module SchemaDefinitions =
         | ObjectValue fields -> 
             let mapped = fields |> Map.map (fun k v -> coerceAstValue variables v)
             upcast mapped
-        | Variable variable -> variables.[variable] |> Option.toObj
+        | Variable variable -> variables.[variable]
     
     /// Adds a single field to existing object type, returning new object type in result.
     let mergeField (objectType : ObjectDef) (field : FieldDef) : ObjectDef = 
@@ -705,6 +705,9 @@ module SchemaDefinitions =
             match interfaces with
             | None -> o
             | Some i -> implements o i
+            
+        /// GraphQL custom input object type
+        static member InputObject(name : string, fields : FieldDef list) : InputObjectDef = { Name = name; Fields = fields}
         
         /// Single field defined inside either object types or interfaces
         static member Field(name : string, typedef : OutputDef, resolve : ResolveFieldContext -> 'Object -> 'Value, ?description : string, ?args : ArgDef list, ?deprecationReason : string) : FieldDef = 

--- a/tests/FSharp.Data.GraphQL.Tests/AbstractionTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/AbstractionTests.fs
@@ -17,12 +17,12 @@ type Human = { Name: string; }
 
 [<Fact>]
 let ``Execute handles execution of abstract types: isTypeOf is used to resolve runtime type for Interface`` () = 
-    let PetType = Define.Interface("Pet", [ Define.Field("name", String) ])
+    let PetType = Define.Interface("Pet", fun () -> [ Define.Field("name", String) ])
     let DogType = Define.Object(
         name = "Dog", 
         isTypeOf = is<Dog>,
         interfaces = [ PetType ],
-        fields = [
+        fields = fun () -> [
             Define.Field("name", String)
             Define.Field("woofs", Boolean)
         ])
@@ -30,15 +30,14 @@ let ``Execute handles execution of abstract types: isTypeOf is used to resolve r
         name = "Cat", 
         isTypeOf = is<Cat>,
         interfaces = [ PetType ],
-        fields = [
+        fields = fun () -> [
             Define.Field("name", String)
             Define.Field("meows", Boolean)
         ])
     let schema = Schema(
         types = [CatType; DogType],
-        query = Define.Object("Query", [
-            Define.Field("pets", ListOf PetType, resolve = fun _ _ -> 
-                [ { Name = "Odie"; Woofs = true } :> obj; upcast { Name = "Garfield"; Meows = false } ])
+        query = Define.Object("Query", fun () -> [
+            Define.Field("pets", ListOf PetType, resolve = fun _ _ -> [ { Name = "Odie"; Woofs = true } :> obj; upcast { Name = "Garfield"; Meows = false } ])
         ]))
     let query = """{
       pets {
@@ -68,20 +67,20 @@ let ``Execute handles execution of abstract types: isTypeOf is used to resolve r
     let DogType = Define.Object(
         name = "Dog", 
         isTypeOf = is<Dog>,
-        fields = [
+        fields = fun () -> [
             Define.Field("name", String)
             Define.Field("woofs", Boolean)
         ])
     let CatType = Define.Object(
         name = "Cat", 
         isTypeOf = is<Cat>,
-        fields = [
+        fields = fun () -> [
             Define.Field("name", String)
             Define.Field("meows", Boolean)
         ])
     let PetType = Define.Union("Pet", [ DogType; CatType ])
     let schema = Schema(
-        query = Define.Object("Query", [
+        query = Define.Object("Query", fun () -> [
             Define.Field("pets", ListOf PetType, resolve = fun _ _ -> 
                 [ { Name = "Odie"; Woofs = true } :> obj; upcast { Name = "Garfield"; Meows = false } ])
         ]))

--- a/tests/FSharp.Data.GraphQL.Tests/ExecutionTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/ExecutionTests.fs
@@ -126,14 +126,12 @@ let ``Execution handles basic tasks: merges parallel fragments`` () =
         deep { c, deeper: deep { c } }
       }"""
 
-    let mutable Type = objdef "Type" [
+    let rec Type = Define.Object("Type", (fun () -> [
         field "a" String (fun () -> "Apple")
         field "b" String (fun () -> "Banana")
         field "c" String (fun () -> "Cherry")
-    ]
-    //TODO: API fix - self referencing data type
-    let (Object x) = Type
-    x.AddField (field "deep" Type id)
+        field "deep" Type id
+    ]))
 
     let schema = Schema(Type)
     let expected: Map<string, obj> = Map.ofList [

--- a/tests/FSharp.Data.GraphQL.Tests/FSharp.Data.GraphQL.Tests.fsproj
+++ b/tests/FSharp.Data.GraphQL.Tests/FSharp.Data.GraphQL.Tests.fsproj
@@ -62,6 +62,39 @@
   </Target>
   -->
   <Import Project="..\..\.paket\paket.targets" />
+  <ItemGroup>
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="Helpers.fs" />
+    <Compile Include="AbstractionTests.fs" />
+    <Compile Include="DirectivesTests.fs" />
+    <Compile Include="ValidationTests.fs" />
+    <Compile Include="ParserTests.fs" />
+    <Compile Include="SchemaTests.fs" />
+    <Compile Include="CoercionTests.fs" />
+    <Compile Include="IntrospectionTests.fs" />
+    <Compile Include="ReflectedSchemaTests.fs" />
+    <Compile Include="ExecutionTests.fs" />
+    <Compile Include="MutationTests.fs" />
+    <Compile Include="ResolveTests.fs" />
+    <Compile Include="UnionInterfaceTests.fs" />
+    <Compile Include="VariablesTests.fs" />
+    <None Include="paket.references" />
+    <Content Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib" />
+    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Numerics" />
+    <ProjectReference Include="..\..\src\FSharp.Data.GraphQL\FSharp.Data.GraphQL.fsproj">
+      <Name>FSharp.Data.GraphQL</Name>
+      <Project>{474179d3-0090-49e9-88f8-2971c0966077}</Project>
+      <Private>True</Private>
+    </ProjectReference>
+  </ItemGroup>
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1')">
       <ItemGroup>
@@ -111,37 +144,4 @@
       </ItemGroup>
     </When>
   </Choose>
-  <ItemGroup>
-    <Compile Include="AssemblyInfo.fs" />
-    <Compile Include="Helpers.fs" />
-    <Compile Include="AbstractionTests.fs" />
-    <Compile Include="DirectivesTests.fs" />
-    <Compile Include="ValidationTests.fs" />
-    <Compile Include="ParserTests.fs" />
-    <Compile Include="SchemaTests.fs" />
-    <Compile Include="CoercionTests.fs" />
-    <Compile Include="IntrospectionTests.fs" />
-    <Compile Include="ReflectedSchemaTests.fs" />
-    <Compile Include="ExecutionTests.fs" />
-    <Compile Include="MutationTests.fs" />
-    <Compile Include="ResolveTests.fs" />
-    <Compile Include="UnionInterfaceTests.fs" />
-    <Compile Include="VariablesTests.fs" />
-    <None Include="paket.references" />
-    <Content Include="App.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="mscorlib" />
-    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Numerics" />
-    <ProjectReference Include="..\..\src\FSharp.Data.GraphQL\FSharp.Data.GraphQL.fsproj">
-      <Name>FSharp.Data.GraphQL</Name>
-      <Project>{474179d3-0090-49e9-88f8-2971c0966077}</Project>
-      <Private>True</Private>
-    </ProjectReference>
-  </ItemGroup>
 </Project>

--- a/tests/FSharp.Data.GraphQL.Tests/Helpers.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/Helpers.fs
@@ -22,7 +22,7 @@ let asyncField name typedef (resolve : 'a -> Async<'b>) = Define.AsyncField(name
 let asyncFieldA name typedef args (resolve : ResolveFieldContext -> 'a -> Async<'b>) = 
     Define.AsyncField(name = name, typedef = typedef, arguments = args, resolve = resolve)
 let arg name typedef = Define.Arg(name, typedef)
-let objdef name fields = Define.Object(name, fields)
+let objdef name (fields: FieldDef list) = Define.Object(name, fields)
 let is<'t> (o: obj) = o :? 't
 let hasError errMsg errors =
     let containsMessage = 

--- a/tests/FSharp.Data.GraphQL.Tests/UnionInterfaceTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/UnionInterfaceTests.fs
@@ -95,12 +95,12 @@ let ``Execute can introspect on union and intersection types`` () =
             "kind", box "INTERFACE"
             "name", upcast "Named"
             "fields", upcast [
-                "name", box "name"]
+                box (Map.ofList [ "name", box "name"])]
             "interfaces", null
             "possibleTypes", upcast [
-                "name", box "Person"
-                "name", box "Dog"
-                "name", box "Cat"]
+                box (Map.ofList ["name", box "Person"])
+                upcast Map.ofList ["name", box "Dog"]
+                upcast Map.ofList ["name", box "Cat"]]
             "enumValues", null
             "inputFields", null]
         "Pet", upcast Map.ofList [
@@ -109,8 +109,8 @@ let ``Execute can introspect on union and intersection types`` () =
             "fields", null
             "interfaces", null
             "possibleTypes", upcast [
-                "name", box "Dog"
-                "name", box "Cat"]
+                box (Map.ofList ["name", box "Cat"])
+                upcast Map.ofList ["name", box "Dog"]]
             "enumValues", null
             "inputFields", null]]
     noErrors actual

--- a/tests/FSharp.Data.GraphQL.Tests/VariablesTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/VariablesTests.fs
@@ -18,7 +18,7 @@ let TestComplexScalar = Define.Scalar(
     coerceOutput = (fun value -> if value = "DeserializedValue" then Some (StringValue "SerializedValue") else None),
     coerceValue = (fun value -> if value = upcast "DeserializedValue" then Some "SerializedValue" else None))
 
-let TestInputObject = Define.Object(
+let TestInputObject = Define.InputObject(
     name = "TestInputObject",
     fields = [
         Define.Field("a", String)
@@ -27,7 +27,7 @@ let TestInputObject = Define.Object(
         Define.Field("d", TestComplexScalar)
     ])
 
-let TestNestedInputObject = Define.Object(
+let TestNestedInputObject = Define.InputObject(
     name = "TestNestedInputObject",
     fields = [
         Define.Field("na", NonNull TestInputObject)
@@ -447,7 +447,7 @@ let ``Execute handles list inputs and nullability and does not allow unknown typ
 let ``Execute uses argument default value when no argument was provided`` () =
     let ast = parse """{ fieldWithDefaultArgumentValue }"""
     let actual = sync <| schema.AsyncExecute(ast)
-    let expected: Map<string, obj> = Map.ofList [ "fieldWithDefaultArgumentValue", upcast [ "hello world" ]]
+    let expected: Map<string, obj> = Map.ofList [ "fieldWithDefaultArgumentValue", upcast "hello world" ]
     noErrors actual
     equals expected actual.Data.Value
     
@@ -457,7 +457,7 @@ let ``Execute uses argument default value when nullable variable provided`` () =
         fieldWithDefaultArgumentValue(input: $optional)
       }"""
     let actual = sync <| schema.AsyncExecute(ast, variables = Map.ofList ["optional", null ])
-    let expected: Map<string, obj> = Map.ofList [ "fieldWithDefaultArgumentValue", upcast [ "hello world" ]]
+    let expected: Map<string, obj> = Map.ofList [ "fieldWithDefaultArgumentValue", upcast "hello world" ]
     noErrors actual
     equals expected actual.Data.Value
     
@@ -465,6 +465,6 @@ let ``Execute uses argument default value when nullable variable provided`` () =
 let ``Execute uses argument default value when argument provided cannot be parsed`` () =
     let ast = parse """{ fieldWithDefaultArgumentValue(input: WRONG_TYPE) }"""
     let actual = sync <| schema.AsyncExecute(ast)
-    let expected: Map<string, obj> = Map.ofList [ "fieldWithDefaultArgumentValue", upcast [ "hello world" ]]
+    let expected: Map<string, obj> = Map.ofList [ "fieldWithDefaultArgumentValue", upcast "hello world" ]
     noErrors actual
     equals expected actual.Data.Value


### PR DESCRIPTION
### Sample Suave.IO server

`server.fsx` contains example of graphql api server. After running it one can easily test a sample query using i.e. curl, like: 

> curl --form 'query={ hero(id: "1000") { id, name, appearsIn } }' http://localhost:8083/
### Input Object

Now complex input types for arguments and variables can be defined.
### Bug fixes
- Some minor fixes in argument values coercion, including: 
  - list wrapping for single elements (previously that was a problem, when string element was used, as it was evaluated as collection of chars)
  - option types coercion to string (by default it was coerced using option.ToString() which resulted with wrong value)
- Fixed resolving field definitions for meta types (as part of fixing Introspection API).
- Meta types resolution is now (properly) returning null instead of empty lists on value absence.
- Fixed broken expected values in some of the tests.
- Partially fixed problem of self-referencing GraphQL type definitions. This one is solved by defining fields as function (delayed evaluation) instead of lists (immediately evaluated).
