### PR TITLE
Recursive example

### DIFF
--- a/src/FSharp.Data.GraphQL/Execution.fs
+++ b/src/FSharp.Data.GraphQL/Execution.fs
@@ -216,7 +216,9 @@ let private resolveField value ctx fieldDef = async {
         let! resolved = fieldDef.Resolve ctx value 
         return Choice1Of2 (Option.ofObj resolved )
     with
-    | ex -> return Choice2Of2 (GraphQLError ex.Message) }
+    | ex -> 
+        let error = (value, ctx, fieldDef)
+        return Choice2Of2 (GraphQLError ex.Message) }
 
 open FSharp.Data.GraphQL.Introspection
 /// Takes an object type and a field, and returns that field’s type on the object type, or null if the field is not valid on the object type

--- a/src/FSharp.Data.GraphQL/Introspection.fs
+++ b/src/FSharp.Data.GraphQL/Introspection.fs
@@ -60,7 +60,7 @@ let __DirectiveLocation = Define.Enum(
         Define.EnumValue("INLINE_FRAGMENT", DirectiveLocation.INLINE_FRAGMENT, "Location adjacent to an inline fragment.")
     ])
     
-let mutable __Type = Define.Object(
+let rec __Type = Define.Object(
     name = "__Type",
     description = """The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum. Depending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.""",
     fields = fun () -> [
@@ -73,9 +73,38 @@ let mutable __Type = Define.Object(
                 | null -> null
                 | property -> property.GetValue(t, null))
         Define.Field("description", String)
+        Define.Field("fields", ListOf (NonNull __Field), 
+            args = [ Define.Arg("includeDeprecated", Boolean, false) ],
+            resolve = fun ctx t ->
+                let fieldsOpt = 
+                    match t with
+                    | Object odef -> Some odef.Fields
+                    | Interface idef -> Some idef.Fields
+                    | _ -> None
+                match fieldsOpt with
+                | None -> null
+                | Some fields when ctx.Arg("includeDeprecated").Value -> box fields
+                | Some fields -> 
+                    fields
+                    |> List.filter (fun f -> Option.isNone f.DeprecationReason)
+                    |> box)
+        Define.Field("interfaces", ListOf (NonNull __Type), resolve = fun _ t -> match t with Object o -> box o.Implements | _ -> null)
+        Define.Field("possibleTypes", ListOf (NonNull __Type), resolve = fun ctx t -> match t with Abstract a -> box (ctx.Schema.GetPossibleTypes a) | _ -> null)
+        Define.Field("enumValues", ListOf (NonNull __EnumValue),
+            args = [ Define.Arg("includeDeprecated", Boolean, false) ],
+            resolve = fun ctx t ->
+                match t with
+                | Enum e when ctx.Arg("includeDeprecated").Value -> box e.Options
+                | Enum e -> e.Options |> List.filter (fun v -> Option.isNone v.DeprecationReason) |> box
+                | _ -> null)
+        Define.Field("inputFields", ListOf (NonNull __InputValue), resolve = fun _ t ->
+            match t with
+            | InputObject idef -> box idef.FieldsFn
+            | _ -> null)
+        Define.Field("ofType", __Type)
     ])
    
-let __InputValue = Define.Object(
+and __InputValue = Define.Object(
     name = "__InputValue",
     description = "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.",
     fields = fun () -> [
@@ -90,7 +119,7 @@ let __InputValue = Define.Object(
                 else property.GetValue(input, null))
     ])
     
-let __Field = Define.Object(
+and __Field = Define.Object(
     name = "__Field",
     description = "Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.",
     fields = fun () -> [
@@ -102,7 +131,7 @@ let __Field = Define.Object(
         Define.Field("deprecationReason", String)
     ])
     
-let __EnumValue = Define.Object(
+and __EnumValue = Define.Object(
     name = "__EnumValue",
     description = "One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.",
     fields = fun () -> [
@@ -111,40 +140,8 @@ let __EnumValue = Define.Object(
         Define.Field("isDeprecated", NonNull Boolean, resolve = fun _ (e: EnumValue) -> Option.isSome e.DeprecationReason)
         Define.Field("deprecationReason", String)
     ])
-    
-__Type <-  mergeFields __Type [
-    Define.Field("fields", ListOf (NonNull __Field), 
-        args = [ Define.Arg("includeDeprecated", Boolean, false) ],
-        resolve = fun ctx t ->
-            let fieldsOpt = 
-                match t with
-                | Object odef -> Some odef.Fields
-                | Interface idef -> Some idef.Fields
-                | _ -> None
-            match fieldsOpt with
-            | None -> null
-            | Some fields when ctx.Arg("includeDeprecated").Value -> box fields
-            | Some fields -> 
-                fields 
-                |> List.filter (fun f -> Option.isNone f.DeprecationReason)
-                |> box)
-    Define.Field("interfaces", ListOf (NonNull __Type), resolve = fun _ t -> match t with Object o -> box o.Implements | _ -> null)
-    Define.Field("possibleTypes", ListOf (NonNull __Type), resolve = fun ctx t -> match t with Abstract a -> box (ctx.Schema.GetPossibleTypes a) | _ -> null)
-    Define.Field("enumValues", ListOf (NonNull __EnumValue),
-        args = [ Define.Arg("includeDeprecated", Boolean, false) ],
-        resolve = fun ctx t ->
-            match t with
-            | Enum e when ctx.Arg("includeDeprecated").Value -> box e.Options
-            | Enum e -> e.Options |> List.filter (fun v -> Option.isNone v.DeprecationReason) |> box
-            | _ -> null)
-    Define.Field("inputFields", ListOf (NonNull __InputValue), resolve = fun _ t ->
-        match t with
-        | InputObject idef -> box idef.Fields
-        | _ -> null)
-    Define.Field("ofType", __Type)
-]
 
-let __Directive = Define.Object(
+and __Directive = Define.Object(
     name = "__Directive",
     description = """A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document. In some cases, you need to provide options to alter GraphQL’s execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.""",
     fields = fun () -> [
@@ -159,7 +156,7 @@ let __Directive = Define.Object(
         Define.Field("onField", NonNull Boolean, resolve = fun _ (d: DirectiveDef) -> d.Locations.HasFlag(DirectiveLocation.FIELD))
     ])
     
-let __Schema = Define.Object(
+and __Schema = Define.Object(
     name = "__Schema",
     description = "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.",
     fields = fun () -> [

--- a/src/FSharp.Data.GraphQL/Schema.fs
+++ b/src/FSharp.Data.GraphQL/Schema.fs
@@ -29,22 +29,20 @@ type Schema(query: ObjectDef, ?mutation: ObjectDef, ?types: NamedDef list, ?dire
             objdef.Implements
             |> List.fold (fun n t -> insert n t) withFields'
         | Interface interfacedef ->
-            let ns' = 
-                interfacedef.Fields
-                |> List.map (fun x -> x.Type)
-                |> List.filter (fun (Named x) -> not (Map.containsKey x.Name ns))
-                |> List.fold (fun n (Named t) -> insert n t) ns
-            addOrReturn typedef.Name typedef ns' 
+            let ns' = addOrReturn typedef.Name typedef ns
+            interfacedef.Fields
+            |> List.map (fun x -> x.Type)
+            |> List.filter (fun (Named x) -> not (Map.containsKey x.Name ns'))
+            |> List.fold (fun n (Named t) -> insert n t) ns'            
         | Union uniondef ->
-            let ns' =
-                uniondef.Options
-                |> List.fold (fun n t -> insert n t) ns
-            addOrReturn typedef.Name typedef ns' 
+            let ns' = addOrReturn typedef.Name typedef ns
+            uniondef.Options
+            |> List.fold (fun n t -> insert n t) ns'            
         | List (Named innerdef) -> insert ns innerdef 
         | NonNull (Named innerdef) -> insert ns innerdef
         | InputObject objdef -> 
             let ns' = addOrReturn objdef.Name typedef ns
-            objdef.Fields
+            objdef.FieldsFn()
             |> List.collect (fun x -> (x.Type :> TypeDef) :: (x.Args |> List.map (fun a -> a.Type)))
             |> List.filter (fun (Named x) -> not (Map.containsKey x.Name ns'))
             |> List.fold (fun n (Named t) -> insert n t) ns'

--- a/src/FSharp.Data.GraphQL/Schema.fs
+++ b/src/FSharp.Data.GraphQL/Schema.fs
@@ -23,7 +23,7 @@ type Schema(query: ObjectDef, ?mutation: ObjectDef, ?types: NamedDef list, ?dire
             let ns' = addOrReturn objdef.Name typedef ns
             let withFields' =
                 objdef.Fields
-                |> List.collect (fun x -> (x.Type :> TypeDef) :: (x.Args |> List.map (fun a -> a.Type)))
+                |> List.collect (fun x -> (x.Type :> TypeDef) :: (x.Args |> List.map (fun a -> upcast a.Type)))
                 |> List.filter (fun (Named x) -> not (Map.containsKey x.Name ns'))
                 |> List.fold (fun n (Named t) -> insert n t) ns'
             objdef.Implements
@@ -43,7 +43,7 @@ type Schema(query: ObjectDef, ?mutation: ObjectDef, ?types: NamedDef list, ?dire
         | InputObject objdef -> 
             let ns' = addOrReturn objdef.Name typedef ns
             objdef.FieldsFn()
-            |> List.collect (fun x -> (x.Type :> TypeDef) :: (x.Args |> List.map (fun a -> a.Type)))
+            |> List.collect (fun x -> (x.Type :> TypeDef) :: (x.Args |> List.map (fun a -> upcast a.Type)))
             |> List.filter (fun (Named x) -> not (Map.containsKey x.Name ns'))
             |> List.fold (fun n (Named t) -> insert n t) ns'
         

--- a/src/FSharp.Data.GraphQL/TypeSystem.fs
+++ b/src/FSharp.Data.GraphQL/TypeSystem.fs
@@ -272,7 +272,7 @@ and InputObjectDef =
 and ArgDef = 
     { Name : string
       Description : string option
-      Type : TypeDef
+      Type : InputDef
       DefaultValue : obj option }
     override x.ToString() = 
         x.Name + ": " + x.Type.ToString() + (if x.DefaultValue.IsSome then " = " + x.DefaultValue.Value.ToString()
@@ -735,7 +735,7 @@ module SchemaDefinitions =
                   else args.Value
               DeprecationReason = deprecationReason }
         
-        static member Arg(name : string, schema : TypeDef, ?defaultValue : 'T, ?description : string) : ArgDef = 
+        static member Arg(name : string, schema : InputDef, ?defaultValue : 'T, ?description : string) : ArgDef = 
             { Name = name
               Description = description
               Type = schema

--- a/src/FSharp.Data.GraphQL/TypeSystem.fs
+++ b/src/FSharp.Data.GraphQL/TypeSystem.fs
@@ -239,22 +239,22 @@ and [<CustomEquality; NoComparison>]UnionDef =
     override x.ToString() = "union " + x.Name + " = " + String.Join(" | ", x.Options |> List.map (fun o -> o.Name))
     
 and ListOfDef = 
-    { Type: TypeDef }
+    { OfType: TypeDef }
     interface TypeDef
     interface InputDef
     interface OutputDef
     override x.ToString() = 
-        match x.Type with
+        match x.OfType with
         | :? NamedDef as named -> "[" + named.Name + "]"
         | other -> "[" + other.ToString() + "]"
 
 and NonNullDef = 
-    { Type: TypeDef }
+    { OfType: TypeDef }
     interface TypeDef
     interface InputDef
     interface OutputDef
     override x.ToString() = 
-        match x.Type with
+        match x.OfType with
         | :? NamedDef as named -> named.Name + "!"
         | other -> other.ToString() + "!"
 
@@ -453,8 +453,8 @@ module SchemaDefinitions =
         | StringValue s -> Some s
         | _ -> None
 
-    let NonNull (innerDef: #TypeDef): NonNullDef = { Type = innerDef }
-    let ListOf (innerDef: #TypeDef): ListOfDef = { Type = innerDef }
+    let NonNull (innerDef: #TypeDef): NonNullDef = { OfType = innerDef }
+    let ListOf (innerDef: #TypeDef): ListOfDef = { OfType = innerDef }
 
     let (|Scalar|_|) (tdef: TypeDef) =
         match tdef with
@@ -482,11 +482,11 @@ module SchemaDefinitions =
         | _ -> None        
     let (|List|_|) (tdef: TypeDef) =
         match tdef with
-        | :? ListOfDef as x -> Some x.Type
+        | :? ListOfDef as x -> Some x.OfType
         | _ -> None        
     let (|NonNull|_|) (tdef: TypeDef) =
         match tdef with
-        | :? NonNullDef as x -> Some x.Type
+        | :? NonNullDef as x -> Some x.OfType
         | _ -> None
     let (|Input|_|) (tdef: TypeDef) =
         match tdef with
@@ -570,7 +570,7 @@ module SchemaDefinitions =
           Description = 
               Some "Directs the executor to include this field or fragment only when the `if` argument is true."
           Locations = 
-              DirectiveLocation.FIELD &&& DirectiveLocation.FRAGMENT_SPREAD &&& DirectiveLocation.INLINE_FRAGMENT
+              DirectiveLocation.FIELD ||| DirectiveLocation.FRAGMENT_SPREAD ||| DirectiveLocation.INLINE_FRAGMENT
           Args = 
               [ { Name = "if"
                   Description = Some "Included when true."
@@ -581,7 +581,7 @@ module SchemaDefinitions =
         { Name = "skip"
           Description = Some "Directs the executor to skip this field or fragment when the `if` argument is true."
           Locations = 
-              DirectiveLocation.FIELD &&& DirectiveLocation.FRAGMENT_SPREAD &&& DirectiveLocation.INLINE_FRAGMENT
+              DirectiveLocation.FIELD ||| DirectiveLocation.FRAGMENT_SPREAD ||| DirectiveLocation.INLINE_FRAGMENT
           Args = 
               [ { Name = "if"
                   Description = Some "Skipped when true."

--- a/tests/FSharp.Data.GraphQL.Tests/SchemaTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/SchemaTests.fs
@@ -11,37 +11,19 @@ open FSharp.Data.GraphQL.Types
 
 [<Fact>]
 let ``Object type should be able to merge fields with matching signatures from different interfaces`` () = 
-    let person = Define.Object("Person", [
-        Define.Field("name", String)
-    ])
-    let movable = Define.Interface("Movable", [
+    let MovableType = Define.Interface("Movable", [
         Define.Field("speed", Int)
     ])
-    let movable2 = Define.Interface("Movable2", [
+    let Movable2Type = Define.Interface("Movable2", [
         Define.Field("speed", Int)
         Define.Field("acceleration", Int)
     ])
-    let objectType = implements person [ movable; movable2 ]
-    let expected = Define.Object("Person", [
-        Define.Field("name", String)
-        Define.Field("speed", Int)
-        Define.Field("acceleration", Int)
-    ], interfaces = [movable; movable2])
-    equals expected objectType
-
-
-[<Fact>]
-let ``Object type should not be able to merge fields with matching names but different types from different interfaces`` () = 
-    let person = Define.Object("Person", [
-        Define.Field("name", String)
-    ])
-    let movable = Define.Interface("Movable", [
-        Define.Field("speed", String)
-    ])
-    let movable2 = Define.Interface("Movable2", [
-        Define.Field("speed", Int)
-        Define.Field("acceleration", Int)
-    ])
-
-    (fun () -> implements person [ movable; movable2 ] |> ignore)
-    |> throws<GraphQLException>
+    let PersonType = Define.Object(
+        name = "Person",
+        interfaces = [MovableType; Movable2Type],
+        fields = [
+            Define.Field("name", String)
+            Define.Field("speed", Int)
+            Define.Field("acceleration", Int)])
+    equals [MovableType; Movable2Type] PersonType.Implements
+    equals [Define.Field("name", String); Define.Field("speed", Int); Define.Field("acceleration", Int)] PersonType.Fields


### PR DESCRIPTION
- Fixed type of ArgDef value (narrowed to contain only definitions satisfying `InputDef`)
- Fixed more parts of Introspection API, mainly missing `Directive.Locations` list of enums.

Also extended GraphQL server example to work with self-referencing data types. Right now after running `server.fsx` you can make call such as:

> curl --form 'query={ hero(id: "1000") { id, name, appearsIn, friends { id,name } } }' http://localhost:8083/

which will produce following output:

``` json
{
  "data": {
    "hero": {
      "appearsIn": [
        "NewHope",
        "Empire",
        "Jedi"
      ],
      "friends": [
        {
          "id": "1002",
          "name": "Han Solo"
        },
        {
          "id": "1003",
          "name": "Leia Organa"
        },
        {
          "id": "2000",
          "name": "C-3PO"
        },
        {
          "id": "2001",
          "name": "R2-D2"
        }
      ],
      "id": "1000",
      "name": "Luke Skywalker"
    }
  },
  "errors": null
}
```
