### PR TITLE
Added perf benchmark project

### DIFF
--- a/FSharp.Data.GraphQL.sln
+++ b/FSharp.Data.GraphQL.sln
@@ -42,6 +42,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "graphiql", "graphiql", "{5D
 		samples\graphiql\server.fsx = samples\graphiql\server.fsx
 	EndProjectSection
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FSharp.Data.GraphQL.Benchmarks", "tests\FSharp.Data.GraphQL.Benchmarks\FSharp.Data.GraphQL.Benchmarks.fsproj", "{751357AE-F2B2-4B38-956E-81E0B8606C73}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -56,6 +58,10 @@ Global
 		{54AAFE43-FA5F-485A-AD40-0240165FC633}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{54AAFE43-FA5F-485A-AD40-0240165FC633}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{54AAFE43-FA5F-485A-AD40-0240165FC633}.Release|Any CPU.Build.0 = Release|Any CPU
+		{751357AE-F2B2-4B38-956E-81E0B8606C73}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{751357AE-F2B2-4B38-956E-81E0B8606C73}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{751357AE-F2B2-4B38-956E-81E0B8606C73}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{751357AE-F2B2-4B38-956E-81E0B8606C73}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -65,5 +71,6 @@ Global
 		{8E6D5255-776D-4B61-85F9-73C37AA1FB9A} = {A6A6AF7D-D6E3-442D-9B1E-58CC91879BE1}
 		{54AAFE43-FA5F-485A-AD40-0240165FC633} = {ED8079DD-2B06-4030-9F0F-DC548F98E1C4}
 		{5DC4AE38-2814-4E36-9E75-95AA1FC384EB} = {B0C25450-74BF-40C2-9E02-09AADBAE2C2F}
+		{751357AE-F2B2-4B38-956E-81E0B8606C73} = {ED8079DD-2B06-4030-9F0F-DC548F98E1C4}
 	EndGlobalSection
 EndGlobal

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,4 +1,5 @@
 source https://nuget.org/api/v2
+nuget BenchmarkDotNet
 nuget FParsec
 nuget Newtonsoft.Json
 nuget Suave

--- a/paket.lock
+++ b/paket.lock
@@ -1,6 +1,7 @@
 NUGET
   remote: https://www.nuget.org/api/v2
   specs:
+    BenchmarkDotNet (0.9.5)
     FParsec (1.0.2)
     FSharp.Core (4.0.0.1)
     Newtonsoft.Json (8.0.3)

--- a/samples/graphiql/server.fsx
+++ b/samples/graphiql/server.fsx
@@ -1,6 +1,6 @@
 #r "../../packages/Suave/lib/net40/Suave.dll"
 #r "../../packages/Newtonsoft.Json/lib/net40/Newtonsoft.Json.dll"
-#r "../../src/FSharp.Data.GraphQL/bin/Debug/FSharp.Data.GraphQL.dll"
+#r "../../src/FSharp.Data.GraphQL/bin/Release/FSharp.Data.GraphQL.dll"
 
 open System
 
@@ -130,7 +130,7 @@ and DroidType = Define.Object(
         Define.Field("id", NonNull String, "The id of the droid.")
         Define.Field("name", String, "The name of the Droid.")
         Define.Field("friends", ListOf CharacterType, description = "The friends of the Droid, or an empty list if they have none.",
-            resolve = fun ctx (droid: Droid) -> printfn "%+A" ctx; droid.Friends |> List.map getCharacter)
+            resolve = fun ctx (droid: Droid) -> droid.Friends |> List.map getCharacter)
         Define.Field("appearsIn", ListOf EpisodeType, "Which movies they appear in.")
         Define.Field("primaryFunction", String, "The primary function of the droid.")])
 

--- a/src/FSharp.Data.GraphQL/Parser.fs
+++ b/src/FSharp.Data.GraphQL/Parser.fs
@@ -24,9 +24,9 @@ let private BP (p: Parser<_,_>) stream =
 
 let private (<!>) (p: Parser<_,_>) label : Parser<_,_> =
     fun stream ->
-        printfn "%A: Entering %s" stream.Position label
+       // printfn "%A: Entering %s" stream.Position label
         let reply = p stream
-        printfn "%A: Leaving %s (%A)" stream.Position label reply.Status
+       // printfn "%A: Leaving %s (%A)" stream.Position label reply.Status
         reply
 
 let private pSelection, pSelectionRef = createParserForwardedToRef<_, unit>()

--- a/tests/FSharp.Data.GraphQL.Benchmarks/App.config
+++ b/tests/FSharp.Data.GraphQL.Benchmarks/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
+  </startup>
+</configuration>

--- a/tests/FSharp.Data.GraphQL.Benchmarks/AssemblyInfo.fs
+++ b/tests/FSharp.Data.GraphQL.Benchmarks/AssemblyInfo.fs
@@ -1,0 +1,41 @@
+﻿namespace FSharp.Data.GraphQL.Benchmarks.AssemblyInfo
+
+open System.Reflection
+open System.Runtime.CompilerServices
+open System.Runtime.InteropServices
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[<assembly: AssemblyTitle("FSharp.Data.GraphQL.Benchmarks")>]
+[<assembly: AssemblyDescription("")>]
+[<assembly: AssemblyConfiguration("")>]
+[<assembly: AssemblyCompany("")>]
+[<assembly: AssemblyProduct("FSharp.Data.GraphQL.Benchmarks")>]
+[<assembly: AssemblyCopyright("Copyright ©  2016")>]
+[<assembly: AssemblyTrademark("")>]
+[<assembly: AssemblyCulture("")>]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[<assembly: ComVisible(false)>]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[<assembly: Guid("751357ae-f2b2-4b38-956e-81e0b8606c73")>]
+
+// Version information for an assembly consists of the following four values:
+// 
+//       Major Version
+//       Minor Version 
+//       Build Number
+//       Revision
+// 
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [<assembly: AssemblyVersion("1.0.*")>]
+[<assembly: AssemblyVersion("1.0.0.0")>]
+[<assembly: AssemblyFileVersion("1.0.0.0")>]
+
+do
+    ()

--- a/tests/FSharp.Data.GraphQL.Benchmarks/ExecutionBenchmark.fs
+++ b/tests/FSharp.Data.GraphQL.Benchmarks/ExecutionBenchmark.fs
@@ -1,0 +1,117 @@
+﻿/// The MIT License (MIT)
+/// Copyright (c) 2016 Bazinga Technologies Inc
+
+module FSharp.Data.GraphQL.ExecutionBenchmark
+
+open System
+open FSharp.Data.GraphQL
+open FSharp.Data.GraphQL.Types
+open FSharp.Data.GraphQL.Parser
+open FSharp.Data.GraphQL.Execution
+
+type Person = 
+    { Id : string
+      Name : string option
+      Friends : string list
+      HomePlanet : string option }
+
+let humans = 
+    [ { Id = "1000"
+        Name = Some "Luke Skywalker"
+        Friends = [ "1002"; "1003"; ]
+        HomePlanet = Some "Tatooine" }
+      { Id = "1001"
+        Name = Some "Darth Vader"
+        Friends = [ "1004" ]
+        HomePlanet = Some "Tatooine" }
+      { Id = "1002"
+        Name = Some "Han Solo"
+        Friends = [ "1000"; "1003"; ]
+        HomePlanet = None }
+      { Id = "1003"
+        Name = Some "Leia Organa"
+        Friends = [ "1000"; "1002"; ]
+        HomePlanet = Some "Alderaan" }
+      { Id = "1004"
+        Name = Some "Wilhuff Tarkin"
+        Friends = [ "1001" ]
+        HomePlanet = None } ]
+
+let getPerson id = humans |> List.find (fun h -> h.Id = id)
+
+let rec Person = Define.Object(
+    name = "Person",
+    isTypeOf = (fun o -> o :? Person),
+    fields = fun() -> [
+        Define.Field("id", NonNull String, resolve = fun _ person -> person.Id)
+        Define.Field("name", String, resolve = fun _ person -> person.Name)
+        Define.Field("friends", ListOf Person, resolve = fun _ person -> person.Friends |> List.map getPerson)
+        Define.Field("homePlanet", String)])
+let Query = Define.Object(
+    name = "Query",
+    fields = [Define.Field("hero", Person, args = [ Define.Arg("id", String) ], resolve = fun ctx _ -> getPerson (ctx.Arg("id").Value))])
+
+let schema = Schema(Query)
+
+let simpleQueryString = """{ 
+    hero(id: "1000") { 
+        id
+    } 
+}"""
+let simpleAst = parse simpleQueryString
+
+let flatQueryString = """{ 
+    hero(id: "1000") { 
+        id,
+        name, 
+        homePlanet
+    } 
+}"""
+let flatAst = parse flatQueryString
+
+let nestedQueryString = """{ 
+    hero(id: "1000") { 
+        id, 
+        name, 
+        friends { 
+            id, 
+            name, 
+            friends { 
+                id, 
+                name, 
+                friends { 
+                    id, 
+                    name 
+                } 
+            } 
+        } 
+    } 
+}"""
+let nestedAst = parse nestedQueryString
+
+open BenchmarkDotNet.Attributes
+
+[<Config(typeof<GraphQLBenchConfig>)>]
+type SimpleExecutionBenchmark() = 
+    [<Setup>] member x.Setup () = ()
+    [<Benchmark>] member x.BenchmarkSimpleQueryUnparsed () = schema.AsyncExecute(simpleQueryString) |> Async.RunSynchronously
+    [<Benchmark>] member x.BenchmarkSimpleQueryParsed () =   schema.AsyncExecute(simpleAst) |> Async.RunSynchronously
+    [<Benchmark>] member x.BenchmarkFlatQueryUnparsed () =   schema.AsyncExecute(flatQueryString) |> Async.RunSynchronously
+    [<Benchmark>] member x.BenchmarkFlatQueryParsed () =     schema.AsyncExecute(flatAst) |> Async.RunSynchronously
+    [<Benchmark>] member x.BenchmarkNestedQueryUnparsed () = schema.AsyncExecute(nestedQueryString) |> Async.RunSynchronously
+    [<Benchmark>] member x.BenchmarkNestedQueryParsed () =   schema.AsyncExecute(nestedAst) |> Async.RunSynchronously
+    
+[<Config(typeof<GraphQLBenchConfig>)>]
+type RepeatableExecutionBenchmark() = 
+    let repeat times action =
+        for i in 0..times do
+            action() |> Async.RunSynchronously |> ignore
+    let N = 1000
+    let repeatN = repeat N
+    [<Setup>] member x.Setup () = ()
+    [<Benchmark>] member x.BenchmarkSimpleQueryUnparsed () = repeatN <| fun () -> schema.AsyncExecute(simpleQueryString)
+    [<Benchmark>] member x.BenchmarkSimpleQueryParsed () =   repeatN <| fun () -> schema.AsyncExecute(simpleAst) 
+    [<Benchmark>] member x.BenchmarkFlatQueryUnparsed () =   repeatN <| fun () -> schema.AsyncExecute(flatQueryString) 
+    [<Benchmark>] member x.BenchmarkFlatQueryParsed () =     repeatN <| fun () -> schema.AsyncExecute(flatAst) 
+    [<Benchmark>] member x.BenchmarkNestedQueryUnparsed () = repeatN <| fun () -> schema.AsyncExecute(nestedQueryString) 
+    [<Benchmark>] member x.BenchmarkNestedQueryParsed () =   repeatN <| fun () -> schema.AsyncExecute(nestedAst) 

--- a/tests/FSharp.Data.GraphQL.Benchmarks/FSharp.Data.GraphQL.Benchmarks.fsproj
+++ b/tests/FSharp.Data.GraphQL.Benchmarks/FSharp.Data.GraphQL.Benchmarks.fsproj
@@ -1,0 +1,155 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>751357ae-f2b2-4b38-956e-81e0b8606c73</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>FSharp.Data.GraphQL.Benchmarks</RootNamespace>
+    <AssemblyName>FSharp.Data.GraphQL.Benchmarks</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFSharpCoreVersion>4.4.0.0</TargetFSharpCoreVersion>
+    <Name>FSharp.Data.GraphQL.Benchmarks</Name>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <Tailcalls>false</Tailcalls>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DocumentationFile>bin\Debug\FSharp.Data.GraphQL.Benchmarks.XML</DocumentationFile>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <Tailcalls>true</Tailcalls>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DocumentationFile>bin\Release\FSharp.Data.GraphQL.Benchmarks.XML</DocumentationFile>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Build" />
+    <Reference Include="mscorlib" />
+    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Numerics" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="Prolog.fs" />
+    <Compile Include="ParsingBenchmark.fs" />
+    <Compile Include="ExecutionBenchmark.fs" />
+    <Compile Include="Program.fs" />
+    <None Include="App.config" />
+    <None Include="paket.references" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\FSharp.Data.GraphQL\FSharp.Data.GraphQL.fsproj">
+      <Name>FSharp.Data.GraphQL</Name>
+      <Project>{474179d3-0090-49e9-88f8-2971c0966077}</Project>
+      <Private>True</Private>
+    </ProjectReference>
+  </ItemGroup>
+  <PropertyGroup>
+    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0')">
+      <ItemGroup>
+        <Reference Include="BenchmarkDotNet">
+          <HintPath>..\..\packages\BenchmarkDotNet\lib\net40\BenchmarkDotNet.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Microsoft.Build.Framework">
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Microsoft.Build.Utilities.v4.0">
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Microsoft.CSharp">
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="System.Management">
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3')">
+      <ItemGroup>
+        <Reference Include="BenchmarkDotNet">
+          <HintPath>..\..\packages\BenchmarkDotNet\lib\net45\BenchmarkDotNet.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Microsoft.Build.Framework">
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Microsoft.Build.Utilities.v12.0">
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Microsoft.CSharp">
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="System.Management">
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1')">
+      <ItemGroup>
+        <Reference Include="BenchmarkDotNet">
+          <HintPath>..\..\packages\BenchmarkDotNet\lib\net46\BenchmarkDotNet.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Microsoft.Build.Framework">
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Microsoft.Build.Utilities.Core">
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Microsoft.CSharp">
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="System.Management">
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+</Project>

--- a/tests/FSharp.Data.GraphQL.Benchmarks/ParsingBenchmark.fs
+++ b/tests/FSharp.Data.GraphQL.Benchmarks/ParsingBenchmark.fs
@@ -1,0 +1,100 @@
+﻿/// The MIT License (MIT)
+/// Copyright (c) 2016 Bazinga Technologies Inc
+
+module FSharp.Data.GraphQL.ParsingBenchmark
+
+open System
+open BenchmarkDotNet
+open FSharp.Data.GraphQL
+open FSharp.Data.GraphQL.Parser
+
+let simpleQueryString = """{ 
+    hero(id: "1000") { 
+        id
+    } 
+}"""
+
+let complexQuery = """query IntrospectionQuery {
+    __schema {
+      queryType { name }
+      mutationType { name }
+      subscriptionType { name }
+      types {
+        ...FullType
+      }
+      directives {
+        name
+        description
+        locations
+        args {
+          ...InputValue
+        }
+      }
+    }
+  }
+
+  fragment FullType on __Type {
+    kind
+    name
+    description
+    fields(includeDeprecated: true) {
+      name
+      description
+      args {
+        ...InputValue
+      }
+      type {
+        ...TypeRef
+      }
+      isDeprecated
+      deprecationReason
+    }
+    inputFields {
+      ...InputValue
+    }
+    interfaces {
+      ...TypeRef
+    }
+    enumValues(includeDeprecated: true) {
+      name
+      description
+      isDeprecated
+      deprecationReason
+    }
+    possibleTypes {
+      ...TypeRef
+    }
+  }
+
+  fragment InputValue on __InputValue {
+    name
+    description
+    type { ...TypeRef }
+    defaultValue
+  }
+
+  fragment TypeRef on __Type {
+    kind
+    name
+    ofType {
+      kind
+      name
+      ofType {
+        kind
+        name
+        ofType {
+          kind
+          name
+        }
+      }
+    }
+  }"""
+
+
+open BenchmarkDotNet.Attributes
+
+[<Config(typeof<GraphQLBenchConfig>)>]
+type ParsingBenchmark() = 
+    [<Setup>] member x.Setup () = ()
+    [<Benchmark>] member x.ParseSimpleQuery () =  parse simpleQueryString
+    [<Benchmark>] member x.ParseComplexQuery () = parse complexQuery

--- a/tests/FSharp.Data.GraphQL.Benchmarks/Program.fs
+++ b/tests/FSharp.Data.GraphQL.Benchmarks/Program.fs
@@ -1,0 +1,16 @@
+﻿module Program
+
+open System
+open System.IO
+open System.Collections.Concurrent
+open BenchmarkDotNet.Attributes
+open BenchmarkDotNet.Running
+open FSharp.Data.GraphQL.ParsingBenchmark
+open FSharp.Data.GraphQL.ExecutionBenchmark
+
+let defaultSwitch () = BenchmarkSwitcher [| typeof<SimpleExecutionBenchmark>; typeof<RepeatableExecutionBenchmark>; typeof<ParsingBenchmark>  |]
+
+[<EntryPoint>]
+let Main args =
+    defaultSwitch().Run args 
+    0

--- a/tests/FSharp.Data.GraphQL.Benchmarks/Prolog.fs
+++ b/tests/FSharp.Data.GraphQL.Benchmarks/Prolog.fs
@@ -1,0 +1,15 @@
+﻿/// The MIT License (MIT)
+/// Copyright (c) 2016 Bazinga Technologies Inc
+
+[<AutoOpen>]
+module FSharp.Data.GraphQL.BenchmarkProlog
+
+open BenchmarkDotNet.Configs
+open BenchmarkDotNet.Columns
+open BenchmarkDotNet.Exporters
+
+type GraphQLBenchConfig() as this= 
+    inherit ManualConfig()
+    do
+        this.Add(StatisticColumn.Mean, StatisticColumn.Min, StatisticColumn.Max, StatisticColumn.OperationsPerSecond)
+        this.Add(MarkdownExporter.GitHub)

--- a/tests/FSharp.Data.GraphQL.Benchmarks/paket.references
+++ b/tests/FSharp.Data.GraphQL.Benchmarks/paket.references
@@ -1,0 +1,1 @@
+BenchmarkDotNet

--- a/tests/FSharp.Data.GraphQL.Tests/AbstractionTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/AbstractionTests.fs
@@ -35,10 +35,10 @@ let ``Execute handles execution of abstract types: isTypeOf is used to resolve r
             Define.Field("meows", Boolean)
         ])
     let schema = Schema(
-        types = [CatType; DogType],
         query = Define.Object("Query", fun () -> [
             Define.Field("pets", ListOf PetType, resolve = fun _ _ -> [ { Name = "Odie"; Woofs = true } :> obj; upcast { Name = "Garfield"; Meows = false } ])
-        ]))
+        ]), 
+        config = { SchemaConfig.Default with Types = [CatType; DogType] })
     let query = """{
       pets {
         name

--- a/tests/FSharp.Data.GraphQL.Tests/UnionInterfaceTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/UnionInterfaceTests.fs
@@ -60,7 +60,7 @@ let PersonType = Define.Object(
         Define.Field("friends", ListOf NamedType)
     ])
 
-let schema = Schema(query = PersonType, types = [ PetType ])
+let schema = Schema(query = PersonType, config = { SchemaConfig.Default with Types = [ PetType ] })
 
 let garfield = { Name = "Garfield"; Meows = false }
 let odie = { Name = "Odie"; Barks = true }


### PR DESCRIPTION
- Added performance benchmarking tests.
- Additionally removed multiple optional parameters from `Schema` in favor of single optional `SchemaConfig` record.
## Initial benchmarks results

They don't look impressive so we definitely have a room for improvements here:
### Parsing benchmark

``` ini

BenchmarkDotNet=v0.9.5.0
OS=Microsoft Windows NT 6.2.9200.0
Processor=Intel(R) Core(TM) i5-4430 CPU @ 3.00GHz, ProcessorCount=4
Frequency=2929689 ticks, Resolution=341.3332 ns, Timer=TSC
HostCLR=MS.NET 4.0.30319.42000, Arch=32-bit RELEASE
JitModules=clrjit-v4.6.1055.0

Type=ParsingBenchmark  Mode=Throughput  

```

| Method | Median | StdDev | Mean | Min | Max | Op/s |
| --- | --- | --- | --- | --- | --- | --- |
| ParseSimpleQuery | 33.8274 us | 0.3540 us | 33.7482 us | 33.0816 us | 34.1611 us | 29631.22 |
| ParseComplexQuery | 577.0307 us | 8.9946 us | 578.8314 us | 566.7890 us | 594.1037 us | 1727.62 |
### Querying benchmark

``` ini

BenchmarkDotNet=v0.9.5.0
OS=Microsoft Windows NT 6.2.9200.0
Processor=Intel(R) Core(TM) i5-4430 CPU @ 3.00GHz, ProcessorCount=4
Frequency=2929689 ticks, Resolution=341.3332 ns, Timer=TSC
HostCLR=MS.NET 4.0.30319.42000, Arch=32-bit RELEASE
JitModules=clrjit-v4.6.1055.0

Type=SimpleExecutionBenchmark  Mode=Throughput  

```

| Method | Median | StdDev | Mean | Min | Max | Op/s |
| --- | --- | --- | --- | --- | --- | --- |
| BenchmarkSimpleQueryUnparsed | 71.0288 us | 0.8807 us | 71.3812 us | 70.0700 us | 72.8218 us | 14009.3 |
| BenchmarkSimpleQueryParsed | 24.4913 us | 0.6096 us | 24.5193 us | 23.8519 us | 26.7201 us | 40784.22 |
| BenchmarkFlatQueryUnparsed | 125.2367 us | 3.0207 us | 126.3752 us | 124.3089 us | 135.1953 us | 7912.95 |
| BenchmarkFlatQueryParsed | 52.4176 us | 2.2771 us | 52.3338 us | 48.0172 us | 55.2310 us | 19108.12 |
| BenchmarkNestedQueryUnparsed | 394.4258 us | 9.6195 us | 398.5617 us | 390.9118 us | 427.4011 us | 2509.02 |
| BenchmarkNestedQueryParsed | 170.9940 us | 13.3266 us | 175.4107 us | 165.8474 us | 223.2751 us | 5700.91 |
