### PR TITLE
Safe type system

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ F# implementation of Facebook [GraphQL query language specification](https://fac
 
 [![Build status](https://ci.appveyor.com/api/projects/status/yjsen9xyvqhyak4b?svg=true)](https://ci.appveyor.com/project/johnberzy-bazinga/fsharp-data-graphql)
 
-## Example
+## Quick start
 
 ```fsharp
-type Person = {
-    FirstName: string
-    LastName: string }
+type Person = 
+    { FirstName: string
+      LastName: string }
 
 // define GraphQL type 
 let PersonType = Define.Object(
@@ -31,9 +31,17 @@ let reply = schema.AsyncExecute(parse "{ firstName, lastName }", johnSnow) |> As
 // #> map [("firstName", "John"); ("lastName", "Snow")] 
 ```
 
+It's type safe. Things like invalid fields or invalid return types will be checked at compile time.
+
+## Demo
+
+You can checkout this project in work, by running [example Suave server](samples/graphiql/server.fsx) from your FSI, and calling it by sending example request:
+
+    curl --form 'query={ hero(id: "1000") { id, name, appearsIn, friends { id,name } } }' http://localhost:8083/
+
 ## Implementation progress
 
 Missing parts:
 
-- Fully functional Introspection API
+- Introspection API
 - Query validation

--- a/src/FSharp.Data.GraphQL/Ast.fs
+++ b/src/FSharp.Data.GraphQL/Ast.fs
@@ -173,3 +173,8 @@ and TypeDefinition =
     | UnionTypeDefinition of UnionTypeDefinition
     | EnumTypeDefinition of EnumTypeDefinition
     | InputObjectTypeDefinition of InputObjectTypeDefinition
+
+module Visitor =
+    
+    let visit enter leave ast = failwith "Not implemented"
+        

--- a/src/FSharp.Data.GraphQL/Execution.fs
+++ b/src/FSharp.Data.GraphQL/Execution.fs
@@ -211,7 +211,7 @@ and collectFragment ctx typedef visitedFragments groupedFields fragment =
         ) groupedFields    
                 
 /// Takes an object, current execution context and a field definition, and returns the result of resolving that field on the object
-let private resolveField value ctx fieldDef = async {
+let private resolveField value ctx (fieldDef: FieldDef) = async {
     try
         let! resolved = fieldDef.Resolve ctx value 
         let unboxed = 
@@ -224,14 +224,12 @@ let private resolveField value ctx fieldDef = async {
 
 open FSharp.Data.GraphQL.Introspection
 /// Takes an object type and a field, and returns that field’s type on the object type, or null if the field is not valid on the object type
-let private getFieldDefinition ctx (objectType: ObjectDef) (field: Field) =
-    let result =
+let private getFieldDefinition ctx (objectType: ObjectDef) (field: Field) : FieldDef option =
         match field.Name with
-        | "__schema" when Object.ReferenceEquals(ctx.Schema.Query, objectType) -> Some SchemaMetaFieldDef
-        | "__type" when Object.ReferenceEquals(ctx.Schema.Query, objectType) -> Some TypeMetaFieldDef
-        | "__typename" -> Some TypeNameMetaFieldDef
+        | "__schema" when Object.ReferenceEquals(ctx.Schema.Query, objectType) -> Some (upcast SchemaMetaFieldDef)
+        | "__type" when Object.ReferenceEquals(ctx.Schema.Query, objectType) -> Some (upcast TypeMetaFieldDef)
+        | "__typename" -> Some (upcast TypeNameMetaFieldDef)
         | fieldName -> objectType.Fields |> List.tryFind (fun f -> f.Name = fieldName)
-    result
 
 let private defaultResolveType ctx abstractDef objectValue =
     let possibleTypes = ctx.Schema.GetPossibleTypes abstractDef

--- a/src/FSharp.Data.GraphQL/Introspection.fs
+++ b/src/FSharp.Data.GraphQL/Introspection.fs
@@ -18,7 +18,6 @@ let internal flagsToList (e:'TEnum) =
     System.Enum.GetValues(typeof<'TEnum>)
     |> Seq.cast<'TEnum>
     |> Seq.filter (fun v -> int(e) &&& int(v) <> 0)
-    |> List.ofSeq
     
 let internal graphQLKind (_: ResolveFieldContext) = function
     | Scalar _ -> TypeKind.SCALAR
@@ -31,10 +30,12 @@ let internal graphQLKind (_: ResolveFieldContext) = function
     | InputObject _ -> TypeKind.INPUT_OBJECT
 
 open System.Reflection
-let internal getProperty o name =
-    o.GetType().GetProperty(name, BindingFlags.IgnoreCase ||| BindingFlags.Public ||| BindingFlags.Instance)
+let internal getFieldValue name o =
+    let property = o.GetType().GetProperty(name, BindingFlags.IgnoreCase ||| BindingFlags.Public ||| BindingFlags.Instance)
+    if property = null then null else property.GetValue(o, null)
+let inline getStringField name o = (getFieldValue name o) :?> string
     
-let __TypeKind = Define.Enum(
+let __TypeKind = Define.Enum<TypeKind>(
     name = "__TypeKind", 
     description = "An enum describing what kind of type a given __Type is.",
     options = [
@@ -61,20 +62,17 @@ let __DirectiveLocation = Define.Enum(
         Define.EnumValue("INLINE_FRAGMENT", DirectiveLocation.INLINE_FRAGMENT, "Location adjacent to an inline fragment.")
     ])
     
-let rec __Type = Define.Object(
+let rec __Type = Define.Object<TypeDef>(
     name = "__Type",
     description = """The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum. Depending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.""",
-    fields = fun () -> [
-        Define.Field("kind", NonNull __TypeKind, resolve = graphQLKind)
+    fieldsFn = fun () -> [
+        Define.Field("kind", NonNull __TypeKind, graphQLKind)
         Define.Field("name", NonNull String, resolve = fun _ t ->
             match t with
-            | Named namedType -> namedType.Name :> obj
-            | _ -> 
-                match getProperty t "name" with
-                | null -> null
-                | property -> property.GetValue(t, null))
-        Define.Field("description", String)
-        Define.Field("fields", ListOf (NonNull __Field), 
+            | Named namedType -> namedType.Name
+            | _ -> getStringField "name" t)
+        Define.Field("description", String, fun _ t -> getStringField "description" t)
+        Define.Field("fields", ListOf (NonNull __Field), description = null,
             args = [ Define.Arg("includeDeprecated", Boolean, false) ],
             resolve = fun ctx t ->
                 let fieldsOpt = 
@@ -84,50 +82,45 @@ let rec __Type = Define.Object(
                     | _ -> None
                 match fieldsOpt with
                 | None -> null
-                | Some fields when ctx.Arg("includeDeprecated").Value -> box fields
+                | Some fields when ctx.Arg("includeDeprecated").Value -> fields |> Seq.ofList
                 | Some fields -> 
                     fields
                     |> List.filter (fun f -> Option.isNone f.DeprecationReason)
-                    |> box)
-        Define.Field("interfaces", ListOf (NonNull __Type), resolve = fun _ t -> match t with Object o -> box o.Implements | _ -> null)
-        Define.Field("possibleTypes", ListOf (NonNull __Type), resolve = fun ctx t -> match t with Abstract a -> box (ctx.Schema.GetPossibleTypes a) | _ -> null)
-        Define.Field("enumValues", ListOf (NonNull __EnumValue),
+                    |> Seq.ofList)
+        Define.Field("interfaces", ListOf (NonNull __Type), resolve = fun _ t -> match t with Object o -> o.Implements |> Seq.ofList |> Seq.cast<TypeDef> | _ -> null)
+        Define.Field("possibleTypes", ListOf (NonNull __Type), resolve = fun ctx t -> match t with Abstract a -> ctx.Schema.GetPossibleTypes a |> Seq.ofList |> Seq.cast<TypeDef> | _ -> null)
+        Define.Field("enumValues", ListOf (NonNull __EnumValue), description = null,
             args = [ Define.Arg("includeDeprecated", Boolean, false) ],
             resolve = fun ctx t ->
                 match t with
-                | Enum e when ctx.Arg("includeDeprecated").Value -> box e.Options
-                | Enum e -> e.Options |> List.filter (fun v -> Option.isNone v.DeprecationReason) |> box
+                | Enum e when ctx.Arg("includeDeprecated").Value -> e.Options |> Seq.ofList
+                | Enum e -> e.Options |> List.filter (fun v -> Option.isNone v.DeprecationReason) |> Seq.ofList
                 | _ -> null)
         Define.Field("inputFields", ListOf (NonNull __InputValue), resolve = fun _ t ->
             match t with
-            | InputObject idef -> box idef.FieldsFn
+            | InputObject idef -> idef.Fields |> Seq.ofList
             | _ -> null)
         Define.Field("ofType", __Type, resolve = fun _ typedef ->
             match typedef with
-            | NonNull inner | List inner -> box inner
-            | _ -> null)
+            | NonNull inner | List inner -> inner
+            | _ -> Unchecked.defaultof<TypeDef>)
     ])
    
-and __InputValue = Define.Object(
+and __InputValue = Define.Object<FieldDef>(
     name = "__InputValue",
     description = "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.",
-    fields = fun () -> [
-        Define.Field("name", NonNull String)
-        Define.Field("description", String)
+    fieldsFn = fun () -> [
+        Define.Field("name", NonNull String, fun _ f -> f.Name)
+        Define.Field("description", String, fun _ f -> f.Description)
         Define.Field("type", NonNull __Type)
-        Define.Field("defaultValue", String, 
-            resolve = fun _ input ->
-                let property = input.GetType().GetProperty("defaultValue", BindingFlags.IgnoreCase|||BindingFlags.Public|||BindingFlags.Instance)
-                if property = null 
-                then null
-                else property.GetValue(input, null))
+        Define.Field("defaultValue", String, fun _ input -> getStringField "defaultValue" input)
     ])
     
-and __Field = Define.Object(
+and __Field = Define.Object<FieldDef>(
     name = "__Field",
     description = "Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.",
-    fields = fun () -> [
-        Define.Field("name", NonNull String)
+    fieldsFn = fun () -> [
+        Define.Field("name", NonNull String, fun _ f -> f.Name)
         Define.Field("description", String)
         Define.Field("args", NonNull(ListOf (NonNull __InputValue)))
         Define.Field("type", NonNull __Type)
@@ -135,40 +128,40 @@ and __Field = Define.Object(
         Define.Field("deprecationReason", String)
     ])
     
-and __EnumValue = Define.Object(
+and __EnumValue = Define.Object<EnumVal>(
     name = "__EnumValue",
     description = "One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.",
-    fields = fun () -> [
+    fieldsFn = fun () -> [
         Define.Field("name", NonNull String)
         Define.Field("description", String)
-        Define.Field("isDeprecated", NonNull Boolean, resolve = fun _ (e: EnumValue) -> Option.isSome e.DeprecationReason)
+        Define.Field("isDeprecated", NonNull Boolean, resolve = fun _ e -> Option.isSome e.DeprecationReason)
         Define.Field("deprecationReason", String)
     ])
 
-and __Directive = Define.Object(
+and __Directive = Define.Object<DirectiveDef>(
     name = "__Directive",
     description = """A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document. In some cases, you need to provide options to alter GraphQL’s execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.""",
-    fields = fun () -> [
+    fieldsFn = fun () -> [
         Define.Field("name", NonNull String)
         Define.Field("description", String)
-        Define.Field("locations", NonNull (ListOf (NonNull __DirectiveLocation)), resolve = fun _ (directive: DirectiveDef) -> flagsToList directive.Locations)
+        Define.Field("locations", NonNull (ListOf (NonNull __DirectiveLocation)), resolve = fun _ directive -> flagsToList directive.Locations)
         Define.Field("args", NonNull (ListOf (NonNull __InputValue)))
-        Define.Field("onOperation", NonNull Boolean, resolve = fun _ (d: DirectiveDef) -> 
+        Define.Field("onOperation", NonNull Boolean, resolve = fun _ d -> 
             d.Locations.HasFlag(DirectiveLocation.QUERY) || d.Locations.HasFlag(DirectiveLocation.MUTATION) || d.Locations.HasFlag(DirectiveLocation.SUBSCRIPTION))
         Define.Field("onFragment", NonNull Boolean, resolve = fun _ (d: DirectiveDef) -> 
             d.Locations.HasFlag(DirectiveLocation.FRAGMENT_SPREAD) || d.Locations.HasFlag(DirectiveLocation.INLINE_FRAGMENT) || d.Locations.HasFlag(DirectiveLocation.FRAGMENT_DEFINITION))
         Define.Field("onField", NonNull Boolean, resolve = fun _ (d: DirectiveDef) -> d.Locations.HasFlag(DirectiveLocation.FIELD))
     ])
     
-and __Schema = Define.Object(
+and __Schema : ObjectDefinition<ISchema> = Define.Object<ISchema>(
     name = "__Schema",
     description = "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.",
-    fields = fun () -> [
-        Define.Field("types", NonNull (ListOf (NonNull __Type)), description = "A list of all types supported by this server.", resolve = fun _ (schema: ISchema) -> (schema :> System.Collections.Generic.IEnumerable<NamedDef>))
-        Define.Field("queryType", NonNull __Type, description = "The type that query operations will be rooted at.", resolve = fun _ (schema: ISchema) -> schema.Query)
-        Define.Field("mutationType", __Type, description = "If this server supports mutation, the type that mutation operations will be rooted at.", resolve = fun _ (schema: ISchema) -> schema.Mutation)
+    fieldsFn = fun () -> [
+        Define.Field("types", NonNull (ListOf (NonNull __Type)), "A list of all types supported by this server.", fun _ schema -> schema :> seq<NamedDef>)
+        Define.Field("queryType", NonNull __Type, description = "The type that query operations will be rooted at.", resolve = fun _ schema -> upcast schema.Query)
+        Define.Field("mutationType", __Type, description = "If this server supports mutation, the type that mutation operations will be rooted at.", resolve = fun _ schema -> schema.Mutation)
         Define.Field("subscriptionType", __Type, description = "If this server support subscription, the type that subscription operations will be rooted at.", resolve = fun _ _ -> null)
-        Define.Field("directives", NonNull (ListOf (NonNull __Directive)), description = "A list of all directives supported by this server.", resolve = fun _ (schema: ISchema) -> schema.Directives)
+        Define.Field("directives", NonNull (ListOf (NonNull __Directive)), description = "A list of all directives supported by this server.", resolve = fun _  schema -> schema.Directives)
     ])
 
 let SchemaMetaFieldDef = Define.Field(
@@ -184,7 +177,7 @@ let TypeMetaFieldDef = Define.Field(
     args = [
         { Name = "name"; Type = (NonNull String); Description = None; DefaultValue = None }
     ],
-    resolve = fun ctx _ -> ctx.Schema.TryFindType(ctx.Arg("name").Value) |> Option.map box |> Option.toObj)
+    resolve = fun ctx _ -> ctx.Schema.TryFindType(ctx.Arg("name").Value))
     
 let TypeNameMetaFieldDef = Define.Field(
     name = "__typename",

--- a/src/FSharp.Data.GraphQL/Relay.fs
+++ b/src/FSharp.Data.GraphQL/Relay.fs
@@ -18,40 +18,34 @@ type Connection<'Node> =
     { TotalCount : int
       PageInfo : PageInfo
       Edges : Edge<'Node> list }
-    member x.Items = x.Edges |> List.map (fun e -> e.Node)
+    member x.Items : 'Node list = x.Edges |> List.map (fun e -> e.Node)
 
-let Edge nodeType = Define.Object(
+let Edge (nodeType: #OutputDef<'Node>) = Define.Object<Edge<'Node>>(
     name = nodeType.ToString() + "Edge",
     description = "An edge in a connection from an object to another object of type " + nodeType.ToString(),
-    fields = fun () -> [
-        Define.Field("cursor", NonNull String, fun _ edge -> edge.Cursor, "A cursor for use in pagination")
-        Define.Field("node", nodeType, fun _ edge -> edge.Node, "The item at the end of the edge")
+    fields = [
+        Define.Field("cursor", NonNull String, "A cursor for use in pagination", fun _ edge -> edge.Cursor)
+        Define.Field("node", nodeType, "The item at the end of the edge", fun _ edge -> edge.Node)
     ]) 
 
-let PageInfo = Define.Object(
+let PageInfo = Define.Object<PageInfo>(
     name = "PageInfo",
     description = "Information about pagination in a connection.",
-    fields = fun () -> [
-        Define.Field("hasNextPage", NonNull Boolean, fun _ pageInfo -> pageInfo.HasNextPage, "When paginating forwards, are there more items?")
-        Define.Field("hasPreviousPage", NonNull Boolean, fun _ pageInfo -> pageInfo.HasPreviousPage, "When paginating backwards, are there more items?")
-        Define.Field("startCursor", String, fun _ pageInfo -> pageInfo.StartCursor, "When paginating backwards, the cursor to continue.")
-        Define.Field("endCursor ", String, fun _ pageInfo -> pageInfo.EndCursor, "When paginating forwards, the cursor to continue.")
+    fields = [
+        Define.Field("hasNextPage", NonNull Boolean, "When paginating forwards, are there more items?", fun _ pageInfo -> pageInfo.HasNextPage)
+        Define.Field("hasPreviousPage", NonNull Boolean, "When paginating backwards, are there more items?", fun _ pageInfo -> pageInfo.HasPreviousPage)
+        Define.Field("startCursor", String, "When paginating backwards, the cursor to continue.", fun _ pageInfo -> pageInfo.StartCursor)
+        Define.Field("endCursor ", String, "When paginating forwards, the cursor to continue.", fun _ pageInfo -> pageInfo.EndCursor)
     ])
 
-let ConnectionType nodeType = Define.Object(
+let Connection(nodeType: #OutputDef<'Node>) = Define.Object<Connection<'Node>>(
     name = nodeType.ToString(),
     description = "A connection from an object to a list of objects of type " + nodeType.ToString(),
-    fields = fun () -> [
-        Define.Field("totalCount", Int, fun _ conn -> conn.TotalCount , """A count of the total number of objects in this connection, ignoring pagination. 
-                    This allows a client to fetch the first five objects by passing \"5\" as the argument 
-                    to `first`, then fetch the total count so it could display \"5 of 83\", for example. 
-                    In cases where we employ infinite scrolling or don't have an exact count of entries, 
-                    this field will return `null`.""")
-        Define.Field("pageInfo", NonNull PageInfo, fun _ conn -> conn.PageInfo, "Information to aid in pagination.")
-        Define.Field("edges", ListOf(Edge nodeType), fun _ conn -> conn.Edges, "Information to aid in pagination.")
-        Define.Field("items", ListOf(nodeType), fun _ (conn: Connection<_>) -> conn.Items, """A list of all of the objects returned in the connection. This is a convenience field provided 
-                    for quickly exploring the API; rather than querying for \"{ edges { node } }\" when no edge data 
-                    is needed, this field can be used instead. Note that when clients like Relay need to fetch 
-                    the \"cursor\" field on the edge to enable efficient pagination, this shortcut cannot be used, 
-                    and the full \"{ edges { node } } \" version should be used instead.""")
+    fields = [
+        Define.Field("totalCount", Int, """A count of the total number of objects in this connection, ignoring pagination. This allows a client to fetch the first five objects by passing \"5\" as the argument to `first`, then fetch the total count so it could display \"5 of 83\", for example. In cases where we employ infinite scrolling or don't have an exact count of entries, this field will return `null`.""", fun _ conn -> conn.TotalCount)
+        Define.Field("pageInfo", NonNull PageInfo, "Information to aid in pagination.", fun _ conn -> conn.PageInfo)
+        Define.Field("edges", ListOf(Edge nodeType), "Information to aid in pagination.", fun _ conn -> conn.Edges |> List.toSeq) //TODO: make this toSeq conversion implicit somehow
+        Define.Field("items", ListOf(nodeType),
+            """A list of all of the objects returned in the connection. This is a convenience field provided for quickly exploring the API; rather than querying for \"{ edges { node } }\" when no edge data is needed, this field can be used instead. Note that when clients like Relay need to fetch the \"cursor\" field on the edge to enable efficient pagination, this shortcut cannot be used, and the full \"{ edges { node } } \" version should be used instead.""",
+            fun _ conn -> conn.Items |> List.toSeq) //TODO: make this toSeq conversion implicit somehow
     ])

--- a/src/FSharp.Data.GraphQL/Relay.fs
+++ b/src/FSharp.Data.GraphQL/Relay.fs
@@ -11,8 +11,8 @@ type Edge<'Node> =
 type PageInfo = 
     { HasNextPage : bool
       HasPreviousPage : bool
-      StartCursor : string
-      EndCursor : string }
+      StartCursor : string option
+      EndCursor : string option }
 
 type Connection<'Node> = 
     { TotalCount : int
@@ -24,7 +24,7 @@ let Edge (nodeType: #OutputDef<'Node>) = Define.Object<Edge<'Node>>(
     name = nodeType.ToString() + "Edge",
     description = "An edge in a connection from an object to another object of type " + nodeType.ToString(),
     fields = [
-        Define.Field("cursor", NonNull String, "A cursor for use in pagination", fun _ edge -> edge.Cursor)
+        Define.Field("cursor", String, "A cursor for use in pagination", fun _ edge -> edge.Cursor)
         Define.Field("node", nodeType, "The item at the end of the edge", fun _ edge -> edge.Node)
     ]) 
 
@@ -32,10 +32,10 @@ let PageInfo = Define.Object<PageInfo>(
     name = "PageInfo",
     description = "Information about pagination in a connection.",
     fields = [
-        Define.Field("hasNextPage", NonNull Boolean, "When paginating forwards, are there more items?", fun _ pageInfo -> pageInfo.HasNextPage)
-        Define.Field("hasPreviousPage", NonNull Boolean, "When paginating backwards, are there more items?", fun _ pageInfo -> pageInfo.HasPreviousPage)
-        Define.Field("startCursor", String, "When paginating backwards, the cursor to continue.", fun _ pageInfo -> pageInfo.StartCursor)
-        Define.Field("endCursor ", String, "When paginating forwards, the cursor to continue.", fun _ pageInfo -> pageInfo.EndCursor)
+        Define.Field("hasNextPage", Boolean, "When paginating forwards, are there more items?", fun _ pageInfo -> pageInfo.HasNextPage)
+        Define.Field("hasPreviousPage", Boolean, "When paginating backwards, are there more items?", fun _ pageInfo -> pageInfo.HasPreviousPage)
+        Define.Field("startCursor", Nullable String, "When paginating backwards, the cursor to continue.", fun _ pageInfo -> pageInfo.StartCursor)
+        Define.Field("endCursor ", Nullable String, "When paginating forwards, the cursor to continue.", fun _ pageInfo -> pageInfo.EndCursor)
     ])
 
 let Connection(nodeType: #OutputDef<'Node>) = Define.Object<Connection<'Node>>(
@@ -43,7 +43,7 @@ let Connection(nodeType: #OutputDef<'Node>) = Define.Object<Connection<'Node>>(
     description = "A connection from an object to a list of objects of type " + nodeType.ToString(),
     fields = [
         Define.Field("totalCount", Int, """A count of the total number of objects in this connection, ignoring pagination. This allows a client to fetch the first five objects by passing \"5\" as the argument to `first`, then fetch the total count so it could display \"5 of 83\", for example. In cases where we employ infinite scrolling or don't have an exact count of entries, this field will return `null`.""", fun _ conn -> conn.TotalCount)
-        Define.Field("pageInfo", NonNull PageInfo, "Information to aid in pagination.", fun _ conn -> conn.PageInfo)
+        Define.Field("pageInfo", PageInfo, "Information to aid in pagination.", fun _ conn -> conn.PageInfo)
         Define.Field("edges", ListOf(Edge nodeType), "Information to aid in pagination.", fun _ conn -> conn.Edges |> List.toSeq) //TODO: make this toSeq conversion implicit somehow
         Define.Field("items", ListOf(nodeType),
             """A list of all of the objects returned in the connection. This is a convenience field provided for quickly exploring the API; rather than querying for \"{ edges { node } }\" when no edge data is needed, this field can be used instead. Note that when clients like Relay need to fetch the \"cursor\" field on the edge to enable efficient pagination, this shortcut cannot be used, and the full \"{ edges { node } } \" version should be used instead.""",

--- a/src/FSharp.Data.GraphQL/Schema.fs
+++ b/src/FSharp.Data.GraphQL/Schema.fs
@@ -46,11 +46,11 @@ type Schema(query: ObjectDef, ?mutation: ObjectDef, ?config: SchemaConfig) =
             uniondef.Options
             |> List.fold (fun n t -> insert n t) ns'            
         | List (Named innerdef) -> insert ns innerdef 
-        | NonNull (Named innerdef) -> insert ns innerdef
+        | Nullable (Named innerdef) -> insert ns innerdef
         | InputObject objdef -> 
             let ns' = addOrReturn objdef.Name typedef ns
             objdef.Fields
-            |> List.collect (fun x -> (x.Type :> TypeDef) :: (x.Args |> List.map (fun a -> upcast a.Type)))
+            |> List.collect (fun x -> [x.Type :> TypeDef])
             |> List.filter (fun (Named x) -> not (Map.containsKey x.Name ns'))
             |> List.fold (fun n (Named t) -> insert n t) ns'
         

--- a/src/FSharp.Data.GraphQL/Schema.fs
+++ b/src/FSharp.Data.GraphQL/Schema.fs
@@ -49,7 +49,7 @@ type Schema(query: ObjectDef, ?mutation: ObjectDef, ?config: SchemaConfig) =
         | NonNull (Named innerdef) -> insert ns innerdef
         | InputObject objdef -> 
             let ns' = addOrReturn objdef.Name typedef ns
-            objdef.FieldsFn()
+            objdef.Fields
             |> List.collect (fun x -> (x.Type :> TypeDef) :: (x.Args |> List.map (fun a -> upcast a.Type)))
             |> List.filter (fun (Named x) -> not (Map.containsKey x.Name ns'))
             |> List.fold (fun n (Named t) -> insert n t) ns'

--- a/src/FSharp.Data.GraphQL/Schema.fs
+++ b/src/FSharp.Data.GraphQL/Schema.fs
@@ -6,8 +6,9 @@ namespace FSharp.Data.GraphQL
 open System
 open FSharp.Data.GraphQL.Ast
 open FSharp.Data.GraphQL.Types
-open FSharp.Data.GraphQL.Validation
+open FSharp.Data.GraphQL.Types.Introspection
 open FSharp.Data.GraphQL.Introspection
+open FSharp.Data.GraphQL.Validation
 
 type SchemaConfig =
     { Types : NamedDef list
@@ -16,7 +17,7 @@ type SchemaConfig =
         { Types = []
           Directives = [IncludeDirective; SkipDirective] }
 
-type Schema(query: ObjectDef, ?mutation: ObjectDef, ?config: SchemaConfig) =
+type Schema(query: ObjectDef, ?mutation: ObjectDef, ?config: SchemaConfig) as this =
     let rec insert ns typedef =
         let inline addOrReturn tname (tdef: NamedDef) acc =
             if Map.containsKey tname acc 
@@ -86,18 +87,127 @@ type Schema(query: ObjectDef, ?mutation: ObjectDef, ?config: SchemaConfig) =
                 | Some list -> Map.add iface.Name (objdef::list) acc'
                 | None -> Map.add iface.Name [objdef] acc') acc
             ) Map.empty
+    
+    let getPossibleTypes abstractDef =
+        match abstractDef with
+        | Union u -> u.Options
+        | Interface i -> Map.find i.Name implementations
+        | _ -> []
+
+    let rec introspectTypeRef isNullable namedTypes typedef =
+        match typedef with
+        | Named named -> 
+            if isNullable
+            then NamedTypeRef(Map.find named.Name namedTypes)
+            else NonNullTypeRef(introspectTypeRef true namedTypes typedef)
+        | List inner -> 
+            if isNullable 
+            then ListTypeRef(introspectTypeRef false namedTypes inner)
+            else NonNullTypeRef(introspectTypeRef true namedTypes typedef)
+        | Nullable inner -> introspectTypeRef true namedTypes inner
+
+    let introspectInput namedTypes (inputDef: InputFieldDef) : IntrospectionInputVal =
+        { Name = inputDef.Name
+          Description = inputDef.Description
+          Type = introspectTypeRef false namedTypes inputDef.Type
+          DefaultValue = inputDef.DefaultValue |> Option.map (fun x -> x.ToString()) }
+
+    let introspectField namedTypes (fdef: FieldDef) =
+        { Name = fdef.Name
+          Description = fdef.Description
+          Args = fdef.Args |> List.map (introspectInput namedTypes)
+          Type = introspectTypeRef false namedTypes fdef.Type
+          IsDeprecated = Option.isSome fdef.DeprecationReason
+          DeprecationReason = fdef.DeprecationReason }
+
+    let introspectEnumVal (enumVal: EnumVal) : IntrospectionEnumVal =
+        { Name = enumVal.Name
+          Description = enumVal.Description
+          IsDeprecated = Option.isSome enumVal.DeprecationReason
+          DeprecationReason = enumVal.DeprecationReason }
+          
+    let locationToList location =
+        System.Enum.GetValues(typeof<DirectiveLocation>)
+        |> Seq.cast<DirectiveLocation>
+        |> Seq.filter (fun v -> int(location) &&& int(v) <> 0)
+
+    let introspectDirective namedTypes (directive: DirectiveDef) : IntrospectionDirective =
+        { Name = directive.Name
+          Description = directive.Description
+          Locations = locationToList directive.Locations
+          Args = directive.Args |> List.map (introspectInput namedTypes) }
+
+    let introspectType namedTypes typedef =
+        match typedef with
+        | Scalar scalardef -> 
+            IntrospectionScalar(scalardef.Name, scalardef.Description)
+        | Object objdef -> 
+            let fields = 
+                objdef.Fields 
+                |> List.map (introspectField namedTypes)
+            let interfaces = 
+                objdef.Implements 
+                |> List.map (fun idef -> Map.find idef.Name namedTypes)
+            IntrospectionObject(objdef.Name, objdef.Description, fields, interfaces)
+        | InputObject inObjDef -> 
+            let inputs = inObjDef.Fields |> List.map (introspectInput namedTypes)
+            IntrospectionInputObject(inObjDef.Name, inObjDef.Description, inputs)
+        | Union uniondef -> 
+            let possibleTypes = 
+                getPossibleTypes uniondef
+                |> List.map (fun tdef -> Map.find tdef.Name namedTypes)
+            IntrospectionUnion(uniondef.Name, uniondef.Description, possibleTypes)
+        | Enum enumdef -> 
+            let enumVals = 
+                enumdef.Options
+                |> List.map introspectEnumVal
+            IntrospectionEnum(enumdef.Name, enumdef.Description, enumVals)
+        | Interface idef ->
+            let fields = 
+                idef.Fields 
+                |> List.map (introspectField namedTypes)
+            let possibleTypes = 
+                getPossibleTypes idef
+                |> List.map (fun tdef -> Map.find tdef.Name namedTypes)
+            IntrospectionInterface(idef.Name, idef.Description, fields, possibleTypes)
+
+    let introspectSchema types : IntrospectionSchema =
+        let inamed = 
+            types 
+            |> Map.map (fun typeName typedef -> 
+                match typedef with
+                | Scalar x -> { Kind = TypeKind.SCALAR; Name = typeName; Description = x.Description }
+                | Object x -> { Kind = TypeKind.OBJECT; Name = typeName; Description = x.Description }
+                | InputObject x -> { Kind = TypeKind.INPUT_OBJECT; Name = typeName; Description = x.Description }
+                | Union x -> { Kind = TypeKind.UNION; Name = typeName; Description = x.Description }
+                | Enum x -> { Kind = TypeKind.ENUM; Name = typeName; Description = x.Description }
+                | Interface x -> { Kind = TypeKind.INTERFACE; Name = typeName; Description = x.Description })
+
+        let itypes =
+            types
+            |> Map.toList
+            |> List.map (snd >> (introspectType inamed))
+
+        let idirectives = schemaConfig.Directives |> List.map (introspectDirective inamed)
+            
+        let ischema =
+            { QueryType = Map.find query.Name inamed
+              MutationType = mutation |> Option.map (fun m -> Map.find m.Name inamed)
+              SubscriptionType = None // not supported yet
+              Types = itypes
+              Directives = idirectives }
+        ischema
+
+    let introspected = introspectSchema typeMap
 
     interface ISchema with
         member val TypeMap = typeMap
         member val Query = query
         member val Mutation = mutation
         member val Directives = schemaConfig.Directives
+        member val Introspected = introspected
         member x.TryFindType typeName = Map.tryFind typeName typeMap
-        member x.GetPossibleTypes typedef = 
-            match typedef with
-            | Union u -> u.Options
-            | Interface i -> Map.find i.Name implementations
-            | _ -> []
+        member x.GetPossibleTypes typedef = getPossibleTypes typedef
         member x.IsPossibleType abstractdef possibledef =
             match (x :> ISchema).GetPossibleTypes abstractdef with
             | [] -> false

--- a/tests/FSharp.Data.GraphQL.Tests/CoercionTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/CoercionTests.fs
@@ -11,8 +11,8 @@ open FSharp.Data.GraphQL.Ast
 open FSharp.Data.GraphQL.Types
 
 let private testCoercion graphQLType (expected: 't) actual =
-    let (Scalar {CoerceInput = coerce; Name = _; Description = _}) = graphQLType
-    let result = (coerce actual) :?> ('t option)
+    let (Scalar scalar) = graphQLType
+    let result = (scalar.CoerceInput actual) :?> ('t option)
     match result with
     | Some x -> equals expected x
     

--- a/tests/FSharp.Data.GraphQL.Tests/DirectivesTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/DirectivesTests.fs
@@ -14,10 +14,10 @@ open FSharp.Data.GraphQL.Execution
 type Data = { A: string; B: string }
 let data = { A = "a"; B = "b" }
 
-let schema = Schema(objdef "TestType" [
+let schema = Schema(Define.Object("TestType", [
     Define.Field("a", String)
     Define.Field("b", String)
-])
+]))
 
 let private execAndCompare query expected =
     let actual = sync <| schema.AsyncExecute(parse query, data)

--- a/tests/FSharp.Data.GraphQL.Tests/Helpers.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/Helpers.fs
@@ -7,6 +7,7 @@ open System
 open Xunit
 open FSharp.Data.GraphQL
 open FSharp.Data.GraphQL.Types
+open FSharp.Data.GraphQL.Types.Introspection
 open FSharp.Data.GraphQL.Execution
 
 let equals (expected : 'x) (actual : 'x) = 

--- a/tests/FSharp.Data.GraphQL.Tests/Helpers.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/Helpers.fs
@@ -15,14 +15,6 @@ let noErrors (result: ExecutionResult) =
     Assert.True((None = result.Errors), sprintf "expected ExecutionResult to have no errors but got %+A" result.Errors)
 let throws<'e when 'e :> exn> (action : unit -> unit) = Assert.Throws<'e>(action)
 let sync = Async.RunSynchronously
-let field name typedef (resolve : 'a -> 'b) = Define.Field(name = name, typedef = typedef, resolve = (fun _ a -> resolve a))
-let fieldA name typedef args (resolve : ResolveFieldContext -> 'a -> 'b) = 
-    Define.Field(name = name, typedef = typedef, args = args, resolve = resolve)    
-let asyncField name typedef (resolve : 'a -> Async<'b>) = Define.AsyncField(name = name, typedef = typedef, resolve = (fun _ a -> resolve a))
-let asyncFieldA name typedef args (resolve : ResolveFieldContext -> 'a -> Async<'b>) = 
-    Define.AsyncField(name = name, typedef = typedef, arguments = args, resolve = resolve)
-let arg name typedef = Define.Arg(name, typedef)
-let objdef name (fields: FieldDef list) = Define.Object(name, fields)
 let is<'t> (o: obj) = o :? 't
 let hasError errMsg errors =
     let containsMessage = 

--- a/tests/FSharp.Data.GraphQL.Tests/IntrospectionTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/IntrospectionTests.fs
@@ -20,773 +20,625 @@ let ``Introspection executes an introspection query`` () =
     let (Object raw) = root
     let result = sync <| schema.AsyncExecute(parse introspectionQuery, raw)
     noErrors result
-    let expected: Map<string,obj> =
-        Map.ofList<string, obj> [
-          "__schema", upcast Map.ofList<string, obj> [
-            "queryType", upcast Map.ofList<string, obj> [
-              "name", upcast "QueryRoot"
-            ]
+    let expected: Map<string,obj> = Map.ofList<string, obj> [
+        "__schema", upcast Map.ofList<string, obj> [
             "mutationType", null
             "subscriptionType", null
+            "queryType", upcast Map.ofList<string, obj> [
+                    "name", upcast "QueryRoot"]
             "types", upcast [
-              Map.ofList<string, obj> [
-                "inputFields", null
-                "name", upcast "QueryRoot"
-                "description", null
-                "interfaces", upcast []
-                "enumValues", null
-                "fields", upcast []
-                "kind", upcast "OBJECT"
-                "possibleTypes", null
-              ] :> obj
-              upcast Map.ofList<string, obj> [
-                "inputFields", null
-                "name", upcast "__Directive"
-                "description", upcast "A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.\n\nIn some cases, you need to provide options to alter GraphQL’s execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor."
-                "interfaces", upcast []
-                "enumValues", null
-                "fields", upcast [
-                  Map.ofList<string, obj> [
-                    "name", upcast "name"
-                    "description", null
-                    "isDeprecated", upcast false
-                    "deprecationReason", null
-                    "args", upcast []
-                    "type", upcast Map.ofList<string, obj> [
-                      "kind", upcast "NON_NULL"
-                      "name", null
-                      "ofType", upcast Map.ofList<string, obj> [
-                        "kind", upcast "SCALAR"
-                        "name", upcast "String"
-                        "ofType", null]]] :> obj
-                  upcast Map.ofList<string, obj> [
-                    "name", upcast "description"
-                    "description", null
-                    "isDeprecated", upcast false
-                    "deprecationReason", null
-                    "args", upcast []
-                    "type", upcast Map.ofList<string, obj> [
-                      "kind", upcast "SCALAR"
-                      "name", upcast "String"
-                      "ofType", null]]
-                  upcast Map.ofList<string, obj> [
-                    "name", upcast "locations"
-                    "description", null
-                    "isDeprecated", upcast false
-                    "deprecationReason", null
-                    "args", upcast []
-                    "type", upcast Map.ofList<string, obj> [
-                      "kind", upcast "NON_NULL"
-                      "name", null
-                      "ofType", upcast Map.ofList<string, obj> [
-                        "kind", upcast "LIST"
-                        "name", null
-                        "ofType", upcast Map.ofList<string, obj> [
-                          "kind", upcast "NON_NULL"
-                          "name", null
-                          "ofType", upcast Map.ofList<string, obj> [
-                            "kind", upcast "ENUM"
-                            "name", upcast "__DirectiveLocation"]]]]]
-                  upcast Map.ofList<string, obj> [
-                    "name", upcast "args"
-                    "description", null
-                    "isDeprecated", upcast false
-                    "deprecationReason", null
-                    "args", upcast []
-                    "type", upcast Map.ofList<string, obj> [
-                      "kind", upcast "NON_NULL"
-                      "name", null
-                      "ofType", upcast Map.ofList<string, obj> [
-                        "kind", upcast "LIST"
-                        "name", null
-                        "ofType", upcast Map.ofList<string, obj> [
-                          "kind", upcast "NON_NULL"
-                          "name", null
-                          "ofType", upcast Map.ofList<string, obj> [
-                            "kind", upcast "OBJECT"
-                            "name", upcast "__InputValue"]]]]]
-                  upcast Map.ofList<string, obj> [
-                    "name", upcast "onOperation"
-                    "description", null
-                    "isDeprecated", upcast true
-                    "deprecationReason", upcast "Use `locations`."
-                    "args", upcast []
-                    "type", upcast Map.ofList<string, obj> [
-                      "kind", upcast "NON_NULL"
-                      "name", null
-                      "ofType", upcast Map.ofList<string, obj> [
-                        "kind", upcast "SCALAR"
-                        "name", upcast "Boolean"
-                        "ofType", null]]]
-                  upcast Map.ofList<string, obj> [
-                    "name", upcast "onFragment"
-                    "description", null
-                    "isDeprecated", upcast true
-                    "deprecationReason", upcast "Use `locations`."
-                    "args", upcast []
-                    "type", upcast Map.ofList<string, obj> [
-                      "kind", upcast "NON_NULL"
-                      "name", null
-                      "ofType", upcast Map.ofList<string, obj> [
-                        "kind", upcast "SCALAR"
-                        "name", upcast "Boolean"
-                        "ofType", null]]]
-                  upcast Map.ofList<string, obj> [
-                    "name", upcast "onField"
-                    "description", null
-                    "isDeprecated", upcast true
-                    "deprecationReason", upcast "Use `locations`."
-                    "args", upcast []
-                    "type", upcast Map.ofList<string, obj> [
-                      "kind", upcast "NON_NULL"
-                      "name", null
-                      "ofType", upcast Map.ofList<string, obj> [
-                        "kind", upcast "SCALAR"
-                        "name", upcast "Boolean"
-                        "ofType", null]]]]
-                "kind", upcast "OBJECT"
-                "possibleTypes", null]
-              upcast Map.ofList<string, obj> [
-                "inputFields", null
-                "name", upcast "__DirectiveLocation"
-                "description", upcast "A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies."
-                "interfaces", null
-                "enumValues", upcast [
-                  Map.ofList<string, obj> [
-                    "name", upcast "QUERY"
-                    "description", upcast "Location adjacent to a query operation."
-                    "isDeprecated", upcast false
-                    "deprecationReason", null] :> obj
-                  upcast Map.ofList<string, obj> [
-                    "name", upcast "MUTATION"
-                    "description", upcast "Location adjacent to a mutation operation."
-                    "isDeprecated", upcast false
-                    "deprecationReason", null]
-                  upcast Map.ofList<string, obj> [
-                    "name", upcast "SUBSCRIPTION"
-                    "description", upcast "Location adjacent to a subscription operation."
-                    "isDeprecated", upcast false
-                    "deprecationReason", null]
-                  upcast Map.ofList<string, obj> [
-                    "name", upcast "FIELD"
-                    "description", upcast "Location adjacent to a field."
-                    "isDeprecated", upcast false
-                    "deprecationReason", null]
-                  upcast Map.ofList<string, obj> [
-                    "name", upcast "FRAGMENT_DEFINITION"
-                    "description", upcast "Location adjacent to a fragment definition."
-                    "isDeprecated", upcast false
-                    "deprecationReason", null]
-                  upcast Map.ofList<string, obj> [
-                    "name", upcast "FRAGMENT_SPREAD"
-                    "description", upcast "Location adjacent to a fragment spread."
-                    "isDeprecated", upcast false
-                    "deprecationReason", null]
-                  upcast Map.ofList<string, obj> [
-                    "name", upcast "INLINE_FRAGMENT"
-                    "description", upcast "Location adjacent to an inline fragment."
-                    "isDeprecated", upcast false
-                    "deprecationReason", null]]
-                "fields", null
-                "kind", upcast "ENUM"
-                "possibleTypes", null]
-              upcast Map.ofList<string, obj> [
-                "inputFields", null
-                "name", upcast "__EnumValue"
-                "description", upcast "One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string."
-                "interfaces", upcast []
-                "enumValues", null
-                "fields", upcast [
-                  Map.ofList<string, obj> [
-                    "name", upcast "name"
-                    "description", null
-                    "isDeprecated", upcast false
-                    "deprecationReason", null
-                    "args", upcast []
-                    "type", upcast Map.ofList<string, obj> [
-                      "kind", upcast "NON_NULL"
-                      "name", null
-                      "ofType", upcast Map.ofList<string, obj> [
-                        "kind", upcast "SCALAR"
-                        "name", upcast "String"
-                        "ofType", null]]] :> obj
-                  upcast Map.ofList<string, obj> [
-                    "name", upcast "description"
-                    "description", null
-                    "isDeprecated", upcast false
-                    "deprecationReason", null
-                    "args", upcast []
-                    "type", upcast Map.ofList<string, obj> [
-                      "kind", upcast "SCALAR"
-                      "name", upcast "String"
-                      "ofType", null]]
-                  upcast Map.ofList<string, obj> [
-                    "name", upcast "isDeprecated"
-                    "description", null
-                    "isDeprecated", upcast false
-                    "deprecationReason", null
-                    "args", upcast []
-                    "type", upcast Map.ofList<string, obj> [
-                      "kind", upcast "NON_NULL"
-                      "name", null
-                      "ofType", upcast Map.ofList<string, obj> [
-                        "kind", upcast "SCALAR"
-                        "name", upcast "Boolean"
-                        "ofType", null]]]
-                  upcast Map.ofList<string, obj> [
-                    "name", upcast "deprecationReason"
-                    "description", null
-                    "isDeprecated", upcast false
-                    "deprecationReason", null
-                    "args", upcast []
-                    "type", upcast Map.ofList<string, obj> [
-                      "kind", upcast "SCALAR"
-                      "name", upcast "String"
-                      "ofType", null]]
-                ]
-                "kind", upcast "OBJECT"
-                "possibleTypes", null
-              ]
-              upcast Map.ofList<string, obj> [
-                "inputFields", null
-                "name", upcast "__Field"
-                "description", upcast "Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type."
-                "interfaces", upcast []
-                "enumValues", null
-                "fields", upcast [
-                  Map.ofList<string, obj> [
-                    "name", upcast "name"
-                    "description", null
-                    "isDeprecated", upcast false
-                    "deprecationReason", null
-                    "args", upcast []
-                    "type", upcast Map.ofList<string, obj> [
-                      "kind", upcast "NON_NULL"
-                      "name", null
-                      "ofType", upcast Map.ofList<string, obj> [
-                        "kind", upcast "SCALAR"
-                        "name", upcast "String"
-                        "ofType", null]]] :> obj
-                  upcast Map.ofList<string, obj> [
-                    "name", upcast "description"
-                    "description", null
-                    "isDeprecated", upcast false
-                    "deprecationReason", null
-                    "args", upcast []
-                    "type", upcast Map.ofList<string, obj> [
-                      "kind", upcast "SCALAR"
-                      "name", upcast "String"
-                      "ofType", null]]
-                  upcast Map.ofList<string, obj> [
-                    "name", upcast "args"
-                    "description", null
-                    "isDeprecated", upcast false
-                    "deprecationReason", null
-                    "args", upcast []
-                    "type", upcast Map.ofList<string, obj> [
-                      "kind", upcast "NON_NULL"
-                      "name", null
-                      "ofType", upcast Map.ofList<string, obj> [
-                        "kind", upcast "LIST"
-                        "name", null
-                        "ofType", upcast Map.ofList<string, obj> [
-                          "kind", upcast "NON_NULL"
-                          "name", null
-                          "ofType", upcast Map.ofList<string, obj> [
-                            "kind", upcast "OBJECT"
-                            "name", upcast "__InputValue"]]]]]
-                  upcast Map.ofList<string, obj> [
-                    "name", upcast "type"
-                    "description", null
-                    "isDeprecated", upcast false
-                    "deprecationReason", null
-                    "args", upcast []
-                    "type", upcast Map.ofList<string, obj> [
-                      "kind", upcast "NON_NULL"
-                      "name", null
-                      "ofType", upcast Map.ofList<string, obj> [
-                        "kind", upcast "OBJECT"
-                        "name", upcast "__Type"
-                        "ofType", null]]]
-                  upcast Map.ofList<string, obj> [
-                    "name", upcast "isDeprecated"
-                    "description", null
-                    "isDeprecated", upcast false
-                    "deprecationReason", null
-                    "args", upcast []
-                    "type", upcast Map.ofList<string, obj> [
-                      "kind", upcast "NON_NULL"
-                      "name", null
-                      "ofType", upcast Map.ofList<string, obj> [
-                        "kind", upcast "SCALAR"
-                        "name", upcast "Boolean"
-                        "ofType", null]]]
-                  upcast Map.ofList<string, obj> [
-                    "name", upcast "deprecationReason"
-                    "description", null
-                    "isDeprecated", upcast false
-                    "deprecationReason", null
-                    "args", upcast []
-                    "type", upcast Map.ofList<string, obj> [
-                      "kind", upcast "SCALAR"
-                      "name", upcast "String"
-                      "ofType", null]]
-                ]
-                "kind", upcast "OBJECT"
-                "possibleTypes", null
-              ]
-              upcast Map.ofList<string, obj> [
-                "inputFields", null
-                "name", upcast "__InputValue"
-                "description", upcast "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value."
-                "interfaces", upcast []
-                "enumValues", null
-                "fields", upcast [
-                  Map.ofList<string, obj> [
-                    "name", upcast "name"
-                    "description", null
-                    "isDeprecated", upcast false
-                    "deprecationReason", null
-                    "args", upcast []
-                    "type", upcast Map.ofList<string, obj> [
-                      "kind", upcast "NON_NULL"
-                      "name", null
-                      "ofType", upcast Map.ofList<string, obj> [
-                        "kind", upcast "SCALAR"
-                        "name", upcast "String"
-                        "ofType", null]]] :> obj
-                  upcast Map.ofList<string, obj> [
-                    "name", upcast "description"
-                    "description", null
-                    "isDeprecated", upcast false
-                    "deprecationReason", null
-                    "args", upcast []
-                    "type", upcast Map.ofList<string, obj> [
-                      "kind", upcast "SCALAR"
-                      "name", upcast "String"
-                      "ofType", null]]
-                  upcast Map.ofList<string, obj> [
-                    "name", upcast "type"
-                    "description", null
-                    "isDeprecated", upcast false
-                    "deprecationReason", null
-                    "args", upcast []
-                    "type", upcast Map.ofList<string, obj> [
-                      "kind", upcast "NON_NULL"
-                      "name", null
-                      "ofType", upcast Map.ofList<string, obj> [
-                        "kind", upcast "OBJECT"
-                        "name", upcast "__Type"
-                        "ofType", null]]]
-                  upcast Map.ofList<string, obj> [
-                    "name", upcast "defaultValue"
-                    "description", upcast "A GraphQL-formatted string representing the default value for this input value."
-                    "isDeprecated", upcast false
-                    "deprecationReason", null
-                    "args", upcast []
-                    "type", upcast Map.ofList<string, obj> [
-                      "kind", upcast "SCALAR"
-                      "name", upcast "String"
-                      "ofType", null]]
-                ]
-                "kind", upcast "OBJECT"
-                "possibleTypes", null
-              ]
-              upcast Map.ofList<string, obj> [
-                "inputFields", null
-                "name", upcast "__Schema"
-                "description", upcast "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations."
-                "interfaces", upcast []
-                "enumValues", null
-                "fields", upcast [
-                  Map.ofList<string, obj> [
-                    "name", upcast "types"
-                    "description", upcast "A list of all types supported by this server."
-                    "isDeprecated", upcast false
-                    "deprecationReason", null
-                    "args", upcast []
-                    "type", upcast Map.ofList<string, obj> [
-                      "kind", upcast "NON_NULL"
-                      "name", null
-                      "ofType", upcast Map.ofList<string, obj> [
-                        "kind", upcast "LIST"
-                        "name", null
-                        "ofType", upcast Map.ofList<string, obj> [
-                          "kind", upcast "NON_NULL"
-                          "name", null
-                          "ofType", upcast Map.ofList<string, obj> [
-                            "kind", upcast "OBJECT"
-                            "name", upcast "__Type"]]]]] :> obj
-                  upcast Map.ofList<string, obj> [
-                    "name", upcast "queryType"
-                    "description", upcast "The type that query operations will be rooted at."
-                    "isDeprecated", upcast false
-                    "deprecationReason", null
-                    "args", upcast []
-                    "type", upcast Map.ofList<string, obj> [
-                      "kind", upcast "NON_NULL"
-                      "name", null
-                      "ofType", upcast Map.ofList<string, obj> [
-                        "kind", upcast "OBJECT"
-                        "name", upcast "__Type"
-                        "ofType", null]]]
-                  upcast Map.ofList<string, obj> [
-                    "name", upcast "mutationType"
-                    "description", upcast "If this server supports mutation, the type that mutation operations will be rooted at."
-                    "isDeprecated", upcast false
-                    "deprecationReason", null
-                    "args", upcast []
-                    "type", upcast Map.ofList<string, obj> [
-                      "kind", upcast "OBJECT"
-                      "name", upcast "__Type"
-                      "ofType", null]]
-                  upcast Map.ofList<string, obj> [
-                    "name", upcast "subscriptionType"
-                    "description", upcast "If this server support subscription, the type that subscription operations will be rooted at."
-                    "isDeprecated", upcast false
-                    "deprecationReason", null
-                    "args", upcast []
-                    "type", upcast Map.ofList<string, obj> [
-                      "kind", upcast "OBJECT"
-                      "name", upcast "__Type"
-                      "ofType", null]]
-                  upcast Map.ofList<string, obj> [
-                    "name", upcast "directives"
-                    "description", upcast "A list of all directives supported by this server."
-                    "isDeprecated", upcast false
-                    "deprecationReason", null
-                    "args", upcast []
-                    "type", upcast Map.ofList<string, obj> [
-                      "kind", upcast "NON_NULL"
-                      "name", null
-                      "ofType", upcast Map.ofList<string, obj> [
-                        "kind", upcast "LIST"
-                        "name", null
-                        "ofType", upcast Map.ofList<string, obj> [
-                          "kind", upcast "NON_NULL"
-                          "name", null
-                          "ofType", upcast Map.ofList<string, obj> [
-                            "kind", upcast "OBJECT"
-                            "name", upcast "__Directive"]]]]]
-                ]
-                "kind", upcast "OBJECT"
-                "possibleTypes", null
-              ]
-              upcast Map.ofList<string, obj> [
-                "inputFields", null
-                "name", upcast "__Type"
-                "description", upcast "The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types."
-                "interfaces", upcast []
-                "enumValues", null
-                "fields", upcast [
-                  Map.ofList<string, obj> [
-                    "name", upcast "kind"
-                    "description", null
-                    "isDeprecated", upcast false
-                    "deprecationReason", null
-                    "args", upcast []
-                    "type", upcast Map.ofList<string, obj> [
-                      "kind", upcast "NON_NULL"
-                      "name", null
-                      "ofType", upcast Map.ofList<string, obj> [
-                        "kind", upcast "ENUM"
-                        "name", upcast "__TypeKind"
-                        "ofType", null]]] :> obj
-                  upcast Map.ofList<string, obj> [
-                    "name", upcast "name"
-                    "description", null
-                    "isDeprecated", upcast false
-                    "deprecationReason", null
-                    "args", upcast []
-                    "type", upcast Map.ofList<string, obj> [
-                      "kind", upcast "SCALAR"
-                      "name", upcast "String"
-                      "ofType", null]]
-                  upcast Map.ofList<string, obj> [
-                    "name", upcast "description"
-                    "description", null
-                    "isDeprecated", upcast false
-                    "deprecationReason", null
-                    "args", upcast []
-                    "type", upcast Map.ofList<string, obj> [
-                      "kind", upcast "SCALAR"
-                      "name", upcast "String"
-                      "ofType", null]]
-                  upcast Map.ofList<string, obj> [
-                    "name", upcast "fields"
-                    "description", null
-                    "isDeprecated", upcast false
-                    "deprecationReason", null
-                    "args", upcast [
-                      Map.ofList<string, obj> [
-                        "name", upcast "includeDeprecated"
-                        "description", null
-                        "type", upcast Map.ofList<string, obj> [
-                          "kind", upcast "SCALAR"
-                          "name", upcast "Boolean"
-                          "ofType", null]
-                        "defaultValue", upcast "false"]:>obj]
-                    "type", upcast Map.ofList<string, obj> [
-                      "kind", upcast "LIST"
-                      "name", null
-                      "ofType", upcast Map.ofList<string, obj> [
-                        "kind", upcast "NON_NULL"
-                        "name", null
-                        "ofType", upcast Map.ofList<string, obj> [
-                          "kind", upcast "OBJECT"
-                          "name", upcast "__Field"
-                          "ofType", null]]]]
-                  upcast Map.ofList<string, obj> [
-                    "name", upcast "interfaces"
-                    "description", null
-                    "isDeprecated", upcast false
-                    "deprecationReason", null
-                    "args", upcast []
-                    "type", upcast Map.ofList<string, obj> [
-                      "kind", upcast "LIST"
-                      "name", null
-                      "ofType", upcast Map.ofList<string, obj> [
-                        "kind", upcast "NON_NULL"
-                        "name", null
-                        "ofType", upcast Map.ofList<string, obj> [
-                          "kind", upcast "OBJECT"
-                          "name", upcast "__Type"
-                          "ofType", null]]]]
-                  upcast Map.ofList<string, obj> [
-                    "name", upcast "possibleTypes"
-                    "description", null
-                    "isDeprecated", upcast false
-                    "deprecationReason", null
-                    "args", upcast []
-                    "type", upcast Map.ofList<string, obj> [
-                      "kind", upcast "LIST"
-                      "name", null
-                      "ofType", upcast Map.ofList<string, obj> [
-                        "kind", upcast "NON_NULL"
-                        "name", null
-                        "ofType", upcast Map.ofList<string, obj> [
-                          "kind", upcast "OBJECT"
-                          "name", upcast "__Type"
-                          "ofType", null]]]]
-                  upcast Map.ofList<string, obj> [
-                    "name", upcast "enumValues"
-                    "description", null
-                    "isDeprecated", upcast false
-                    "deprecationReason", null
-                    "args", upcast [
-                      Map.ofList<string, obj> [
-                        "name", upcast "includeDeprecated"
-                        "description", null
-                        "type", upcast Map.ofList<string, obj> [
-                          "kind", upcast "SCALAR"
-                          "name", upcast "Boolean"
-                          "ofType", null]
-                        "defaultValue", upcast "false"]:>obj]
-                    "type", upcast Map.ofList<string, obj> [
-                      "kind", upcast "LIST"
-                      "name", null
-                      "ofType", upcast Map.ofList<string, obj> [
-                        "kind", upcast "NON_NULL"
-                        "name", null
-                        "ofType", upcast Map.ofList<string, obj> [
-                          "kind", upcast "OBJECT"
-                          "name", upcast "__EnumValue"
-                          "ofType", null]]]]
-                  upcast Map.ofList<string, obj> [
-                    "name", upcast "inputFields"
-                    "description", null
-                    "isDeprecated", upcast false
-                    "deprecationReason", null
-                    "args", upcast []
-                    "type", upcast Map.ofList<string, obj> [
-                      "kind", upcast "LIST"
-                      "name", null
-                      "ofType", upcast Map.ofList<string, obj> [
-                        "kind", upcast "NON_NULL"
-                        "name", null
-                        "ofType", upcast Map.ofList<string, obj> [
-                          "kind", upcast "OBJECT"
-                          "name", upcast "__InputValue"
-                          "ofType", null]]]]
-                  upcast Map.ofList<string, obj> [
-                    "name", upcast "ofType"
-                    "description", null
-                    "isDeprecated", upcast false
-                    "deprecationReason", null
-                    "args", upcast []
-                    "type", upcast Map.ofList<string, obj> [
-                      "kind", upcast "OBJECT"
-                      "name", upcast "__Type"
-                      "ofType", null]]
-                ]
-                "kind", upcast "OBJECT"
-                "possibleTypes", null
-              ]
-              upcast Map.ofList<string, obj> [
-                "inputFields", null
-                "name", upcast "__TypeKind"
-                "description", upcast "An enum describing what kind of type a given `__Type` is."
-                "interfaces", null
-                "enumValues", upcast [
-                  Map.ofList<string, obj> [
-                    "name", upcast "SCALAR"
-                    "description", upcast "Indicates this type is a scalar."
-                    "isDeprecated", upcast false
-                    "deprecationReason", null] :> obj
-                  upcast Map.ofList<string, obj> [
-                    "name", upcast "OBJECT"
-                    "description", upcast "Indicates this type is an object. `fields` and `interfaces` are valid fields."
-                    "isDeprecated", upcast false
-                    "deprecationReason", null]
-                  upcast Map.ofList<string, obj> [
-                    "name", upcast "INTERFACE"
-                    "description", upcast "Indicates this type is an interface. `fields` and `possibleTypes` are valid fields."
-                    "isDeprecated", upcast false
-                    "deprecationReason", null]
-                  upcast Map.ofList<string, obj> [
-                    "name", upcast "UNION"
-                    "description", upcast "Indicates this type is a union. `possibleTypes` is a valid field."
-                    "isDeprecated", upcast false
-                    "deprecationReason", null]
-                  upcast Map.ofList<string, obj> [
-                    "name", upcast "ENUM"
-                    "description", upcast "Indicates this type is an enum. `enumValues` is a valid field."
-                    "isDeprecated", upcast false
-                    "deprecationReason", null]
-                  upcast Map.ofList<string, obj> [
-                    "name", upcast "INPUT_OBJECT"
-                    "description", upcast "Indicates this type is an input object. `inputFields` is a valid field."
-                    "isDeprecated", upcast false
-                    "deprecationReason", null]
-                  upcast Map.ofList<string, obj> [
-                    "name", upcast "LIST"
-                    "description", upcast "Indicates this type is a list. `ofType` is a valid field."
-                    "isDeprecated", upcast false
-                    "deprecationReason", null]
-                  upcast Map.ofList<string, obj> [
-                    "name", upcast "NON_NULL"
-                    "description", upcast "Indicates this type is a non-null. `ofType` is a valid field."
-                    "isDeprecated", upcast false
-                    "deprecationReason", null]
-                ]
-                "fields", null
-                "kind", upcast "ENUM"
-                "possibleTypes", null]
-              upcast Map.ofList<string, obj> [
-                "inputFields", null
-                "name", upcast "BigDecimal"
-                "description", upcast "The `BigDecimal` scalar type represents signed fractional values with arbitrary precision."
-                "interfaces", null
-                "enumValues", null
-                "fields", null
-                "kind", upcast "SCALAR"
-                "possibleTypes", null]
-              upcast Map.ofList<string, obj> [
-                "inputFields", null
-                "name", upcast "BigInt"
-                "description", upcast "The `BigInt` scalar type represents non-fractional signed whole numeric values. BigInt can represent arbitrary big values."
-                "interfaces", null
-                "enumValues", null
-                "fields", null
-                "kind", upcast "SCALAR"
-                "possibleTypes", null]
-              upcast Map.ofList<string, obj> [
-                "inputFields", null
-                "name", upcast "Boolean"
-                "description", upcast "The `Boolean` scalar type represents `true` or `false`."
-                "interfaces", null
-                "enumValues", null
-                "fields", null
-                "kind", upcast "SCALAR"
-                "possibleTypes", null]
-              upcast Map.ofList<string, obj> [
-                "inputFields", null
-                "name", upcast "Float"
-                "description", upcast "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point)."
-                "interfaces", null
-                "enumValues", null
-                "fields", null
-                "kind", upcast "SCALAR"
-                "possibleTypes", null]
-              upcast Map.ofList<string, obj> [
-                "inputFields", null
-                "name", upcast "ID"
-                "description", upcast (
-                  "The `ID` scalar type represents a unique identifier, often used to " +
-                  "refetch an object or as key for a cache. The ID type appears in a JSON " +
-                  "response as a String; however, it is not intended to be human-readable. " +
-                  "When expected as an input type, any string (such as `\"4\"`) or integer " +
-                  "(such as `4`) input value will be accepted as an ID.")
-                "interfaces", null
-                "enumValues", null
-                "fields", null
-                "kind", upcast "SCALAR"
-                "possibleTypes", null]
-              upcast Map.ofList<string, obj> [
-                "inputFields", null
-                "name", upcast "Int"
-                "description", upcast (
-                  "The `Int` scalar type represents non-fractional signed whole numeric values. " +
-                  "Int can represent values between -(2^31) and 2^31 - 1.")
-                "interfaces", null
-                "enumValues", null
-                "fields", null
-                "kind", upcast "SCALAR"
-                "possibleTypes", null]
-              upcast Map.ofList<string, obj> [
-                "inputFields", null
-                "name", upcast "Long"
-                "description", upcast (
-                  "The `Long` scalar type represents non-fractional signed whole numeric values. " +
-                  "Long can represent values between -(2^63) and 2^63 - 1.")
-                "interfaces", null
-                "enumValues", null
-                "fields", null
-                "kind", upcast "SCALAR"
-                "possibleTypes", null]
-              upcast Map.ofList<string, obj> [
-                "inputFields", null
-                "name", upcast "String"
-                "description", upcast (
-                  "The `String` scalar type represents textual data, represented as UTF-8 " +
-                  "character sequences. The String type is most often used by GraphQL to " +
-                  "represent free-form human-readable text.")
-                "interfaces", null
-                "enumValues", null
-                "fields", null
-                "kind", upcast "SCALAR"
-                "possibleTypes", null]]
+                    box <| Map.ofList<string, obj> [
+                         "kind", upcast "OBJECT"
+                         "name", upcast "QueryRoot"
+                         "inputFields", null
+                         "interfaces", upcast []
+                         "enumValues", null
+                         "possibleTypes", null];
+                    upcast Map.ofList<string, obj> [
+                         "kind", upcast "OBJECT"
+                         "name", upcast "__Schema"
+                         "fields", upcast [
+                                 box <| Map.ofList<string, obj> [
+                                      "name", upcast "types"
+                                      "args", upcast []
+                                      "type", upcast Map.ofList<string, obj> [
+                                              "kind", upcast "NON_NULL"
+                                              "name", null
+                                              "ofType", upcast Map.ofList<string, obj> [
+                                                      "kind", upcast "LIST"
+                                                      "name", null
+                                                      "ofType", upcast Map.ofList<string, obj> [
+                                                              "kind", upcast "NON_NULL"
+                                                              "name", null
+                                                              "ofType", upcast Map.ofList<string, obj> [
+                                                                      "kind", upcast "OBJECT"
+                                                                      "name", upcast "__Type"]]]]
+                                      "isDeprecated", upcast false
+                                      "deprecationReason", null];
+                                 upcast Map.ofList<string, obj> [
+                                      "name", upcast "queryType"
+                                      "args", upcast []
+                                      "type", upcast Map.ofList<string, obj> [
+                                              "kind", upcast "NON_NULL"
+                                              "name", null
+                                              "ofType", upcast Map.ofList<string, obj> [
+                                                      "kind", upcast "OBJECT"
+                                                      "name", upcast "__Type"
+                                                      "ofType", null]]
+                                      "isDeprecated", upcast false
+                                      "deprecationReason", null];
+                                 upcast Map.ofList<string, obj> [
+                                      "name", upcast "mutationType"
+                                      "args", upcast []
+                                      "type", upcast Map.ofList<string, obj> [
+                                              "kind", upcast "OBJECT"
+                                              "name", upcast "__Type"
+                                              "ofType", null]
+                                      "isDeprecated", upcast false
+                                      "deprecationReason", null];
+                                 upcast Map.ofList<string, obj> [
+                                      "name", upcast "subscriptionType"
+                                      "args", upcast []
+                                      "type", upcast Map.ofList<string, obj> [
+                                              "kind", upcast "OBJECT"
+                                              "name", upcast "__Type"
+                                              "ofType", null]
+                                      "isDeprecated", upcast false
+                                      "deprecationReason", null];
+                                 upcast Map.ofList<string, obj> [
+                                      "name", upcast "directives"
+                                      "args", upcast []
+                                      "type", upcast Map.ofList<string, obj> [
+                                              "kind", upcast "NON_NULL"
+                                              "name", null
+                                              "ofType", upcast Map.ofList<string, obj> [
+                                                      "kind", upcast "LIST"
+                                                      "name", null
+                                                      "ofType", upcast Map.ofList<string, obj> [
+                                                              "kind", upcast "NON_NULL"
+                                                              "name", null
+                                                              "ofType", upcast Map.ofList<string, obj> [
+                                                                      "kind", upcast "OBJECT"
+                                                                      "name", upcast "__Directive"]]]]
+                                      "isDeprecated", upcast false
+                                      "deprecationReason", null];]
+                         "inputFields", null
+                         "interfaces", upcast []
+                         "enumValues", null
+                         "possibleTypes", null];
+                    upcast Map.ofList<string, obj> [
+                         "kind", upcast "OBJECT"
+                         "name", upcast "__Type"
+                         "fields", upcast [
+                                 box <| Map.ofList<string, obj> [
+                                      "name", upcast "kind"
+                                      "args", upcast []
+                                      "type", upcast Map.ofList<string, obj> [
+                                              "kind", upcast "NON_NULL"
+                                              "name", null
+                                              "ofType", upcast Map.ofList<string, obj> [
+                                                      "kind", upcast "ENUM"
+                                                      "name", upcast "__TypeKind"
+                                                      "ofType", null]]
+                                      "isDeprecated", upcast false
+                                      "deprecationReason", null];
+                                 upcast Map.ofList<string, obj> [
+                                      "name", upcast "name"
+                                      "args", upcast []
+                                      "type", upcast Map.ofList<string, obj> [
+                                              "kind", upcast "SCALAR"
+                                              "name", upcast "String"
+                                              "ofType", null]
+                                      "isDeprecated", upcast false
+                                      "deprecationReason", null];
+                                 upcast Map.ofList<string, obj> [
+                                      "name", upcast "description"
+                                      "args", upcast []
+                                      "type", upcast Map.ofList<string, obj> [
+                                              "kind", upcast "SCALAR"
+                                              "name", upcast "String"
+                                              "ofType", null]
+                                      "isDeprecated", upcast false
+                                      "deprecationReason", null];
+                                 upcast Map.ofList<string, obj> [
+                                      "name", upcast "fields"
+                                      "args", upcast [
+                                              box <| Map.ofList<string, obj> [
+                                                   "name", upcast "includeDeprecated"
+                                                   "type", upcast Map.ofList<string, obj> [
+                                                           "kind", upcast "SCALAR"
+                                                           "name", upcast "Boolean"
+                                                           "ofType", null]
+                                                   "defaultValue", upcast "false"];]
+                                      "type", upcast Map.ofList<string, obj> [
+                                              "kind", upcast "LIST"
+                                              "name", null
+                                              "ofType", upcast Map.ofList<string, obj> [
+                                                      "kind", upcast "NON_NULL"
+                                                      "name", null
+                                                      "ofType", upcast Map.ofList<string, obj> [
+                                                              "kind", upcast "OBJECT"
+                                                              "name", upcast "__Field"
+                                                              "ofType", null]]]
+                                      "isDeprecated", upcast false
+                                      "deprecationReason", null];
+                                 upcast Map.ofList<string, obj> [
+                                      "name", upcast "interfaces"
+                                      "args", upcast []
+                                      "type", upcast Map.ofList<string, obj> [
+                                              "kind", upcast "LIST"
+                                              "name", null
+                                              "ofType", upcast Map.ofList<string, obj> [
+                                                      "kind", upcast "NON_NULL"
+                                                      "name", null
+                                                      "ofType", upcast Map.ofList<string, obj> [
+                                                              "kind", upcast "OBJECT"
+                                                              "name", upcast "__Type"
+                                                              "ofType", null]]]
+                                      "isDeprecated", upcast false
+                                      "deprecationReason", null];
+                                 upcast Map.ofList<string, obj> [
+                                      "name", upcast "possibleTypes"
+                                      "args", upcast []
+                                      "type", upcast Map.ofList<string, obj> [
+                                              "kind", upcast "LIST"
+                                              "name", null
+                                              "ofType", upcast Map.ofList<string, obj> [
+                                                      "kind", upcast "NON_NULL"
+                                                      "name", null
+                                                      "ofType", upcast Map.ofList<string, obj> [
+                                                              "kind", upcast "OBJECT"
+                                                              "name", upcast "__Type"
+                                                              "ofType", null]]]
+                                      "isDeprecated", upcast false
+                                      "deprecationReason", null];
+                                 upcast Map.ofList<string, obj> [
+                                      "name", upcast "enumValues"
+                                      "args", upcast [
+                                              box <| Map.ofList<string, obj> [
+                                                   "name", upcast "includeDeprecated"
+                                                   "type", upcast Map.ofList<string, obj> [
+                                                           "kind", upcast "SCALAR"
+                                                           "name", upcast "Boolean"
+                                                           "ofType", null]
+                                                   "defaultValue", upcast "false"];]
+                                      "type", upcast Map.ofList<string, obj> [
+                                              "kind", upcast "LIST"
+                                              "name", null
+                                              "ofType", upcast Map.ofList<string, obj> [
+                                                      "kind", upcast "NON_NULL"
+                                                      "name", null
+                                                      "ofType", upcast Map.ofList<string, obj> [
+                                                              "kind", upcast "OBJECT"
+                                                              "name", upcast "__EnumValue"
+                                                              "ofType", null]]]
+                                      "isDeprecated", upcast false
+                                      "deprecationReason", null];
+                                 upcast Map.ofList<string, obj> [
+                                      "name", upcast "inputFields"
+                                      "args", upcast []
+                                      "type", upcast Map.ofList<string, obj> [
+                                              "kind", upcast "LIST"
+                                              "name", null
+                                              "ofType", upcast Map.ofList<string, obj> [
+                                                      "kind", upcast "NON_NULL"
+                                                      "name", null
+                                                      "ofType", upcast Map.ofList<string, obj> [
+                                                              "kind", upcast "OBJECT"
+                                                              "name", upcast "__InputValue"
+                                                              "ofType", null]]]
+                                      "isDeprecated", upcast false
+                                      "deprecationReason", null];
+                                 upcast Map.ofList<string, obj> [
+                                      "name", upcast "ofType"
+                                      "args", upcast []
+                                      "type", upcast Map.ofList<string, obj> [
+                                              "kind", upcast "OBJECT"
+                                              "name", upcast "__Type"
+                                              "ofType", null]
+                                      "isDeprecated", upcast false
+                                      "deprecationReason", null];]
+                         "inputFields", null
+                         "interfaces", upcast []
+                         "enumValues", null
+                         "possibleTypes", null];
+                    upcast Map.ofList<string, obj> [
+                         "kind", upcast "ENUM"
+                         "name", upcast "__TypeKind"
+                         "fields", null
+                         "inputFields", null
+                         "interfaces", null
+                         "enumValues", upcast [
+                                 box <| Map.ofList<string, obj> [
+                                      "name", upcast "SCALAR"
+                                      "isDeprecated", upcast false
+                                      "deprecationReason", null];
+                                 upcast Map.ofList<string, obj> [
+                                      "name", upcast "OBJECT"
+                                      "isDeprecated", upcast false
+                                      "deprecationReason", null];
+                                 upcast Map.ofList<string, obj> [
+                                      "name", upcast "INTERFACE"
+                                      "isDeprecated", upcast false
+                                      "deprecationReason", null];
+                                 upcast Map.ofList<string, obj> [
+                                      "name", upcast "UNION"
+                                      "isDeprecated", upcast false
+                                      "deprecationReason", null];
+                                 upcast Map.ofList<string, obj> [
+                                      "name", upcast "ENUM"
+                                      "isDeprecated", upcast false
+                                      "deprecationReason", null];
+                                 upcast Map.ofList<string, obj> [
+                                      "name", upcast "INPUT_OBJECT"
+                                      "isDeprecated", upcast false
+                                      "deprecationReason", null];
+                                 upcast Map.ofList<string, obj> [
+                                      "name", upcast "LIST"
+                                      "isDeprecated", upcast false
+                                      "deprecationReason", null];
+                                 upcast Map.ofList<string, obj> [
+                                      "name", upcast "NON_NULL"
+                                      "isDeprecated", upcast false
+                                      "deprecationReason", null];]
+                         "possibleTypes", null];
+                    upcast Map.ofList<string, obj> [
+                         "kind", upcast "SCALAR"
+                         "name", upcast "String"
+                         "fields", null
+                         "inputFields", null
+                         "interfaces", null
+                         "enumValues", null
+                         "possibleTypes", null];
+                    upcast Map.ofList<string, obj> [
+                         "kind", upcast "SCALAR"
+                         "name", upcast "Boolean"
+                         "fields", null
+                         "inputFields", null
+                         "interfaces", null
+                         "enumValues", null
+                         "possibleTypes", null];
+                    upcast Map.ofList<string, obj> [
+                         "kind", upcast "OBJECT"
+                         "name", upcast "__Field"
+                         "fields", upcast [
+                                 box <| Map.ofList<string, obj> [
+                                      "name", upcast "name"
+                                      "args", upcast []
+                                      "type", upcast Map.ofList<string, obj> [
+                                              "kind", upcast "NON_NULL"
+                                              "name", null
+                                              "ofType", upcast Map.ofList<string, obj> [
+                                                      "kind", upcast "SCALAR"
+                                                      "name", upcast "String"
+                                                      "ofType", null]]
+                                      "isDeprecated", upcast false
+                                      "deprecationReason", null];
+                                 upcast Map.ofList<string, obj> [
+                                      "name", upcast "description"
+                                      "args", upcast []
+                                      "type", upcast Map.ofList<string, obj> [
+                                              "kind", upcast "SCALAR"
+                                              "name", upcast "String"
+                                              "ofType", null]
+                                      "isDeprecated", upcast false
+                                      "deprecationReason", null];
+                                 upcast Map.ofList<string, obj> [
+                                      "name", upcast "args"
+                                      "args", upcast []
+                                      "type", upcast Map.ofList<string, obj> [
+                                              "kind", upcast "NON_NULL"
+                                              "name", null
+                                              "ofType", upcast Map.ofList<string, obj> [
+                                                      "kind", upcast "LIST"
+                                                      "name", null
+                                                      "ofType", upcast Map.ofList<string, obj> [
+                                                              "kind", upcast "NON_NULL"
+                                                              "name", null
+                                                              "ofType", upcast Map.ofList<string, obj> [
+                                                                      "kind", upcast "OBJECT"
+                                                                      "name", upcast "__InputValue"]]]]
+                                      "isDeprecated", upcast false
+                                      "deprecationReason", null];
+                                 upcast Map.ofList<string, obj> [
+                                      "name", upcast "type"
+                                      "args", upcast []
+                                      "type", upcast Map.ofList<string, obj> [
+                                              "kind", upcast "NON_NULL"
+                                              "name", null
+                                              "ofType", upcast Map.ofList<string, obj> [
+                                                      "kind", upcast "OBJECT"
+                                                      "name", upcast "__Type"
+                                                      "ofType", null]]
+                                      "isDeprecated", upcast false
+                                      "deprecationReason", null];
+                                 upcast Map.ofList<string, obj> [
+                                      "name", upcast "isDeprecated"
+                                      "args", upcast []
+                                      "type", upcast Map.ofList<string, obj> [
+                                              "kind", upcast "NON_NULL"
+                                              "name", null
+                                              "ofType", upcast Map.ofList<string, obj> [
+                                                      "kind", upcast "SCALAR"
+                                                      "name", upcast "Boolean"
+                                                      "ofType", null]]
+                                      "isDeprecated", upcast false
+                                      "deprecationReason", null];
+                                 upcast Map.ofList<string, obj> [
+                                      "name", upcast "deprecationReason"
+                                      "args", upcast []
+                                      "type", upcast Map.ofList<string, obj> [
+                                              "kind", upcast "SCALAR"
+                                              "name", upcast "String"
+                                              "ofType", null]
+                                      "isDeprecated", upcast false
+                                      "deprecationReason", null];]
+                         "inputFields", null
+                         "interfaces", upcast []
+                         "enumValues", null
+                         "possibleTypes", null];
+                    upcast Map.ofList<string, obj> [
+                         "kind", upcast "OBJECT"
+                         "name", upcast "__InputValue"
+                         "fields", upcast [
+                                 box <| Map.ofList<string, obj> [
+                                      "name", upcast "name"
+                                      "args", upcast []
+                                      "type", upcast Map.ofList<string, obj> [
+                                              "kind", upcast "NON_NULL"
+                                              "name", null
+                                              "ofType", upcast Map.ofList<string, obj> [
+                                                      "kind", upcast "SCALAR"
+                                                      "name", upcast "String"
+                                                      "ofType", null]]
+                                      "isDeprecated", upcast false
+                                      "deprecationReason", null];
+                                 upcast Map.ofList<string, obj> [
+                                      "name", upcast "description"
+                                      "args", upcast []
+                                      "type", upcast Map.ofList<string, obj> [
+                                              "kind", upcast "SCALAR"
+                                              "name", upcast "String"
+                                              "ofType", null]
+                                      "isDeprecated", upcast false
+                                      "deprecationReason", null];
+                                 upcast Map.ofList<string, obj> [
+                                      "name", upcast "type"
+                                      "args", upcast []
+                                      "type", upcast Map.ofList<string, obj> [
+                                              "kind", upcast "NON_NULL"
+                                              "name", null
+                                              "ofType", upcast Map.ofList<string, obj> [
+                                                      "kind", upcast "OBJECT"
+                                                      "name", upcast "__Type"
+                                                      "ofType", null]]
+                                      "isDeprecated", upcast false
+                                      "deprecationReason", null];
+                                 upcast Map.ofList<string, obj> [
+                                      "name", upcast "defaultValue"
+                                      "args", upcast []
+                                      "type", upcast Map.ofList<string, obj> [
+                                              "kind", upcast "SCALAR"
+                                              "name", upcast "String"
+                                              "ofType", null]
+                                      "isDeprecated", upcast false
+                                      "deprecationReason", null];]
+                         "inputFields", null
+                         "interfaces", upcast []
+                         "enumValues", null
+                         "possibleTypes", null];
+                    upcast Map.ofList<string, obj> [
+                         "kind", upcast "OBJECT"
+                         "name", upcast "__EnumValue"
+                         "fields", upcast [
+                                 box <| Map.ofList<string, obj> [
+                                      "name", upcast "name"
+                                      "args", upcast []
+                                      "type", upcast Map.ofList<string, obj> [
+                                              "kind", upcast "NON_NULL"
+                                              "name", null
+                                              "ofType", upcast Map.ofList<string, obj> [
+                                                      "kind", upcast "SCALAR"
+                                                      "name", upcast "String"
+                                                      "ofType", null]]
+                                      "isDeprecated", upcast false
+                                      "deprecationReason", null];
+                                 upcast Map.ofList<string, obj> [
+                                      "name", upcast "description"
+                                      "args", upcast []
+                                      "type", upcast Map.ofList<string, obj> [
+                                              "kind", upcast "SCALAR"
+                                              "name", upcast "String"
+                                              "ofType", null]
+                                      "isDeprecated", upcast false
+                                      "deprecationReason", null];
+                                 upcast Map.ofList<string, obj> [
+                                      "name", upcast "isDeprecated"
+                                      "args", upcast []
+                                      "type", upcast Map.ofList<string, obj> [
+                                              "kind", upcast "NON_NULL"
+                                              "name", null
+                                              "ofType", upcast Map.ofList<string, obj> [
+                                                      "kind", upcast "SCALAR"
+                                                      "name", upcast "Boolean"
+                                                      "ofType", null]]
+                                      "isDeprecated", upcast false
+                                      "deprecationReason", null];
+                                 upcast Map.ofList<string, obj> [
+                                      "name", upcast "deprecationReason"
+                                      "args", upcast []
+                                      "type", upcast Map.ofList<string, obj> [
+                                              "kind", upcast "SCALAR"
+                                              "name", upcast "String"
+                                              "ofType", null]
+                                      "isDeprecated", upcast false
+                                      "deprecationReason", null];]
+                         "inputFields", null
+                         "interfaces", upcast []
+                         "enumValues", null
+                         "possibleTypes", null];
+                    upcast Map.ofList<string, obj> [
+                         "kind", upcast "OBJECT"
+                         "name", upcast "__Directive"
+                         "fields", upcast [
+                                 box <| Map.ofList<string, obj> [
+                                      "name", upcast "name"
+                                      "args", upcast []
+                                      "type", upcast Map.ofList<string, obj> [
+                                              "kind", upcast "NON_NULL"
+                                              "name", null
+                                              "ofType", upcast Map.ofList<string, obj> [
+                                                      "kind", upcast "SCALAR"
+                                                      "name", upcast "String"
+                                                      "ofType", null]]
+                                      "isDeprecated", upcast false
+                                      "deprecationReason", null];
+                                 upcast Map.ofList<string, obj> [
+                                      "name", upcast "description"
+                                      "args", upcast []
+                                      "type", upcast Map.ofList<string, obj> [
+                                              "kind", upcast "SCALAR"
+                                              "name", upcast "String"
+                                              "ofType", null]
+                                      "isDeprecated", upcast false
+                                      "deprecationReason", null];
+                                 upcast Map.ofList<string, obj> [
+                                      "name", upcast "locations"
+                                      "args", upcast []
+                                      "type", upcast Map.ofList<string, obj> [
+                                              "kind", upcast "NON_NULL"
+                                              "name", null
+                                              "ofType", upcast Map.ofList<string, obj> [
+                                                      "kind", upcast "LIST"
+                                                      "name", null
+                                                      "ofType", upcast Map.ofList<string, obj> [
+                                                              "kind", upcast "NON_NULL"
+                                                              "name", null
+                                                              "ofType", upcast Map.ofList<string, obj> [
+                                                                      "kind", upcast "ENUM"
+                                                                      "name", upcast "__DirectiveLocation"]]]]
+                                      "isDeprecated", upcast false
+                                      "deprecationReason", null];
+                                 upcast Map.ofList<string, obj> [
+                                      "name", upcast "args"
+                                      "args", upcast []
+                                      "type", upcast Map.ofList<string, obj> [
+                                              "kind", upcast "NON_NULL"
+                                              "name", null
+                                              "ofType", upcast Map.ofList<string, obj> [
+                                                      "kind", upcast "LIST"
+                                                      "name", null
+                                                      "ofType", upcast Map.ofList<string, obj> [
+                                                              "kind", upcast "NON_NULL"
+                                                              "name", null
+                                                              "ofType", upcast Map.ofList<string, obj> [
+                                                                      "kind", upcast "OBJECT"
+                                                                      "name", upcast "__InputValue"]]]]
+                                      "isDeprecated", upcast false
+                                      "deprecationReason", null];
+                                 upcast Map.ofList<string, obj> [
+                                      "name", upcast "onOperation"
+                                      "args", upcast []
+                                      "type", upcast Map.ofList<string, obj> [
+                                              "kind", upcast "NON_NULL"
+                                              "name", null
+                                              "ofType", upcast Map.ofList<string, obj> [
+                                                      "kind", upcast "SCALAR"
+                                                      "name", upcast "Boolean"
+                                                      "ofType", null]]
+                                      "isDeprecated", upcast true
+                                      "deprecationReason", upcast "Use `locations`."];
+                                 upcast Map.ofList<string, obj> [
+                                      "name", upcast "onFragment"
+                                      "args", upcast []
+                                      "type", upcast Map.ofList<string, obj> [
+                                              "kind", upcast "NON_NULL"
+                                              "name", null
+                                              "ofType", upcast Map.ofList<string, obj> [
+                                                      "kind", upcast "SCALAR"
+                                                      "name", upcast "Boolean"
+                                                      "ofType", null]]
+                                      "isDeprecated", upcast true
+                                      "deprecationReason", upcast "Use `locations`."];
+                                 upcast Map.ofList<string, obj> [
+                                      "name", upcast "onField"
+                                      "args", upcast []
+                                      "type", upcast Map.ofList<string, obj> [
+                                              "kind", upcast "NON_NULL"
+                                              "name", null
+                                              "ofType", upcast Map.ofList<string, obj> [
+                                                      "kind", upcast "SCALAR"
+                                                      "name", upcast "Boolean"
+                                                      "ofType", null]]
+                                      "isDeprecated", upcast true
+                                      "deprecationReason", upcast "Use `locations`."];]
+                         "inputFields", null
+                         "interfaces", upcast []
+                         "enumValues", null
+                         "possibleTypes", null];
+                    upcast Map.ofList<string, obj> [
+                         "kind", upcast "ENUM"
+                         "name", upcast "__DirectiveLocation"
+                         "fields", null
+                         "inputFields", null
+                         "interfaces", null
+                         "enumValues", upcast [
+                                 box <| Map.ofList<string, obj> [
+                                      "name", upcast "QUERY"
+                                      "isDeprecated", upcast false];
+                                 upcast Map.ofList<string, obj> [
+                                      "name", upcast "MUTATION"
+                                      "isDeprecated", upcast false];
+                                 upcast Map.ofList<string, obj> [
+                                      "name", upcast "SUBSCRIPTION"
+                                      "isDeprecated", upcast false];
+                                 upcast Map.ofList<string, obj> [
+                                      "name", upcast "FIELD"
+                                      "isDeprecated", upcast false];
+                                 upcast Map.ofList<string, obj> [
+                                      "name", upcast "FRAGMENT_DEFINITION"
+                                      "isDeprecated", upcast false];
+                                 upcast Map.ofList<string, obj> [
+                                      "name", upcast "FRAGMENT_SPREAD"
+                                      "isDeprecated", upcast false];
+                                 upcast Map.ofList<string, obj> [
+                                      "name", upcast "INLINE_FRAGMENT"
+                                      "isDeprecated", upcast false];]
+                         "possibleTypes", null];]
             "directives", upcast [
-              Map.ofList<string, obj> [
-                "name", upcast "include"
-                "description", upcast "Directs the executor to include this field or fragment only when the `if` argument is true."
-                "locations", upcast ["FIELD" :> obj, "FRAGMENT_SPREAD", "INLINE_FRAGMENT"]
-                "args", upcast [
-                  Map.ofList<string, obj> [
-                    "name", upcast "if"
-                    "description", upcast "Included when true."
-                    "type", upcast Map.ofList<string, obj> [
-                      "kind", upcast "NON_NULL"
-                      "name", null
-                      "ofType", upcast Map.ofList<string, obj> [
-                        "kind", upcast "SCALAR"
-                        "name", upcast "Boolean"
-                        "ofType", null]]
-                    "defaultValue", null]]] :> obj
-              upcast Map.ofList<string, obj> [
-                "name", upcast "skip"
-                "description", upcast "Directs the executor to skip this field or fragment when the `if` argument is true."
-                "locations", upcast ["FIELD" :> obj, "FRAGMENT_SPREAD", "INLINE_FRAGMENT"]
-                "args", upcast [
-                  Map.ofList<string, obj> [
-                    "name", upcast "if"
-                    "description", upcast "Included when true."
-                    "type", upcast Map.ofList<string, obj> [
-                      "kind", upcast "NON_NULL"
-                      "name", null
-                      "ofType", upcast Map.ofList<string, obj> [
-                        "kind", upcast "SCALAR"
-                        "name", upcast "Boolean"
-                        "ofType", null]]
-                    "defaultValue", null]]]]]]
+                    box <| Map.ofList<string, obj> [
+                         "name", upcast "include"
+                         "locations", upcast [
+                                 box <| "FIELD";
+                                 upcast "FRAGMENT_SPREAD";
+                                 upcast "INLINE_FRAGMENT";]
+                         "args", upcast [
+                                 box <| Map.ofList<string, obj> [
+                                      "defaultValue", null
+                                      "name", upcast "if"
+                                      "type", upcast Map.ofList<string, obj> [
+                                              "kind", upcast "NON_NULL"
+                                              "name", null
+                                              "ofType", upcast Map.ofList<string, obj> [
+                                                      "kind", upcast "SCALAR"
+                                                      "name", upcast "Boolean"
+                                                      "ofType", null]]];]];
+                    upcast Map.ofList<string, obj> [
+                         "name", upcast "skip"
+                         "locations", upcast [
+                                 box <| "FIELD";
+                                 upcast "FRAGMENT_SPREAD";
+                                 upcast "INLINE_FRAGMENT";]
+                         "args", upcast [
+                                 box <| Map.ofList<string, obj> [
+                                      "defaultValue", null
+                                      "name", upcast "if"
+                                      "type", upcast Map.ofList<string, obj> [
+                                              "kind", upcast "NON_NULL"
+                                              "name", null
+                                              "ofType", upcast Map.ofList<string, obj> [
+                                                      "kind", upcast "SCALAR"
+                                                      "name", upcast "Boolean"
+                                                      "ofType", null]]];]];]]]
+
     equals expected result.Data.Value

--- a/tests/FSharp.Data.GraphQL.Tests/IntrospectionTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/IntrospectionTests.fs
@@ -13,9 +13,9 @@ open FSharp.Data.GraphQL.Execution
 
 [<Fact>]
 let ``Introspection executes an introspection query`` () =
-    let root = objdef "QueryRoot" [
+    let root = Define.Object("QueryRoot", [
         Define.Field("onlyField", String)
-    ]
+    ])
     let schema = Schema(root)
     let (Object raw) = root
     let result = sync <| schema.AsyncExecute(parse introspectionQuery, raw)

--- a/tests/FSharp.Data.GraphQL.Tests/MutationTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/MutationTests.fs
@@ -24,22 +24,22 @@ type Root =
             x.NumberHolder.Number <- num 
             return x.NumberHolder
         }    
-    member x.ChangeFail(num): int = 
+    member x.ChangeFail(num): NumberHolder = 
         failwith "Cannot change number"
-    member x.AsyncChangeFail(num): Async<int> = 
+    member x.AsyncChangeFail(num): Async<NumberHolder> = 
         async { 
             return failwith "Cannot change number"
         }
 
-let NumberHolder = objdef "NumberHolder" [ field "theNumber" Int (fun x -> x.Number)]
+let NumberHolder = Define.Object("NumberHolder", [ Define.Field("theNumber", Int, fun _ x -> x.Number)])
 let schema = Schema(
-    query = objdef "Query" [ field "numberHolder" NumberHolder (fun x -> x.NumberHolder) ],
-    mutation = objdef "Mutation" [
-        fieldA "immediatelyChangeTheNumber" NumberHolder [arg "newNumber" Int] (fun ctx (x:Root) -> x.ChangeImmediatelly(ctx.Arg("newNumber").Value))
-        asyncFieldA "promiseToChangeTheNumber" NumberHolder [arg "newNumber" Int] (fun ctx (x:Root) -> x.AsyncChange(ctx.Arg("newNumber").Value))
-        fieldA "failToChangeTheNumber" NumberHolder [arg "newNumber" Int] (fun ctx (x:Root) -> x.ChangeFail(ctx.Arg("newNumber").Value))
-        asyncFieldA "promiseAndFailToChangeTheNumber" NumberHolder [arg "newNumber" Int] (fun ctx (x:Root) -> x.AsyncChangeFail(ctx.Arg("newNumber").Value))
-    ])
+    query = Define.Object("Query", [ Define.Field("numberHolder", NumberHolder, fun _ x -> x.NumberHolder) ]),
+    mutation = Define.Object("Mutation", [
+        Define.Field("immediatelyChangeTheNumber", NumberHolder, "", [Define.Input("newNumber", Int)], fun ctx (x:Root) -> x.ChangeImmediatelly(ctx.Arg("newNumber").Value))
+        Define.AsyncField("promiseToChangeTheNumber", NumberHolder, "", [Define.Input("newNumber", Int)], fun ctx (x:Root) -> x.AsyncChange(ctx.Arg("newNumber").Value))
+        Define.Field("failToChangeTheNumber", NumberHolder, "", [Define.Input("newNumber", Int)], fun ctx (x:Root) -> x.ChangeFail(ctx.Arg("newNumber").Value))
+        Define.AsyncField("promiseAndFailToChangeTheNumber", NumberHolder, "", [Define.Input("newNumber", Int)], fun ctx (x:Root) -> x.AsyncChangeFail(ctx.Arg("newNumber").Value))
+    ]))
 
 [<Fact>]
 let ``Execute handles mutation execution ordering: evaluates mutations serially`` () =

--- a/tests/FSharp.Data.GraphQL.Tests/ResolveTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/ResolveTests.fs
@@ -15,7 +15,7 @@ type TestData =
     { Test: string }
     member x.TestMethod (a: string) (b: int) = x.Test + a + b.ToString()
     member x.AsyncTestMethod (a: string) (b: int) = async { return x.Test + a + b.ToString() }
-let testSchema testFields = Schema(objdef "Query" testFields)
+let testSchema testFields = Schema(Define.Object("Query", fields = testFields))
 
 [<Fact>]
 let ``Execute uses default resolve to accesses properties`` () =
@@ -24,22 +24,11 @@ let ``Execute uses default resolve to accesses properties`` () =
     let actual = sync <| schema.AsyncExecute(parse "{ test }", { Test = "testValue" })
     noErrors actual
     equals expected actual.Data.Value
-    
-[<Fact>]
-let ``Execute uses default resolve to invoke methods`` () =
-    let schema = testSchema [ Define.Field("testMethod", String, args = [
-        Define.Arg("a", String)
-        Define.Arg("b", Int)
-    ]) ]
-    let expected = Map.ofList [ "testMethod", "testValueArg123" :> obj ]
-    let actual = sync <| schema.AsyncExecute(parse "{ testMethod(a: \"Arg\", b: 123) }", { Test = "testValue" })
-    noErrors actual
-    equals expected actual.Data.Value
-        
+            
 [<Fact>]
 let ``Execute uses provided resolve function to accesses properties`` () =
     let schema = testSchema [ 
-        Define.Field("test", String, args = [Define.Arg("a", String)], resolve = fun ctx d -> d.Test + ctx.Arg("a").Value) ]
+        Define.Field("test", String, "",[Define.Input("a", String)], resolve = fun ctx d -> d.Test + ctx.Arg("a").Value) ]
     let expected = Map.ofList [ "test", "testValueString" :> obj ]
     let actual = sync <| schema.AsyncExecute(parse "{ test(a: \"String\") }", { Test = "testValue" })
     noErrors actual

--- a/tests/FSharp.Data.GraphQL.Tests/SchemaTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/SchemaTests.fs
@@ -25,5 +25,5 @@ let ``Object type should be able to merge fields with matching signatures from d
             Define.Field("name", String)
             Define.Field("speed", Int)
             Define.Field("acceleration", Int)])
-    equals [MovableType; Movable2Type] PersonType.Implements
-    equals [Define.Field("name", String); Define.Field("speed", Int); Define.Field("acceleration", Int)] PersonType.Fields
+    equals [MovableType :> InterfaceDef; upcast Movable2Type] PersonType.Implements
+    equals [Define.Field("name", String) :> FieldDef; upcast Define.Field("speed", Int); upcast Define.Field("acceleration", Int)] ( PersonType :> ObjectDef).Fields

--- a/tests/FSharp.Data.GraphQL.Tests/UnionInterfaceTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/UnionInterfaceTests.fs
@@ -44,10 +44,14 @@ let CatType = Define.Object(
 let PetType = Define.Union(
     name = "Pet",
     options = [ CatType; DogType ],
-    resolveType = fun pet ->
+    resolveType = (fun pet ->
         match pet with
-        | :? Cat -> CatType
-        | :? Dog -> DogType)
+        | Cat _ -> CatType
+        | Dog _ -> DogType),
+    resolveValue = (fun pet ->
+        match pet with
+        | Cat cat -> box cat
+        | Dog dog -> box dog))
 
 let PersonType = Define.Object(
     name = "Person",
@@ -56,7 +60,7 @@ let PersonType = Define.Object(
     fields = [
         Define.Field("name", String)
         Define.Field("pets", ListOf PetType, 
-            resolve = fun _ person -> person.Pets |> List.map (fun pet -> match pet with Dog d -> box d | Cat c -> box c))
+            resolve = fun _ person -> person.Pets)
         Define.Field("friends", ListOf NamedType)
     ])
 


### PR DESCRIPTION
This PR addresses remarks from #25 and introduces a new version of GraphQL type system validated for safety at compile time. Few new changes were introduced:
- Types are now non-nullable by default. To define nullability use `Nullable` type marker. Nullable types are expected to return options as a result.
- There are new functions allowing to use `UnionDef` with F# discriminated unions - use `resolveValue` for intermediate as step for casting discriminated union case to desired type.
- Input objects have new API - this however cannot be check due to problems with parsing complex input arguments. Once parser will fix this issue, we should consider how to map those types into complex objects (with or without using serializers).

I've seen considerable slowdown in execution speed (around 30%) - most probable reason for that is that options are not simply erased in this scenarios, and since lower level API is unaware of existing generic param types the only way to unwrap options is by using reflection which is pretty expensive. This is at least my track.
