### PR TITLE
Named value lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,5 +64,5 @@ Example query:
 
 Missing parts:
 
-- Introspection API
-- Query validation
+- Complex objects as input arguments
+- Friendly query validation messages

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,5 +1,6 @@
 source https://nuget.org/api/v2
 nuget BenchmarkDotNet
+nuget BenchmarkDotNet.Diagnostics.Windows
 nuget FParsec
 nuget Newtonsoft.Json
 nuget Suave

--- a/paket.lock
+++ b/paket.lock
@@ -1,9 +1,13 @@
 NUGET
   remote: https://www.nuget.org/api/v2
   specs:
-    BenchmarkDotNet (0.9.5)
+    BenchmarkDotNet (0.9.6)
+    BenchmarkDotNet.Diagnostics.Windows (0.9.6)
+      BenchmarkDotNet (>= 0.9.6) - framework: >= net40, dnx451
+      Microsoft.Diagnostics.Tracing.TraceEvent (>= 1.0.41) - framework: >= net40, dnx451
     FParsec (1.0.2)
     FSharp.Core (4.0.0.1)
+    Microsoft.Diagnostics.Tracing.TraceEvent (1.0.41) - framework: >= net40, dnx451
     Newtonsoft.Json (8.0.3)
     Suave (1.1.2)
       FSharp.Core (>= 3.1.2.5)
@@ -12,13 +16,13 @@ GROUP Build
 NUGET
   remote: https://www.nuget.org/api/v2
   specs:
-    FAKE (4.25.4)
+    FAKE (4.26.0)
     FParsec (1.0.2)
     FSharp.Compiler.Service (2.0.0.6)
     FSharp.Formatting (2.14.2)
       FSharp.Compiler.Service (2.0.0.6)
-      FSharpVSPowerTools.Core (>= 2.3 < 2.4)
-    FSharpVSPowerTools.Core (2.3)
+      FSharpVSPowerTools.Core (>= 2.3.0 < 2.4.0)
+    FSharpVSPowerTools.Core (2.3.0)
       FSharp.Compiler.Service (>= 2.0.0.3)
     Microsoft.Bcl (1.1.10) - framework: net10, net11, net20, net35, net40, net40
       Microsoft.Bcl.Build (>= 1.0.14)
@@ -26,19 +30,19 @@ NUGET
     Microsoft.Net.Http (2.2.29) - framework: net10, net11, net20, net35, net40, net40
       Microsoft.Bcl (>= 1.1.10)
       Microsoft.Bcl.Build (>= 1.0.14)
-    Octokit (0.19)
+    Octokit (0.19.0)
       Microsoft.Net.Http
-    SourceLink.Fake (1.1)
+    SourceLink.Fake (1.1.0)
 GITHUB
   remote: fsharp/FAKE
   specs:
-    modules/Octokit/Octokit.fsx (3bf706bd6058733a1a034755741076b3953aaf09)
+    modules/Octokit/Octokit.fsx (32e262c11174b196dc8af16a577c8c3aa0ab0b2b)
       Octokit
 GROUP Test
 NUGET
   remote: https://www.nuget.org/api/v2
   specs:
-    FsCheck (2.3)
+    FsCheck (2.4.0)
       FSharp.Core (>= 3.1.2.5)
     FSharp.Core (4.0.0.1)
     xunit (1.9.2)

--- a/samples/server.fsx
+++ b/samples/server.fsx
@@ -182,7 +182,6 @@ let graphiql : WebPart =
             | Some query ->
                 // at the moment parser is not parsing new lines correctly, so we need to get rid of them
                 let q = query.Trim().Replace("\r\n", " ")
-                printfn "Query: %s" q
                 let! result = schema.AsyncExecute(q)   
                 return! http |> Successful.OK (json result)
             | None ->

--- a/src/FSharp.Data.GraphQL/AssemblyInfo.fs
+++ b/src/FSharp.Data.GraphQL/AssemblyInfo.fs
@@ -1,11 +1,14 @@
 ﻿namespace System
 open System.Reflection
+open System.Runtime.CompilerServices
 
 [<assembly: AssemblyTitleAttribute("FSharp.Data.GraphQL")>]
 [<assembly: AssemblyProductAttribute("FSharp.Data.GraphQL")>]
 [<assembly: AssemblyDescriptionAttribute("FSharp implementation of Facebook GraphQL query language")>]
 [<assembly: AssemblyVersionAttribute("0.0.1")>]
 [<assembly: AssemblyFileVersionAttribute("0.0.1")>]
+[<assembly: InternalsVisibleTo("FSharp.Data.GraphQL.Tests")>]
+[<assembly: InternalsVisibleTo("FSharp.Data.GraphQL.Benchmarks")>]
 do ()
 
 module internal AssemblyVersionInformation =

--- a/src/FSharp.Data.GraphQL/Execution.fs
+++ b/src/FSharp.Data.GraphQL/Execution.fs
@@ -4,9 +4,103 @@
 module FSharp.Data.GraphQL.Execution
 
 open System
+open System.Collections.Generic
 open System.Collections.Concurrent
 open FSharp.Data.GraphQL.Ast
 open FSharp.Data.GraphQL.Types
+
+type internal NameValueLookup(kvals: KeyValuePair<string, obj> []) =
+    let setValue key value =
+        let mutable i = 0
+        while i < kvals.Length do
+            if kvals.[i].Key = key then
+                kvals.[i] <- KeyValuePair<string, obj>(key, value) 
+                i <- Int32.MaxValue
+            else i <- i+1
+    let getValue key = (kvals |> Array.find (fun kv -> kv.Key = key)).Value
+    let rec structEq (x: NameValueLookup) (y: NameValueLookup) =
+        if Object.ReferenceEquals(x, y) then true
+        elif Object.ReferenceEquals(y, null) then false
+        elif x.Count <> y.Count then false
+        else
+            x.Buffer
+            |> Array.forall2 (fun (a: KeyValuePair<string, obj>) (b: KeyValuePair<string, obj>) ->
+                if a.Key <> b.Key then false
+                else 
+                    match a.Value, b.Value with
+                    | :? NameValueLookup, :? NameValueLookup as o -> structEq (downcast fst o) (downcast snd o)
+                    | a1, b1 -> a1 = b1) y.Buffer
+    let pad (sb: System.Text.StringBuilder) times = for i in 0..times do sb.Append("\t") |> ignore
+    let rec stringify (sb: System.Text.StringBuilder) deep (o:obj) =
+        match o with
+        | :? NameValueLookup as lookup ->
+            sb.Append("{ ") |> ignore
+            lookup.Buffer
+            |> Array.iter (fun kv -> 
+                sb.Append(kv.Key).Append(": ") |> ignore
+                stringify sb (deep+1) kv.Value
+                sb.Append(",\r\n") |> ignore
+                pad sb deep)
+            sb.Remove(sb.Length - 4 - deep, 4 + deep).Append(" }") |> ignore
+        | :? string as s ->
+            sb.Append("\"").Append(s).Append("\"") |> ignore
+        | :? System.Collections.IEnumerable as s -> 
+            sb.Append("[") |> ignore
+            for i in s do 
+                stringify sb (deep+1) i
+                sb.Append(", ") |> ignore
+            sb.Append("]") |> ignore
+        | other -> 
+            if other <> null 
+            then sb.Append(other.ToString()) |> ignore
+            else sb.Append("null") |> ignore
+        ()
+    static member ofList (l: (string * obj) list) = NameValueLookup(l)
+    member private x.Buffer : KeyValuePair<string, obj> [] = kvals
+    member x.Count = kvals.Length
+    member x.Update key value = setValue key value
+    override x.Equals(other) = 
+        match other with
+        | :? NameValueLookup as lookup -> structEq x lookup
+        | _ -> false
+    override x.ToString() = 
+        let sb =Text.StringBuilder()
+        stringify sb 1 x
+        sb.ToString()
+    interface IEquatable<NameValueLookup> with
+        member x.Equals(other) = structEq x other
+    interface System.Collections.IEnumerable with
+        member x.GetEnumerator() = (kvals :> System.Collections.IEnumerable).GetEnumerator()
+    interface IEnumerable<KeyValuePair<string, obj>> with
+        member x.GetEnumerator() = (kvals :> IEnumerable<KeyValuePair<string, obj>>).GetEnumerator()
+    interface IDictionary<string, obj> with
+        member x.Add(key, value) = raise (NotSupportedException "NameValueLookup doesn't allow to add/remove entries")
+        member x.Add(item) = raise (NotSupportedException "NameValueLookup doesn't allow to add/remove entries")
+        member x.Clear() = raise (NotSupportedException "NameValueLookup doesn't allow to add/remove entries")
+        member x.Contains(item) = kvals |> Array.exists ((=) item)
+        member x.ContainsKey(key) = kvals |> Array.exists (fun kv -> kv.Key = key)
+        member x.CopyTo(array, arrayIndex) = kvals.CopyTo(array, arrayIndex)
+        member x.Count = x.Count
+        member x.IsReadOnly = true
+        member x.Item
+            with get (key) = getValue key
+            and set (key) v = setValue key v
+        member x.Keys = upcast (kvals |> Array.map (fun kv -> kv.Key))
+        member x.Values = upcast (kvals |> Array.map (fun kv -> kv.Value))
+        member x.Remove(_:string) = 
+            raise (NotSupportedException "NameValueLookup doesn't allow to add/remove entries")
+            false
+        member x.Remove(_:KeyValuePair<string,obj>) = 
+            raise (NotSupportedException "NameValueLookup doesn't allow to add/remove entries")
+            false
+        member x.TryGetValue(key, value) = 
+            match kvals |> Array.tryFind (fun kv -> kv.Key = key) with
+            | Some kv -> value <- kv.Value; true
+            | None -> value <- null; false
+    new(t: (string * obj) list) = 
+        NameValueLookup(t |> List.map (fun (k, v) -> KeyValuePair<string,obj>(k, v)) |> List.toArray)
+    new(t: string []) = 
+        NameValueLookup(Array.map (fun k -> KeyValuePair<string,obj>(k, null)) t)
 
 let private option = function
     | null -> None
@@ -85,7 +179,7 @@ let private getArgumentValues (argDefs: InputFieldDef list) (args: Argument list
 /// non-empty array if an error occurred.
 type ExecutionResult =
     {
-        Data: Map<string,obj> option
+        Data: IDictionary<string, obj> option
         Errors: GraphQLError [] option
     }
 
@@ -157,7 +251,8 @@ let private doesFragmentTypeApply ctx fragment (objectType: ObjectDef) =
 // 6.5 Evaluating selection sets
 let rec private collectFields ctx typedef selectionSet visitedFragments =
     selectionSet
-    |> List.fold (collectField ctx typedef visitedFragments) Map.empty 
+    |> List.fold (collectField ctx typedef visitedFragments) [] 
+    |> List.rev
 
 and collectField ctx (typedef: ObjectDef) visitedFragments groupedFields (selection: Selection) =
     if List.exists (shouldSkip ctx) selection.Directives
@@ -166,9 +261,9 @@ and collectField ctx (typedef: ObjectDef) visitedFragments groupedFields (select
         match selection with
         | Field field ->
             let name = field.AliasOrName
-            match Map.tryFind name groupedFields with
-            | Some groupForResponseKey -> Map.add name (field::groupForResponseKey) groupedFields
-            | None -> Map.add name [field] groupedFields
+            match List.tryFind (fun (n, _) -> n = name) groupedFields with
+            | Some (_, groupForResponseKey) -> (name, (field::groupForResponseKey))::groupedFields
+            | None -> (name, [field])::groupedFields
         | FragmentSpread spread ->
             let fragmentSpreadName = spread.Name
             if List.exists (fun fragmentName -> fragmentName = fragmentSpreadName) !visitedFragments 
@@ -197,11 +292,11 @@ and collectFragment ctx typedef visitedFragments groupedFields fragment =
         let fragmentSelectionSet = fragment.SelectionSet
         let fragmentGroupedFieldSet = collectFields ctx typedef fragmentSelectionSet visitedFragments
         fragmentGroupedFieldSet
-        |> Map.fold (fun acc responseKey fragmentGroup -> 
-            match Map.tryFind responseKey acc with
-            | Some groupForResponseKey -> Map.add responseKey (fragmentGroup @ groupForResponseKey) acc
-            | None -> Map.add responseKey (fragmentGroup) acc
-        ) groupedFields    
+        |> List.fold (fun acc (responseKey, fragmentGroup) -> 
+            match List.tryFind (fun (n, _) -> n = responseKey) acc with
+            | Some (_, groupForResponseKey) -> (responseKey, (fragmentGroup @ groupForResponseKey))::acc
+            | None -> (responseKey, fragmentGroup)::acc
+        ) groupedFields
     
 open FSharp.Data.GraphQL.Introspection
 
@@ -229,10 +324,10 @@ let private resolveUnionType ctx (uniondef: UnionDef) objectValue =
 // ENTRY: 6.6.1 Field entries
 
 /// Complete an ObjectType value by executing all sub-selections
-let rec private completeObjectValue ctx objectType (fields: Field list) (result: obj) = async {
+let rec private completeObjectValue ctx objectType (fields: Field list) (result: obj) : Async<NameValueLookup> = async {
     let groupedFieldSet = 
         fields
-        |> List.fold (fun subFields field -> collectFields ctx objectType field.SelectionSet (ref [])) Map.empty
+        |> List.fold (fun subFields field -> collectFields ctx objectType field.SelectionSet (ref [])) []
     let! res = executeFields ctx objectType result groupedFieldSet 
     return res }
 
@@ -319,24 +414,34 @@ and private getFieldEntry ctx typedef value (fields: Field list) : Async<obj> = 
             ctx.Errors.Add error
             return null }
 
-and private executeFields ctx typedef value (groupedFieldSet): Async<Map<string, obj>> = async {
+and private executeFields ctx typedef value groupedFieldSet = async {
+    let result =
+        groupedFieldSet
+        |> List.toSeq
+        |> Seq.map fst
+        |> Seq.toArray
+        |> NameValueLookup
     let! whenAll = 
         groupedFieldSet
-        |> Map.toSeq
+        |> List.toSeq
         |> Seq.map (fun (responseKey, fields) -> async { 
             let! res = getFieldEntry ctx typedef value fields
-            return responseKey, res })
+            do result.Update responseKey res })
         |> Async.Parallel
-    return whenAll
-        |> Array.fold (fun acc (responseKey, res) -> Map.add responseKey res acc) Map.empty }
+    return result }
 
 // EXIT
 //---------------------------
 
-and private executeFieldsSync ctx typedef value (groupedFieldSet): Async<Map<string, obj>> = async {
-    let result = 
+and private executeFieldsSync ctx typedef value (groupedFieldSet: (string * Field list) list) = async {
+    let result =
         groupedFieldSet
-        |> Map.fold (fun acc responseKey fields -> Map.add responseKey ((getFieldEntry ctx typedef value fields) |> Async.RunSynchronously) acc) Map.empty
+        |> List.toSeq
+        |> Seq.map fst
+        |> Seq.toArray
+        |> NameValueLookup
+    groupedFieldSet
+    |> List.iter (fun (responseKey, fields) -> result.Update responseKey ((getFieldEntry ctx typedef value fields) |> Async.RunSynchronously))
     return result }
 
 let private evaluate (schema: #ISchema) doc operation variables root errors = async {
@@ -371,7 +476,7 @@ type FSharp.Data.GraphQL.Schema with
             try
                 let errors = ConcurrentBag()
                 let! result = execute schema ast operationName variables data errors
-                return { Data = Some result; Errors = if errors.IsEmpty then None else Some (errors.ToArray()) }
+                return { Data = Some (upcast result); Errors = if errors.IsEmpty then None else Some (errors.ToArray()) }
             with 
             | ex -> 
                 let msg = ex.ToString()
@@ -383,7 +488,7 @@ type FSharp.Data.GraphQL.Schema with
                 let ast = parse queryOrMutation
                 let errors = ConcurrentBag()
                 let! result = execute schema ast operationName variables data errors
-                return { Data = Some result; Errors = if errors.IsEmpty then None else Some (errors.ToArray()) }
+                return { Data = Some (upcast result); Errors = if errors.IsEmpty then None else Some (errors.ToArray()) }
             with 
             | ex -> 
                 let msg = ex.ToString()

--- a/tests/FSharp.Data.GraphQL.Benchmarks/FSharp.Data.GraphQL.Benchmarks.fsproj
+++ b/tests/FSharp.Data.GraphQL.Benchmarks/FSharp.Data.GraphQL.Benchmarks.fsproj
@@ -38,32 +38,6 @@
     <DocumentationFile>bin\Release\FSharp.Data.GraphQL.Benchmarks.XML</DocumentationFile>
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Microsoft.Build" />
-    <Reference Include="mscorlib" />
-    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Numerics" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="AssemblyInfo.fs" />
-    <Compile Include="Prolog.fs" />
-    <Compile Include="ParsingBenchmark.fs" />
-    <Compile Include="ExecutionBenchmark.fs" />
-    <Compile Include="Program.fs" />
-    <None Include="App.config" />
-    <None Include="paket.references" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\FSharp.Data.GraphQL\FSharp.Data.GraphQL.fsproj">
-      <Name>FSharp.Data.GraphQL</Name>
-      <Project>{474179d3-0090-49e9-88f8-2971c0966077}</Project>
-      <Private>True</Private>
-    </ProjectReference>
-  </ItemGroup>
   <PropertyGroup>
     <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
   </PropertyGroup>
@@ -95,12 +69,6 @@
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>
-        <Reference Include="Microsoft.Build.Framework">
-          <Paket>True</Paket>
-        </Reference>
-        <Reference Include="Microsoft.Build.Utilities.v4.0">
-          <Paket>True</Paket>
-        </Reference>
         <Reference Include="Microsoft.CSharp">
           <Paket>True</Paket>
         </Reference>
@@ -114,12 +82,6 @@
         <Reference Include="BenchmarkDotNet">
           <HintPath>..\..\packages\BenchmarkDotNet\lib\net45\BenchmarkDotNet.dll</HintPath>
           <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-        <Reference Include="Microsoft.Build.Framework">
-          <Paket>True</Paket>
-        </Reference>
-        <Reference Include="Microsoft.Build.Utilities.v12.0">
           <Paket>True</Paket>
         </Reference>
         <Reference Include="Microsoft.CSharp">
@@ -137,12 +99,6 @@
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>
-        <Reference Include="Microsoft.Build.Framework">
-          <Paket>True</Paket>
-        </Reference>
-        <Reference Include="Microsoft.Build.Utilities.Core">
-          <Paket>True</Paket>
-        </Reference>
         <Reference Include="Microsoft.CSharp">
           <Paket>True</Paket>
         </Reference>
@@ -152,4 +108,61 @@
       </ItemGroup>
     </When>
   </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1')">
+      <ItemGroup>
+        <Reference Include="BenchmarkDotNet.Diagnostics.Windows">
+          <HintPath>..\..\packages\BenchmarkDotNet.Diagnostics.Windows\lib\net40\BenchmarkDotNet.Diagnostics.Windows.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Microsoft.CSharp">
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1')">
+      <PropertyGroup>
+        <__paket__Microsoft_Diagnostics_Tracing_TraceEvent_targets>Microsoft.Diagnostics.Tracing.TraceEvent</__paket__Microsoft_Diagnostics_Tracing_TraceEvent_targets>
+      </PropertyGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1')">
+      <ItemGroup>
+        <Reference Include="Microsoft.Diagnostics.Tracing.TraceEvent">
+          <HintPath>..\..\packages\Microsoft.Diagnostics.Tracing.TraceEvent\lib\net40\Microsoft.Diagnostics.Tracing.TraceEvent.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="..\..\packages\Microsoft.Diagnostics.Tracing.TraceEvent\build\$(__paket__Microsoft_Diagnostics_Tracing_TraceEvent_targets).targets" Condition="Exists('..\..\packages\Microsoft.Diagnostics.Tracing.TraceEvent\build\$(__paket__Microsoft_Diagnostics_Tracing_TraceEvent_targets).targets')" Label="Paket" />
+  <ItemGroup>
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="Prolog.fs" />
+    <Compile Include="ParsingBenchmark.fs" />
+    <Compile Include="ExecutionBenchmark.fs" />
+    <Compile Include="Program.fs" />
+    <None Include="App.config" />
+    <None Include="paket.references" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Build" />
+    <Reference Include="mscorlib" />
+    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Numerics" />
+    <ProjectReference Include="..\..\src\FSharp.Data.GraphQL\FSharp.Data.GraphQL.fsproj">
+      <Name>FSharp.Data.GraphQL</Name>
+      <Project>{474179d3-0090-49e9-88f8-2971c0966077}</Project>
+      <Private>True</Private>
+    </ProjectReference>
+  </ItemGroup>
 </Project>

--- a/tests/FSharp.Data.GraphQL.Benchmarks/Prolog.fs
+++ b/tests/FSharp.Data.GraphQL.Benchmarks/Prolog.fs
@@ -7,9 +7,11 @@ module FSharp.Data.GraphQL.BenchmarkProlog
 open BenchmarkDotNet.Configs
 open BenchmarkDotNet.Columns
 open BenchmarkDotNet.Exporters
+open BenchmarkDotNet.Diagnostics.Windows
 
 type GraphQLBenchConfig() as this= 
     inherit ManualConfig()
     do
         this.Add(StatisticColumn.Mean, StatisticColumn.Min, StatisticColumn.Max, StatisticColumn.OperationsPerSecond)
         this.Add(MarkdownExporter.GitHub)
+        this.Add(MemoryDiagnoser())

--- a/tests/FSharp.Data.GraphQL.Benchmarks/paket.references
+++ b/tests/FSharp.Data.GraphQL.Benchmarks/paket.references
@@ -1,1 +1,2 @@
 BenchmarkDotNet
+BenchmarkDotNet.Diagnostics.Windows

--- a/tests/FSharp.Data.GraphQL.Tests/AbstractionTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/AbstractionTests.fs
@@ -72,16 +72,16 @@ let ``Execute handles execution of abstract types: isTypeOf is used to resolve r
       }
     }"""
     let result = sync <| schema.AsyncExecute(parse query)
-    let expected: Map<string, obj> = Map.ofList [
+    let expected = NameValueLookup.ofList [
         "pets", upcast [
-            Map.ofList [
+            NameValueLookup.ofList [
                 "name", "Odie" :> obj
                 "woofs", upcast true ] :> obj
-            upcast Map.ofList [
+            upcast NameValueLookup.ofList [
                 "name", "Garfield" :> obj
                 "meows", upcast false]]]
     noErrors result
-    equals expected result.Data.Value
+    result.Data.Value |> equals (upcast expected)
     
 [<Fact>]
 let ``Execute handles execution of abstract types: isTypeOf is used to resolve runtime type for Union`` () = 
@@ -117,13 +117,13 @@ let ``Execute handles execution of abstract types: isTypeOf is used to resolve r
       }
     }"""
     let result = sync <| schema.AsyncExecute(parse query)
-    let expected: Map<string, obj> = Map.ofList [
+    let expected = NameValueLookup.ofList [
         "pets", upcast [
-            Map.ofList [
+            NameValueLookup.ofList [
                 "name", "Odie" :> obj
                 "woofs", upcast true ] :> obj
-            upcast Map.ofList [
+            upcast NameValueLookup.ofList [
                 "name", "Garfield" :> obj
                 "meows", upcast false]]]
     noErrors result
-    equals expected result.Data.Value
+    result.Data.Value |> equals (upcast expected)

--- a/tests/FSharp.Data.GraphQL.Tests/DirectivesTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/DirectivesTests.fs
@@ -22,29 +22,29 @@ let schema = Schema(Define.Object("TestType", [
 let private execAndCompare query expected =
     let actual = sync <| schema.AsyncExecute(parse query, data)
     noErrors actual
-    equals expected actual.Data.Value
+    actual.Data.Value |> equals (upcast expected)
     
 [<Fact>]
 let ``Execute works without directives``() = 
-    execAndCompare "{ a, b }" (Map.ofList [("a", "a" :> obj); ("b", upcast "b")])
+    execAndCompare "{ a, b }" (NameValueLookup.ofList [("a", "a" :> obj); ("b", upcast "b")])
     
 // SCALARS
 
 [<Fact>]
 let ``Execute with include works on scalars: if true, includes scalar``() = 
-    execAndCompare "{ a, b @include(if: true) }" (Map.ofList [("a", "a" :> obj); ("b", upcast "b")])
+    execAndCompare "{ a, b @include(if: true) }" (NameValueLookup.ofList [("a", "a" :> obj); ("b", upcast "b")])
 
 [<Fact>]
 let ``Execute with include works on scalars: if false, excludes scalar``() = 
-    execAndCompare "{ a, b @include(if: false) }" (Map.ofList [("a", "a" :> obj)])
+    execAndCompare "{ a, b @include(if: false) }" (NameValueLookup.ofList [("a", "a" :> obj)])
     
 [<Fact>]
 let ``Execute with skip works on scalars: if false, includes scalar``() = 
-    execAndCompare "{ a, b @skip(if: false) }" (Map.ofList [("a", "a" :> obj); ("b", upcast "b")])
+    execAndCompare "{ a, b @skip(if: false) }" (NameValueLookup.ofList [("a", "a" :> obj); ("b", upcast "b")])
     
 [<Fact>]
 let ``Execute with skip works on scalars: if true, excludes scalar``() = 
-    execAndCompare "{ a, b @skip(if: true) }" (Map.ofList [("a", "a" :> obj)])
+    execAndCompare "{ a, b @skip(if: true) }" (NameValueLookup.ofList [("a", "a" :> obj)])
     
 // FRAGMENT SPREADS
 
@@ -58,7 +58,7 @@ let ``Execute with include works on fragment spreads: if true, includes fragment
         fragment Frag on TestType {
           b
         }""" 
-        (Map.ofList [("a", "a" :> obj); ("b", upcast "b")])
+        (NameValueLookup.ofList [("a", "a" :> obj); ("b", upcast "b")])
 
 [<Fact>]
 let ``Execute with include works on fragment spreads: if false, excludes fragment spread``() = 
@@ -70,7 +70,7 @@ let ``Execute with include works on fragment spreads: if false, excludes fragmen
         fragment Frag on TestType {
           b
         }""" 
-        (Map.ofList [("a", "a" :> obj)])
+        (NameValueLookup.ofList [("a", "a" :> obj)])
     
 [<Fact>]
 let ``Execute with skip works on fragment spreads: if false, includes fragment spread``() = 
@@ -82,7 +82,7 @@ let ``Execute with skip works on fragment spreads: if false, includes fragment s
         fragment Frag on TestType {
           b
         }""" 
-        (Map.ofList [("a", "a" :> obj); ("b", upcast "b")])
+        (NameValueLookup.ofList [("a", "a" :> obj); ("b", upcast "b")])
     
 [<Fact>]
 let ``Execute with skip works on fragment spreads: if true, excludes fragment spread``() = 
@@ -94,7 +94,7 @@ let ``Execute with skip works on fragment spreads: if true, excludes fragment sp
         fragment Frag on TestType {
           b
         }""" 
-        (Map.ofList [("a", "a" :> obj)])
+        (NameValueLookup.ofList [("a", "a" :> obj)])
     
 // INLINE FRAGMENTS
 
@@ -110,7 +110,7 @@ let ``Execute with include works on inline fragments: if true, includes inline f
         fragment Frag on TestType {
           b
         }""" 
-        (Map.ofList [("a", "a" :> obj); ("b", upcast "b")])
+        (NameValueLookup.ofList [("a", "a" :> obj); ("b", upcast "b")])
 
 [<Fact>]
 let ``Execute with include works on inline fragments: if false, excludes inline fragment``() = 
@@ -124,7 +124,7 @@ let ``Execute with include works on inline fragments: if false, excludes inline 
         fragment Frag on TestType {
           b
         }""" 
-        (Map.ofList [("a", "a" :> obj)])
+        (NameValueLookup.ofList [("a", "a" :> obj)])
     
 [<Fact>]
 let ``Execute with skip works on inline fragments: if false, includes inline fragment``() = 
@@ -138,7 +138,7 @@ let ``Execute with skip works on inline fragments: if false, includes inline fra
         fragment Frag on TestType {
           b
         }""" 
-        (Map.ofList [("a", "a" :> obj); ("b", upcast "b")])
+        (NameValueLookup.ofList [("a", "a" :> obj); ("b", upcast "b")])
     
 [<Fact>]
 let ``Execute with skip works on inline fragments: if true, excludes inline fragment``() = 
@@ -152,5 +152,5 @@ let ``Execute with skip works on inline fragments: if true, excludes inline frag
         fragment Frag on TestType {
           b
         }""" 
-        (Map.ofList [("a", "a" :> obj)])
+        (NameValueLookup.ofList [("a", "a" :> obj)])
     

--- a/tests/FSharp.Data.GraphQL.Tests/IntrospectionTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/IntrospectionTests.fs
@@ -20,84 +20,84 @@ let ``Introspection executes an introspection query`` () =
     let (Object raw) = root
     let result = sync <| schema.AsyncExecute(parse Introspection.introspectionQuery, raw)
     noErrors result
-    let expected: Map<string,obj> = Map.ofList<string, obj> [
-        "__schema", upcast Map.ofList<string, obj> [
+    let expected = NameValueLookup.ofList [
+        "__schema", upcast NameValueLookup.ofList [
             "mutationType", null
             "subscriptionType", null
-            "queryType", upcast Map.ofList<string, obj> [
+            "queryType", upcast NameValueLookup.ofList [
                     "name", upcast "QueryRoot"]
             "types", upcast [
-                    box <| Map.ofList<string, obj> [
+                    box <| NameValueLookup.ofList [
                          "kind", upcast "OBJECT"
                          "name", upcast "QueryRoot"
                          "inputFields", null
                          "interfaces", upcast []
                          "enumValues", null
                          "possibleTypes", null];
-                    upcast Map.ofList<string, obj> [
+                    upcast NameValueLookup.ofList [
                          "kind", upcast "OBJECT"
                          "name", upcast "__Schema"
                          "fields", upcast [
-                                 box <| Map.ofList<string, obj> [
+                                 box <| NameValueLookup.ofList [
                                       "name", upcast "types"
                                       "args", upcast []
-                                      "type", upcast Map.ofList<string, obj> [
+                                      "type", upcast NameValueLookup.ofList [
                                               "kind", upcast "NON_NULL"
                                               "name", null
-                                              "ofType", upcast Map.ofList<string, obj> [
+                                              "ofType", upcast NameValueLookup.ofList [
                                                       "kind", upcast "LIST"
                                                       "name", null
-                                                      "ofType", upcast Map.ofList<string, obj> [
+                                                      "ofType", upcast NameValueLookup.ofList [
                                                               "kind", upcast "NON_NULL"
                                                               "name", null
-                                                              "ofType", upcast Map.ofList<string, obj> [
+                                                              "ofType", upcast NameValueLookup.ofList [
                                                                       "kind", upcast "OBJECT"
                                                                       "name", upcast "__Type"]]]]
                                       "isDeprecated", upcast false
                                       "deprecationReason", null];
-                                 upcast Map.ofList<string, obj> [
+                                 upcast NameValueLookup.ofList [
                                       "name", upcast "queryType"
                                       "args", upcast []
-                                      "type", upcast Map.ofList<string, obj> [
+                                      "type", upcast NameValueLookup.ofList [
                                               "kind", upcast "NON_NULL"
                                               "name", null
-                                              "ofType", upcast Map.ofList<string, obj> [
+                                              "ofType", upcast NameValueLookup.ofList [
                                                       "kind", upcast "OBJECT"
                                                       "name", upcast "__Type"
                                                       "ofType", null]]
                                       "isDeprecated", upcast false
                                       "deprecationReason", null];
-                                 upcast Map.ofList<string, obj> [
+                                 upcast NameValueLookup.ofList [
                                       "name", upcast "mutationType"
                                       "args", upcast []
-                                      "type", upcast Map.ofList<string, obj> [
+                                      "type", upcast NameValueLookup.ofList [
                                               "kind", upcast "OBJECT"
                                               "name", upcast "__Type"
                                               "ofType", null]
                                       "isDeprecated", upcast false
                                       "deprecationReason", null];
-                                 upcast Map.ofList<string, obj> [
+                                 upcast NameValueLookup.ofList [
                                       "name", upcast "subscriptionType"
                                       "args", upcast []
-                                      "type", upcast Map.ofList<string, obj> [
+                                      "type", upcast NameValueLookup.ofList [
                                               "kind", upcast "OBJECT"
                                               "name", upcast "__Type"
                                               "ofType", null]
                                       "isDeprecated", upcast false
                                       "deprecationReason", null];
-                                 upcast Map.ofList<string, obj> [
+                                 upcast NameValueLookup.ofList [
                                       "name", upcast "directives"
                                       "args", upcast []
-                                      "type", upcast Map.ofList<string, obj> [
+                                      "type", upcast NameValueLookup.ofList [
                                               "kind", upcast "NON_NULL"
                                               "name", null
-                                              "ofType", upcast Map.ofList<string, obj> [
+                                              "ofType", upcast NameValueLookup.ofList [
                                                       "kind", upcast "LIST"
                                                       "name", null
-                                                      "ofType", upcast Map.ofList<string, obj> [
+                                                      "ofType", upcast NameValueLookup.ofList [
                                                               "kind", upcast "NON_NULL"
                                                               "name", null
-                                                              "ofType", upcast Map.ofList<string, obj> [
+                                                              "ofType", upcast NameValueLookup.ofList [
                                                                       "kind", upcast "OBJECT"
                                                                       "name", upcast "__Directive"]]]]
                                       "isDeprecated", upcast false
@@ -106,133 +106,133 @@ let ``Introspection executes an introspection query`` () =
                          "interfaces", upcast []
                          "enumValues", null
                          "possibleTypes", null];
-                    upcast Map.ofList<string, obj> [
+                    upcast NameValueLookup.ofList [
                          "kind", upcast "OBJECT"
                          "name", upcast "__Type"
                          "fields", upcast [
-                                 box <| Map.ofList<string, obj> [
+                                 box <| NameValueLookup.ofList [
                                       "name", upcast "kind"
                                       "args", upcast []
-                                      "type", upcast Map.ofList<string, obj> [
+                                      "type", upcast NameValueLookup.ofList [
                                               "kind", upcast "NON_NULL"
                                               "name", null
-                                              "ofType", upcast Map.ofList<string, obj> [
+                                              "ofType", upcast NameValueLookup.ofList [
                                                       "kind", upcast "ENUM"
                                                       "name", upcast "__TypeKind"
                                                       "ofType", null]]
                                       "isDeprecated", upcast false
                                       "deprecationReason", null];
-                                 upcast Map.ofList<string, obj> [
+                                 upcast NameValueLookup.ofList [
                                       "name", upcast "name"
                                       "args", upcast []
-                                      "type", upcast Map.ofList<string, obj> [
+                                      "type", upcast NameValueLookup.ofList [
                                               "kind", upcast "SCALAR"
                                               "name", upcast "String"
                                               "ofType", null]
                                       "isDeprecated", upcast false
                                       "deprecationReason", null];
-                                 upcast Map.ofList<string, obj> [
+                                 upcast NameValueLookup.ofList [
                                       "name", upcast "description"
                                       "args", upcast []
-                                      "type", upcast Map.ofList<string, obj> [
+                                      "type", upcast NameValueLookup.ofList [
                                               "kind", upcast "SCALAR"
                                               "name", upcast "String"
                                               "ofType", null]
                                       "isDeprecated", upcast false
                                       "deprecationReason", null];
-                                 upcast Map.ofList<string, obj> [
+                                 upcast NameValueLookup.ofList [
                                       "name", upcast "fields"
                                       "args", upcast [
-                                              box <| Map.ofList<string, obj> [
+                                              box <| NameValueLookup.ofList [
                                                    "name", upcast "includeDeprecated"
-                                                   "type", upcast Map.ofList<string, obj> [
+                                                   "type", upcast NameValueLookup.ofList [
                                                            "kind", upcast "SCALAR"
                                                            "name", upcast "Boolean"
                                                            "ofType", null]
                                                    "defaultValue", upcast "false"];]
-                                      "type", upcast Map.ofList<string, obj> [
+                                      "type", upcast NameValueLookup.ofList [
                                               "kind", upcast "LIST"
                                               "name", null
-                                              "ofType", upcast Map.ofList<string, obj> [
+                                              "ofType", upcast NameValueLookup.ofList [
                                                       "kind", upcast "NON_NULL"
                                                       "name", null
-                                                      "ofType", upcast Map.ofList<string, obj> [
+                                                      "ofType", upcast NameValueLookup.ofList [
                                                               "kind", upcast "OBJECT"
                                                               "name", upcast "__Field"
                                                               "ofType", null]]]
                                       "isDeprecated", upcast false
                                       "deprecationReason", null];
-                                 upcast Map.ofList<string, obj> [
+                                 upcast NameValueLookup.ofList [
                                       "name", upcast "interfaces"
                                       "args", upcast []
-                                      "type", upcast Map.ofList<string, obj> [
+                                      "type", upcast NameValueLookup.ofList [
                                               "kind", upcast "LIST"
                                               "name", null
-                                              "ofType", upcast Map.ofList<string, obj> [
+                                              "ofType", upcast NameValueLookup.ofList [
                                                       "kind", upcast "NON_NULL"
                                                       "name", null
-                                                      "ofType", upcast Map.ofList<string, obj> [
+                                                      "ofType", upcast NameValueLookup.ofList [
                                                               "kind", upcast "OBJECT"
                                                               "name", upcast "__Type"
                                                               "ofType", null]]]
                                       "isDeprecated", upcast false
                                       "deprecationReason", null];
-                                 upcast Map.ofList<string, obj> [
+                                 upcast NameValueLookup.ofList [
                                       "name", upcast "possibleTypes"
                                       "args", upcast []
-                                      "type", upcast Map.ofList<string, obj> [
+                                      "type", upcast NameValueLookup.ofList [
                                               "kind", upcast "LIST"
                                               "name", null
-                                              "ofType", upcast Map.ofList<string, obj> [
+                                              "ofType", upcast NameValueLookup.ofList [
                                                       "kind", upcast "NON_NULL"
                                                       "name", null
-                                                      "ofType", upcast Map.ofList<string, obj> [
+                                                      "ofType", upcast NameValueLookup.ofList [
                                                               "kind", upcast "OBJECT"
                                                               "name", upcast "__Type"
                                                               "ofType", null]]]
                                       "isDeprecated", upcast false
                                       "deprecationReason", null];
-                                 upcast Map.ofList<string, obj> [
+                                 upcast NameValueLookup.ofList [
                                       "name", upcast "enumValues"
                                       "args", upcast [
-                                              box <| Map.ofList<string, obj> [
+                                              box <| NameValueLookup.ofList [
                                                    "name", upcast "includeDeprecated"
-                                                   "type", upcast Map.ofList<string, obj> [
+                                                   "type", upcast NameValueLookup.ofList [
                                                            "kind", upcast "SCALAR"
                                                            "name", upcast "Boolean"
                                                            "ofType", null]
                                                    "defaultValue", upcast "false"];]
-                                      "type", upcast Map.ofList<string, obj> [
+                                      "type", upcast NameValueLookup.ofList [
                                               "kind", upcast "LIST"
                                               "name", null
-                                              "ofType", upcast Map.ofList<string, obj> [
+                                              "ofType", upcast NameValueLookup.ofList [
                                                       "kind", upcast "NON_NULL"
                                                       "name", null
-                                                      "ofType", upcast Map.ofList<string, obj> [
+                                                      "ofType", upcast NameValueLookup.ofList [
                                                               "kind", upcast "OBJECT"
                                                               "name", upcast "__EnumValue"
                                                               "ofType", null]]]
                                       "isDeprecated", upcast false
                                       "deprecationReason", null];
-                                 upcast Map.ofList<string, obj> [
+                                 upcast NameValueLookup.ofList [
                                       "name", upcast "inputFields"
                                       "args", upcast []
-                                      "type", upcast Map.ofList<string, obj> [
+                                      "type", upcast NameValueLookup.ofList [
                                               "kind", upcast "LIST"
                                               "name", null
-                                              "ofType", upcast Map.ofList<string, obj> [
+                                              "ofType", upcast NameValueLookup.ofList [
                                                       "kind", upcast "NON_NULL"
                                                       "name", null
-                                                      "ofType", upcast Map.ofList<string, obj> [
+                                                      "ofType", upcast NameValueLookup.ofList [
                                                               "kind", upcast "OBJECT"
                                                               "name", upcast "__InputValue"
                                                               "ofType", null]]]
                                       "isDeprecated", upcast false
                                       "deprecationReason", null];
-                                 upcast Map.ofList<string, obj> [
+                                 upcast NameValueLookup.ofList [
                                       "name", upcast "ofType"
                                       "args", upcast []
-                                      "type", upcast Map.ofList<string, obj> [
+                                      "type", upcast NameValueLookup.ofList [
                                               "kind", upcast "OBJECT"
                                               "name", upcast "__Type"
                                               "ofType", null]
@@ -242,47 +242,47 @@ let ``Introspection executes an introspection query`` () =
                          "interfaces", upcast []
                          "enumValues", null
                          "possibleTypes", null];
-                    upcast Map.ofList<string, obj> [
+                    upcast NameValueLookup.ofList [
                          "kind", upcast "ENUM"
                          "name", upcast "__TypeKind"
                          "fields", null
                          "inputFields", null
                          "interfaces", null
                          "enumValues", upcast [
-                                 box <| Map.ofList<string, obj> [
+                                 box <| NameValueLookup.ofList [
                                       "name", upcast "SCALAR"
                                       "isDeprecated", upcast false
                                       "deprecationReason", null];
-                                 upcast Map.ofList<string, obj> [
+                                 upcast NameValueLookup.ofList [
                                       "name", upcast "OBJECT"
                                       "isDeprecated", upcast false
                                       "deprecationReason", null];
-                                 upcast Map.ofList<string, obj> [
+                                 upcast NameValueLookup.ofList [
                                       "name", upcast "INTERFACE"
                                       "isDeprecated", upcast false
                                       "deprecationReason", null];
-                                 upcast Map.ofList<string, obj> [
+                                 upcast NameValueLookup.ofList [
                                       "name", upcast "UNION"
                                       "isDeprecated", upcast false
                                       "deprecationReason", null];
-                                 upcast Map.ofList<string, obj> [
+                                 upcast NameValueLookup.ofList [
                                       "name", upcast "ENUM"
                                       "isDeprecated", upcast false
                                       "deprecationReason", null];
-                                 upcast Map.ofList<string, obj> [
+                                 upcast NameValueLookup.ofList [
                                       "name", upcast "INPUT_OBJECT"
                                       "isDeprecated", upcast false
                                       "deprecationReason", null];
-                                 upcast Map.ofList<string, obj> [
+                                 upcast NameValueLookup.ofList [
                                       "name", upcast "LIST"
                                       "isDeprecated", upcast false
                                       "deprecationReason", null];
-                                 upcast Map.ofList<string, obj> [
+                                 upcast NameValueLookup.ofList [
                                       "name", upcast "NON_NULL"
                                       "isDeprecated", upcast false
                                       "deprecationReason", null];]
                          "possibleTypes", null];
-                    upcast Map.ofList<string, obj> [
+                    upcast NameValueLookup.ofList [
                          "kind", upcast "SCALAR"
                          "name", upcast "String"
                          "fields", null
@@ -290,7 +290,7 @@ let ``Introspection executes an introspection query`` () =
                          "interfaces", null
                          "enumValues", null
                          "possibleTypes", null];
-                    upcast Map.ofList<string, obj> [
+                    upcast NameValueLookup.ofList [
                          "kind", upcast "SCALAR"
                          "name", upcast "Boolean"
                          "fields", null
@@ -298,76 +298,76 @@ let ``Introspection executes an introspection query`` () =
                          "interfaces", null
                          "enumValues", null
                          "possibleTypes", null];
-                    upcast Map.ofList<string, obj> [
+                    upcast NameValueLookup.ofList [
                          "kind", upcast "OBJECT"
                          "name", upcast "__Field"
                          "fields", upcast [
-                                 box <| Map.ofList<string, obj> [
+                                 box <| NameValueLookup.ofList [
                                       "name", upcast "name"
                                       "args", upcast []
-                                      "type", upcast Map.ofList<string, obj> [
+                                      "type", upcast NameValueLookup.ofList [
                                               "kind", upcast "NON_NULL"
                                               "name", null
-                                              "ofType", upcast Map.ofList<string, obj> [
+                                              "ofType", upcast NameValueLookup.ofList [
                                                       "kind", upcast "SCALAR"
                                                       "name", upcast "String"
                                                       "ofType", null]]
                                       "isDeprecated", upcast false
                                       "deprecationReason", null];
-                                 upcast Map.ofList<string, obj> [
+                                 upcast NameValueLookup.ofList [
                                       "name", upcast "description"
                                       "args", upcast []
-                                      "type", upcast Map.ofList<string, obj> [
+                                      "type", upcast NameValueLookup.ofList [
                                               "kind", upcast "SCALAR"
                                               "name", upcast "String"
                                               "ofType", null]
                                       "isDeprecated", upcast false
                                       "deprecationReason", null];
-                                 upcast Map.ofList<string, obj> [
+                                 upcast NameValueLookup.ofList [
                                       "name", upcast "args"
                                       "args", upcast []
-                                      "type", upcast Map.ofList<string, obj> [
+                                      "type", upcast NameValueLookup.ofList [
                                               "kind", upcast "NON_NULL"
                                               "name", null
-                                              "ofType", upcast Map.ofList<string, obj> [
+                                              "ofType", upcast NameValueLookup.ofList [
                                                       "kind", upcast "LIST"
                                                       "name", null
-                                                      "ofType", upcast Map.ofList<string, obj> [
+                                                      "ofType", upcast NameValueLookup.ofList [
                                                               "kind", upcast "NON_NULL"
                                                               "name", null
-                                                              "ofType", upcast Map.ofList<string, obj> [
+                                                              "ofType", upcast NameValueLookup.ofList [
                                                                       "kind", upcast "OBJECT"
                                                                       "name", upcast "__InputValue"]]]]
                                       "isDeprecated", upcast false
                                       "deprecationReason", null];
-                                 upcast Map.ofList<string, obj> [
+                                 upcast NameValueLookup.ofList [
                                       "name", upcast "type"
                                       "args", upcast []
-                                      "type", upcast Map.ofList<string, obj> [
+                                      "type", upcast NameValueLookup.ofList [
                                               "kind", upcast "NON_NULL"
                                               "name", null
-                                              "ofType", upcast Map.ofList<string, obj> [
+                                              "ofType", upcast NameValueLookup.ofList [
                                                       "kind", upcast "OBJECT"
                                                       "name", upcast "__Type"
                                                       "ofType", null]]
                                       "isDeprecated", upcast false
                                       "deprecationReason", null];
-                                 upcast Map.ofList<string, obj> [
+                                 upcast NameValueLookup.ofList [
                                       "name", upcast "isDeprecated"
                                       "args", upcast []
-                                      "type", upcast Map.ofList<string, obj> [
+                                      "type", upcast NameValueLookup.ofList [
                                               "kind", upcast "NON_NULL"
                                               "name", null
-                                              "ofType", upcast Map.ofList<string, obj> [
+                                              "ofType", upcast NameValueLookup.ofList [
                                                       "kind", upcast "SCALAR"
                                                       "name", upcast "Boolean"
                                                       "ofType", null]]
                                       "isDeprecated", upcast false
                                       "deprecationReason", null];
-                                 upcast Map.ofList<string, obj> [
+                                 upcast NameValueLookup.ofList [
                                       "name", upcast "deprecationReason"
                                       "args", upcast []
-                                      "type", upcast Map.ofList<string, obj> [
+                                      "type", upcast NameValueLookup.ofList [
                                               "kind", upcast "SCALAR"
                                               "name", upcast "String"
                                               "ofType", null]
@@ -377,47 +377,47 @@ let ``Introspection executes an introspection query`` () =
                          "interfaces", upcast []
                          "enumValues", null
                          "possibleTypes", null];
-                    upcast Map.ofList<string, obj> [
+                    upcast NameValueLookup.ofList [
                          "kind", upcast "OBJECT"
                          "name", upcast "__InputValue"
                          "fields", upcast [
-                                 box <| Map.ofList<string, obj> [
+                                 box <| NameValueLookup.ofList [
                                       "name", upcast "name"
                                       "args", upcast []
-                                      "type", upcast Map.ofList<string, obj> [
+                                      "type", upcast NameValueLookup.ofList [
                                               "kind", upcast "NON_NULL"
                                               "name", null
-                                              "ofType", upcast Map.ofList<string, obj> [
+                                              "ofType", upcast NameValueLookup.ofList [
                                                       "kind", upcast "SCALAR"
                                                       "name", upcast "String"
                                                       "ofType", null]]
                                       "isDeprecated", upcast false
                                       "deprecationReason", null];
-                                 upcast Map.ofList<string, obj> [
+                                 upcast NameValueLookup.ofList [
                                       "name", upcast "description"
                                       "args", upcast []
-                                      "type", upcast Map.ofList<string, obj> [
+                                      "type", upcast NameValueLookup.ofList [
                                               "kind", upcast "SCALAR"
                                               "name", upcast "String"
                                               "ofType", null]
                                       "isDeprecated", upcast false
                                       "deprecationReason", null];
-                                 upcast Map.ofList<string, obj> [
+                                 upcast NameValueLookup.ofList [
                                       "name", upcast "type"
                                       "args", upcast []
-                                      "type", upcast Map.ofList<string, obj> [
+                                      "type", upcast NameValueLookup.ofList [
                                               "kind", upcast "NON_NULL"
                                               "name", null
-                                              "ofType", upcast Map.ofList<string, obj> [
+                                              "ofType", upcast NameValueLookup.ofList [
                                                       "kind", upcast "OBJECT"
                                                       "name", upcast "__Type"
                                                       "ofType", null]]
                                       "isDeprecated", upcast false
                                       "deprecationReason", null];
-                                 upcast Map.ofList<string, obj> [
+                                 upcast NameValueLookup.ofList [
                                       "name", upcast "defaultValue"
                                       "args", upcast []
-                                      "type", upcast Map.ofList<string, obj> [
+                                      "type", upcast NameValueLookup.ofList [
                                               "kind", upcast "SCALAR"
                                               "name", upcast "String"
                                               "ofType", null]
@@ -427,47 +427,47 @@ let ``Introspection executes an introspection query`` () =
                          "interfaces", upcast []
                          "enumValues", null
                          "possibleTypes", null];
-                    upcast Map.ofList<string, obj> [
+                    upcast NameValueLookup.ofList [
                          "kind", upcast "OBJECT"
                          "name", upcast "__EnumValue"
                          "fields", upcast [
-                                 box <| Map.ofList<string, obj> [
+                                 box <| NameValueLookup.ofList [
                                       "name", upcast "name"
                                       "args", upcast []
-                                      "type", upcast Map.ofList<string, obj> [
+                                      "type", upcast NameValueLookup.ofList [
                                               "kind", upcast "NON_NULL"
                                               "name", null
-                                              "ofType", upcast Map.ofList<string, obj> [
+                                              "ofType", upcast NameValueLookup.ofList [
                                                       "kind", upcast "SCALAR"
                                                       "name", upcast "String"
                                                       "ofType", null]]
                                       "isDeprecated", upcast false
                                       "deprecationReason", null];
-                                 upcast Map.ofList<string, obj> [
+                                 upcast NameValueLookup.ofList [
                                       "name", upcast "description"
                                       "args", upcast []
-                                      "type", upcast Map.ofList<string, obj> [
+                                      "type", upcast NameValueLookup.ofList [
                                               "kind", upcast "SCALAR"
                                               "name", upcast "String"
                                               "ofType", null]
                                       "isDeprecated", upcast false
                                       "deprecationReason", null];
-                                 upcast Map.ofList<string, obj> [
+                                 upcast NameValueLookup.ofList [
                                       "name", upcast "isDeprecated"
                                       "args", upcast []
-                                      "type", upcast Map.ofList<string, obj> [
+                                      "type", upcast NameValueLookup.ofList [
                                               "kind", upcast "NON_NULL"
                                               "name", null
-                                              "ofType", upcast Map.ofList<string, obj> [
+                                              "ofType", upcast NameValueLookup.ofList [
                                                       "kind", upcast "SCALAR"
                                                       "name", upcast "Boolean"
                                                       "ofType", null]]
                                       "isDeprecated", upcast false
                                       "deprecationReason", null];
-                                 upcast Map.ofList<string, obj> [
+                                 upcast NameValueLookup.ofList [
                                       "name", upcast "deprecationReason"
                                       "args", upcast []
-                                      "type", upcast Map.ofList<string, obj> [
+                                      "type", upcast NameValueLookup.ofList [
                                               "kind", upcast "SCALAR"
                                               "name", upcast "String"
                                               "ofType", null]
@@ -477,96 +477,96 @@ let ``Introspection executes an introspection query`` () =
                          "interfaces", upcast []
                          "enumValues", null
                          "possibleTypes", null];
-                    upcast Map.ofList<string, obj> [
+                    upcast NameValueLookup.ofList [
                          "kind", upcast "OBJECT"
                          "name", upcast "__Directive"
                          "fields", upcast [
-                                 box <| Map.ofList<string, obj> [
+                                 box <| NameValueLookup.ofList [
                                       "name", upcast "name"
                                       "args", upcast []
-                                      "type", upcast Map.ofList<string, obj> [
+                                      "type", upcast NameValueLookup.ofList [
                                               "kind", upcast "NON_NULL"
                                               "name", null
-                                              "ofType", upcast Map.ofList<string, obj> [
+                                              "ofType", upcast NameValueLookup.ofList [
                                                       "kind", upcast "SCALAR"
                                                       "name", upcast "String"
                                                       "ofType", null]]
                                       "isDeprecated", upcast false
                                       "deprecationReason", null];
-                                 upcast Map.ofList<string, obj> [
+                                 upcast NameValueLookup.ofList [
                                       "name", upcast "description"
                                       "args", upcast []
-                                      "type", upcast Map.ofList<string, obj> [
+                                      "type", upcast NameValueLookup.ofList [
                                               "kind", upcast "SCALAR"
                                               "name", upcast "String"
                                               "ofType", null]
                                       "isDeprecated", upcast false
                                       "deprecationReason", null];
-                                 upcast Map.ofList<string, obj> [
+                                 upcast NameValueLookup.ofList [
                                       "name", upcast "locations"
                                       "args", upcast []
-                                      "type", upcast Map.ofList<string, obj> [
+                                      "type", upcast NameValueLookup.ofList [
                                               "kind", upcast "NON_NULL"
                                               "name", null
-                                              "ofType", upcast Map.ofList<string, obj> [
+                                              "ofType", upcast NameValueLookup.ofList [
                                                       "kind", upcast "LIST"
                                                       "name", null
-                                                      "ofType", upcast Map.ofList<string, obj> [
+                                                      "ofType", upcast NameValueLookup.ofList [
                                                               "kind", upcast "NON_NULL"
                                                               "name", null
-                                                              "ofType", upcast Map.ofList<string, obj> [
+                                                              "ofType", upcast NameValueLookup.ofList [
                                                                       "kind", upcast "ENUM"
                                                                       "name", upcast "__DirectiveLocation"]]]]
                                       "isDeprecated", upcast false
                                       "deprecationReason", null];
-                                 upcast Map.ofList<string, obj> [
+                                 upcast NameValueLookup.ofList [
                                       "name", upcast "args"
                                       "args", upcast []
-                                      "type", upcast Map.ofList<string, obj> [
+                                      "type", upcast NameValueLookup.ofList [
                                               "kind", upcast "NON_NULL"
                                               "name", null
-                                              "ofType", upcast Map.ofList<string, obj> [
+                                              "ofType", upcast NameValueLookup.ofList [
                                                       "kind", upcast "LIST"
                                                       "name", null
-                                                      "ofType", upcast Map.ofList<string, obj> [
+                                                      "ofType", upcast NameValueLookup.ofList [
                                                               "kind", upcast "NON_NULL"
                                                               "name", null
-                                                              "ofType", upcast Map.ofList<string, obj> [
+                                                              "ofType", upcast NameValueLookup.ofList [
                                                                       "kind", upcast "OBJECT"
                                                                       "name", upcast "__InputValue"]]]]
                                       "isDeprecated", upcast false
                                       "deprecationReason", null];
-                                 upcast Map.ofList<string, obj> [
+                                 upcast NameValueLookup.ofList [
                                       "name", upcast "onOperation"
                                       "args", upcast []
-                                      "type", upcast Map.ofList<string, obj> [
+                                      "type", upcast NameValueLookup.ofList [
                                               "kind", upcast "NON_NULL"
                                               "name", null
-                                              "ofType", upcast Map.ofList<string, obj> [
+                                              "ofType", upcast NameValueLookup.ofList [
                                                       "kind", upcast "SCALAR"
                                                       "name", upcast "Boolean"
                                                       "ofType", null]]
                                       "isDeprecated", upcast true
                                       "deprecationReason", upcast "Use `locations`."];
-                                 upcast Map.ofList<string, obj> [
+                                 upcast NameValueLookup.ofList [
                                       "name", upcast "onFragment"
                                       "args", upcast []
-                                      "type", upcast Map.ofList<string, obj> [
+                                      "type", upcast NameValueLookup.ofList [
                                               "kind", upcast "NON_NULL"
                                               "name", null
-                                              "ofType", upcast Map.ofList<string, obj> [
+                                              "ofType", upcast NameValueLookup.ofList [
                                                       "kind", upcast "SCALAR"
                                                       "name", upcast "Boolean"
                                                       "ofType", null]]
                                       "isDeprecated", upcast true
                                       "deprecationReason", upcast "Use `locations`."];
-                                 upcast Map.ofList<string, obj> [
+                                 upcast NameValueLookup.ofList [
                                       "name", upcast "onField"
                                       "args", upcast []
-                                      "type", upcast Map.ofList<string, obj> [
+                                      "type", upcast NameValueLookup.ofList [
                                               "kind", upcast "NON_NULL"
                                               "name", null
-                                              "ofType", upcast Map.ofList<string, obj> [
+                                              "ofType", upcast NameValueLookup.ofList [
                                                       "kind", upcast "SCALAR"
                                                       "name", upcast "Boolean"
                                                       "ofType", null]]
@@ -576,69 +576,69 @@ let ``Introspection executes an introspection query`` () =
                          "interfaces", upcast []
                          "enumValues", null
                          "possibleTypes", null];
-                    upcast Map.ofList<string, obj> [
+                    upcast NameValueLookup.ofList [
                          "kind", upcast "ENUM"
                          "name", upcast "__DirectiveLocation"
                          "fields", null
                          "inputFields", null
                          "interfaces", null
                          "enumValues", upcast [
-                                 box <| Map.ofList<string, obj> [
+                                 box <| NameValueLookup.ofList [
                                       "name", upcast "QUERY"
                                       "isDeprecated", upcast false];
-                                 upcast Map.ofList<string, obj> [
+                                 upcast NameValueLookup.ofList [
                                       "name", upcast "MUTATION"
                                       "isDeprecated", upcast false];
-                                 upcast Map.ofList<string, obj> [
+                                 upcast NameValueLookup.ofList [
                                       "name", upcast "SUBSCRIPTION"
                                       "isDeprecated", upcast false];
-                                 upcast Map.ofList<string, obj> [
+                                 upcast NameValueLookup.ofList [
                                       "name", upcast "FIELD"
                                       "isDeprecated", upcast false];
-                                 upcast Map.ofList<string, obj> [
+                                 upcast NameValueLookup.ofList [
                                       "name", upcast "FRAGMENT_DEFINITION"
                                       "isDeprecated", upcast false];
-                                 upcast Map.ofList<string, obj> [
+                                 upcast NameValueLookup.ofList [
                                       "name", upcast "FRAGMENT_SPREAD"
                                       "isDeprecated", upcast false];
-                                 upcast Map.ofList<string, obj> [
+                                 upcast NameValueLookup.ofList [
                                       "name", upcast "INLINE_FRAGMENT"
                                       "isDeprecated", upcast false];]
                          "possibleTypes", null];]
             "directives", upcast [
-                    box <| Map.ofList<string, obj> [
+                    box <| NameValueLookup.ofList [
                          "name", upcast "include"
                          "locations", upcast [
                                  box <| "FIELD";
                                  upcast "FRAGMENT_SPREAD";
                                  upcast "INLINE_FRAGMENT";]
                          "args", upcast [
-                                 box <| Map.ofList<string, obj> [
+                                 box <| NameValueLookup.ofList [
                                       "defaultValue", null
                                       "name", upcast "if"
-                                      "type", upcast Map.ofList<string, obj> [
+                                      "type", upcast NameValueLookup.ofList [
                                               "kind", upcast "NON_NULL"
                                               "name", null
-                                              "ofType", upcast Map.ofList<string, obj> [
+                                              "ofType", upcast NameValueLookup.ofList [
                                                       "kind", upcast "SCALAR"
                                                       "name", upcast "Boolean"
                                                       "ofType", null]]];]];
-                    upcast Map.ofList<string, obj> [
+                    upcast NameValueLookup.ofList [
                          "name", upcast "skip"
                          "locations", upcast [
                                  box <| "FIELD";
                                  upcast "FRAGMENT_SPREAD";
                                  upcast "INLINE_FRAGMENT";]
                          "args", upcast [
-                                 box <| Map.ofList<string, obj> [
+                                 box <| NameValueLookup.ofList [
                                       "defaultValue", null
                                       "name", upcast "if"
-                                      "type", upcast Map.ofList<string, obj> [
+                                      "type", upcast NameValueLookup.ofList [
                                               "kind", upcast "NON_NULL"
                                               "name", null
-                                              "ofType", upcast Map.ofList<string, obj> [
+                                              "ofType", upcast NameValueLookup.ofList [
                                                       "kind", upcast "SCALAR"
                                                       "name", upcast "Boolean"
                                                       "ofType", null]]];]];]]]
 
-    equals expected result.Data.Value
+    result.Data.Value|> equals (upcast expected)

--- a/tests/FSharp.Data.GraphQL.Tests/MutationTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/MutationTests.fs
@@ -62,15 +62,15 @@ let ``Execute handles mutation execution ordering: evaluates mutations serially`
     }"""
 
     let mutationResult = sync <| schema.AsyncExecute(parse query, {NumberHolder = {Number = 6}})
-    let expected: Map<string, obj> = Map.ofList [
-        "first",  upcast Map.ofList [ "theNumber", 1 :> obj]
-        "second", upcast Map.ofList [ "theNumber", 2 :> obj]
-        "third",  upcast Map.ofList [ "theNumber", 3 :> obj]
-        "fourth", upcast Map.ofList [ "theNumber", 4 :> obj]
-        "fifth",  upcast Map.ofList [ "theNumber", 5 :> obj]
+    let expected = NameValueLookup.ofList [
+        "first",  upcast NameValueLookup.ofList [ "theNumber", 1 :> obj]
+        "second", upcast NameValueLookup.ofList [ "theNumber", 2 :> obj]
+        "third",  upcast NameValueLookup.ofList [ "theNumber", 3 :> obj]
+        "fourth", upcast NameValueLookup.ofList [ "theNumber", 4 :> obj]
+        "fifth",  upcast NameValueLookup.ofList [ "theNumber", 5 :> obj]
     ]
     noErrors mutationResult
-    equals expected mutationResult.Data.Value
+    mutationResult.Data.Value |> equals (upcast expected)
     
 [<Fact>]
 let ``Execute handles mutation execution ordering: evaluates mutations correctly in the presense of failures`` () =
@@ -97,13 +97,13 @@ let ``Execute handles mutation execution ordering: evaluates mutations correctly
 
     let data = {NumberHolder = {Number = 6}}
     let mutationResult = sync <| schema.AsyncExecute(parse query, data)
-    let expected: Map<string, obj> = Map.ofList [
-        "first",  upcast Map.ofList [ "theNumber", 1 :> obj]
-        "second", upcast Map.ofList [ "theNumber", 2 :> obj]
+    let expected = NameValueLookup.ofList [
+        "first",  upcast NameValueLookup.ofList [ "theNumber", 1 :> obj]
+        "second", upcast NameValueLookup.ofList [ "theNumber", 2 :> obj]
         "third",  null
-        "fourth", upcast Map.ofList [ "theNumber", 4 :> obj]
-        "fifth",  upcast Map.ofList [ "theNumber", 5 :> obj]
+        "fourth", upcast NameValueLookup.ofList [ "theNumber", 4 :> obj]
+        "fifth",  upcast NameValueLookup.ofList [ "theNumber", 5 :> obj]
         "sixth",  null
     ]
-    equals expected mutationResult.Data.Value
+    mutationResult.Data.Value |> equals (upcast expected)
     equals 2 mutationResult.Errors.Value.Length

--- a/tests/FSharp.Data.GraphQL.Tests/ResolveTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/ResolveTests.fs
@@ -20,16 +20,16 @@ let testSchema testFields = Schema(Define.Object("Query", fields = testFields))
 [<Fact>]
 let ``Execute uses default resolve to accesses properties`` () =
     let schema = testSchema [ Define.Field("test", String) ]
-    let expected = Map.ofList [ "test", "testValue" :> obj ]
+    let expected = NameValueLookup.ofList [ "test", "testValue" :> obj ]
     let actual = sync <| schema.AsyncExecute(parse "{ test }", { Test = "testValue" })
     noErrors actual
-    equals expected actual.Data.Value
+    actual.Data.Value |> equals (upcast expected)
             
 [<Fact>]
 let ``Execute uses provided resolve function to accesses properties`` () =
     let schema = testSchema [ 
         Define.Field("test", String, "",[Define.Input("a", String)], resolve = fun ctx d -> d.Test + ctx.Arg("a").Value) ]
-    let expected = Map.ofList [ "test", "testValueString" :> obj ]
+    let expected = NameValueLookup.ofList [ "test", "testValueString" :> obj ]
     let actual = sync <| schema.AsyncExecute(parse "{ test(a: \"String\") }", { Test = "testValue" })
     noErrors actual
-    equals expected actual.Data.Value
+    actual.Data.Value |> equals (upcast expected)

--- a/tests/FSharp.Data.GraphQL.Tests/UnionInterfaceTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/UnionInterfaceTests.fs
@@ -111,31 +111,31 @@ let ``Execute can introspect on union and intersection types`` () =
         }
       }"""
     let actual = sync <| schema.AsyncExecute(ast)
-    let expected: Map<string, obj> = Map.ofList [
-        "Named", upcast Map.ofList [
+    let expected = NameValueLookup.ofList [
+        "Named", upcast NameValueLookup.ofList [
             "kind", box "INTERFACE"
             "name", upcast "Named"
             "fields", upcast [
-                box (Map.ofList [ "name", box "name"])]
+                box (NameValueLookup.ofList [ "name", box "name"])]
             "interfaces", null
             "possibleTypes", upcast [
-                box (Map.ofList ["name", box "Person"])
-                upcast Map.ofList ["name", box "Dog"]
-                upcast Map.ofList ["name", box "Cat"]]
+                box (NameValueLookup.ofList ["name", box "Person"])
+                upcast NameValueLookup.ofList ["name", box "Dog"]
+                upcast NameValueLookup.ofList ["name", box "Cat"]]
             "enumValues", null
             "inputFields", null]
-        "Pet", upcast Map.ofList [
+        "Pet", upcast NameValueLookup.ofList [
             "kind", box "UNION"
             "name", upcast "Pet"
             "fields", null
             "interfaces", null
             "possibleTypes", upcast [
-                box (Map.ofList ["name", box "Cat"])
-                upcast Map.ofList ["name", box "Dog"]]
+                box (NameValueLookup.ofList ["name", box "Cat"])
+                upcast NameValueLookup.ofList ["name", box "Dog"]]
             "enumValues", null
             "inputFields", null]]
     noErrors actual
-    equals expected actual.Data.Value
+    actual.Data.Value |> equals (upcast expected)
 
 [<Fact>]
 let ``Executes union types`` () =
@@ -151,22 +151,22 @@ let ``Executes union types`` () =
         }
       }"""
     let actual = sync <| schema.AsyncExecute(ast, john)
-    let expected: Map<string, obj> = Map.ofList [
+    let expected = NameValueLookup.ofList [
         "__typename", box "Person"
         "name", upcast "John"
         "pets", upcast [
-            box <| Map.ofList [
+            box <| NameValueLookup.ofList [
                 "__typename", box "Cat"
                 "name", upcast "Garfield"
                 "barks", null
                 "meows", upcast false]
-            upcast Map.ofList [
+            upcast NameValueLookup.ofList [
                 "__typename", box "Dog"
                 "name", upcast "Odie"
                 "barks", upcast true
                 "meows", null]]]
     noErrors actual
-    equals expected actual.Data.Value
+    actual.Data.Value |> equals (upcast expected)
     
 [<Fact>]
 let ``Executes union types with inline fragments`` () =
@@ -187,20 +187,20 @@ let ``Executes union types with inline fragments`` () =
         }
       }"""
     let actual = sync <| schema.AsyncExecute(ast, john)
-    let expected: Map<string, obj> = Map.ofList [
+    let expected = NameValueLookup.ofList [
         "__typename", box "Person"
         "name", upcast "John"
         "pets", upcast [
-            box <| Map.ofList [
+            box <| NameValueLookup.ofList [
                 "__typename", box "Cat"
                 "name", upcast "Garfield"
                 "meows", upcast false]
-            upcast Map.ofList [
+            upcast NameValueLookup.ofList [
                 "__typename", box "Dog"
                 "name", upcast "Odie"
                 "barks", upcast true]]]
     noErrors actual
-    equals expected actual.Data.Value
+    actual.Data.Value |> equals (upcast expected)
     
 [<Fact>]
 let ``Executes interface types`` () =
@@ -216,22 +216,22 @@ let ``Executes interface types`` () =
         }
       }"""
     let actual = sync <| schema.AsyncExecute(ast, john)
-    let expected: Map<string, obj> = Map.ofList [
+    let expected = NameValueLookup.ofList [
         "__typename", box "Person"
         "name", upcast "John"
         "friends", upcast [
-            box <| Map.ofList [
+            box <| NameValueLookup.ofList [
                 "__typename", box "Person"
                 "name", upcast "Liz"
                 "barks", null
                 "meows", null]
-            upcast Map.ofList [
+            upcast NameValueLookup.ofList [
                 "__typename", box "Dog"
                 "name", upcast "Odie"
                 "barks", upcast true
                 "meows", null]]]
     noErrors actual
-    equals expected actual.Data.Value
+    actual.Data.Value |> equals (upcast expected)
     
 [<Fact>]
 let ``Executes interface types with inline fragments`` () =
@@ -251,19 +251,19 @@ let ``Executes interface types with inline fragments`` () =
         }
       }"""
     let actual = sync <| schema.AsyncExecute(ast, john)
-    let expected: Map<string, obj> = Map.ofList [
+    let expected = NameValueLookup.ofList [
         "__typename", box "Person"
         "name", upcast "John"
         "friends", upcast [
-            box <| Map.ofList [
+            box <| NameValueLookup.ofList [
                 "__typename", box "Person"
                 "name", upcast "Liz"]
-            upcast Map.ofList [
+            upcast NameValueLookup.ofList [
                 "__typename", box "Dog"
                 "name", upcast "Odie"
                 "barks", upcast true]]]
     noErrors actual
-    equals expected actual.Data.Value
+    actual.Data.Value |> equals (upcast expected)
 
 [<Fact>]
 let ``Execute allows fragment conditions to be abstract types`` () =
@@ -297,26 +297,26 @@ let ``Execute allows fragment conditions to be abstract types`` () =
         }
       }"""
     let actual = sync <| schema.AsyncExecute(ast, john)
-    let expected: Map<string, obj> = Map.ofList [
+    let expected = NameValueLookup.ofList [
         "__typename", box "Person"
         "name", upcast "John"
         "pets", upcast [
-            box <| Map.ofList [
+            box <| NameValueLookup.ofList [
                 "__typename", box "Cat"
                 "name", upcast "Garfield"
                 "meows", upcast false]
-            upcast Map.ofList [
+            upcast NameValueLookup.ofList [
                 "__typename", box "Dog"
                 "name", upcast "Odie"
                 "barks", upcast true]]
         "friends", upcast [
-            box <| Map.ofList [
+            box <| NameValueLookup.ofList [
                 "__typename", box "Person"
                 "name", upcast "Liz"]
-            upcast Map.ofList [
+            upcast NameValueLookup.ofList [
                 "__typename", box "Dog"
                 "name", upcast "Odie"
                 "barks", upcast true]]]
     noErrors actual
-    equals expected actual.Data.Value
+    actual.Data.Value |> equals (upcast expected)
     

--- a/tests/FSharp.Data.GraphQL.Tests/VariablesTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/VariablesTests.fs
@@ -61,59 +61,59 @@ let schema = Schema(TestType)
 let ``Execute handles objects and nullability using inline structs with complex input`` () =
     let ast = parse """{ fieldWithObjectInput(input: {a: "foo", b: ["bar"], c: "baz"}) }"""
     let actual = sync <| schema.AsyncExecute(ast)
-    let expected: Map<string, obj> = Map.ofList [ "fieldWithObjectInput", upcast Map.ofList [
+    let expected = NameValueLookup.ofList [ "fieldWithObjectInput", upcast NameValueLookup.ofList [
         "a", "foo" :> obj
         "b", upcast ["bar"]
         "c", upcast "baz" ]]
     noErrors actual
-    equals expected actual.Data.Value
+    actual.Data.Value |> equals (upcast expected)
     
 [<Fact>]
 let ``Execute handles objects and nullability using inline structs and properly parses single value to list`` () =
     let ast = parse """{ fieldWithObjectInput(input: {a: "foo", b: "bar", c: "baz"}) }"""
     let actual = sync <| schema.AsyncExecute(ast)
-    let expected: Map<string, obj> = Map.ofList [ "fieldWithObjectInput", upcast Map.ofList [
+    let expected = NameValueLookup.ofList [ "fieldWithObjectInput", upcast NameValueLookup.ofList [
         "a", "foo" :> obj
         "b", upcast ["bar"]
         "c", upcast "baz" ]]
     noErrors actual
-    equals expected actual.Data.Value
+    actual.Data.Value |> equals (upcast expected)
     
 [<Fact>]
 let ``Execute handles objects and nullability using inline structs and doesn't use incorrect value`` () =
     let ast = parse """{ fieldWithObjectInput(input: ["foo", "bar", "baz"]) }"""
     let actual = sync <| schema.AsyncExecute(ast)
-    let expected: Map<string, obj> = Map.ofList [ "fieldWithObjectInput", null ]
+    let expected = NameValueLookup.ofList [ "fieldWithObjectInput", null ]
     noErrors actual
-    equals expected actual.Data.Value
+    actual.Data.Value |> equals (upcast expected)
     
 [<Fact>]
 let ``Execute handles objects and nullability using inline structs and proprely coerces complex scalar types`` () =
     let ast = parse """{ fieldWithObjectInput(input: {a: "foo", d: "SerializedValue"}) }"""
     let actual = sync <| schema.AsyncExecute(ast)
-    let expected: Map<string, obj> = Map.ofList [ "fieldWithObjectInput", upcast Map.ofList [
+    let expected = NameValueLookup.ofList [ "fieldWithObjectInput", upcast NameValueLookup.ofList [
         "a", "foo" :> obj
         "d", upcast "DeserializedValue" ]]
     noErrors actual
-    equals expected actual.Data.Value
+    actual.Data.Value |> equals (upcast expected)
     
 [<Fact>]
 let ``Execute handles variables with complex inputs`` () =
     let ast = parse """query q($input: TestInputObject) {
           fieldWithObjectInput(input: $input)
         }"""
-    let params: Map<string, obj> = Map.ofList [
+    let params : Map<string, obj> = Map.ofList [
         "input", upcast Map.ofList [
             "a", "foo" :> obj
             "b", upcast ["bar"]
             "c", upcast "baz"]]
     let actual = sync <| schema.AsyncExecute(ast, variables = params)
-    let expected: Map<string, obj> = Map.ofList [ "fieldWithObjectInput", upcast Map.ofList [
+    let expected = NameValueLookup.ofList [ "fieldWithObjectInput", upcast NameValueLookup.ofList [
         "a", "foo" :> obj
         "b", upcast ["bar"]
         "c", upcast "baz" ]]
     noErrors actual
-    equals expected actual.Data.Value
+    actual.Data.Value |> equals (upcast expected)
     
 [<Fact>]
 let ``Execute handles variables with default value when no value was provided`` () =
@@ -121,53 +121,53 @@ let ``Execute handles variables with default value when no value was provided`` 
             fieldWithObjectInput(input: $input)
           }"""
     let actual = sync <| schema.AsyncExecute(ast)
-    let expected: Map<string, obj> = Map.ofList [ "fieldWithObjectInput", upcast Map.ofList [
+    let expected = NameValueLookup.ofList [ "fieldWithObjectInput", upcast NameValueLookup.ofList [
         "a", "foo" :> obj
         "b", upcast ["bar"]
         "c", upcast "baz" ]]
     noErrors actual
-    equals expected actual.Data.Value
+    actual.Data.Value |> equals (upcast expected)
     
 [<Fact>]
 let ``Execute handles variables and properly parses single value to list`` () =
     let ast = parse """query q($input: TestInputObject) {
           fieldWithObjectInput(input: $input)
         }"""
-    let params: Map<string, obj> = Map.ofList [
+    let params : Map<string, obj> = Map.ofList [
         "input", upcast Map.ofList [
             "a", "foo" :> obj
             "b", upcast "bar"
             "c", upcast "baz"]]
     let actual = sync <| schema.AsyncExecute(ast, variables = params)
-    let expected: Map<string, obj> = Map.ofList [ "fieldWithObjectInput", upcast Map.ofList [
+    let expected = NameValueLookup.ofList [ "fieldWithObjectInput", upcast NameValueLookup.ofList [
         "a", "foo" :> obj
         "b", upcast ["bar"]
         "c", upcast "baz" ]]
     noErrors actual
-    equals expected actual.Data.Value
+    actual.Data.Value |> equals (upcast expected)
     
 [<Fact>]
 let ``Execute handles variables with complex scalar input`` () =
     let ast = parse """query q($input: TestInputObject) {
           fieldWithObjectInput(input: $input)
         }"""
-    let params: Map<string, obj> = Map.ofList [
+    let params : Map<string, obj> = Map.ofList [
         "input", upcast Map.ofList [
             "a", "foo" :> obj
             "d", upcast "SerializedValue" ]]
     let actual = sync <| schema.AsyncExecute(ast, variables = params)
-    let expected: Map<string, obj> = Map.ofList [ "fieldWithObjectInput", upcast Map.ofList [
+    let expected = NameValueLookup.ofList [ "fieldWithObjectInput", upcast NameValueLookup.ofList [
         "a", "foo" :> obj
         "d", upcast "DeserializedValue" ]]
     noErrors actual
-    equals expected actual.Data.Value
+    actual.Data.Value |> equals (upcast expected)
 
 [<Fact>]
 let ``Execute handles variables and errors on null for nested non-nulls`` () =
     let ast = parse """query q($input: TestInputObject) {
           fieldWithObjectInput(input: $input)
         }"""
-    let params: Map<string, obj> = Map.ofList [
+    let params : Map<string, obj> = Map.ofList [
         "input", upcast Map.ofList [
             "a", "foo" :> obj
             "b", upcast ["bar"]
@@ -181,7 +181,7 @@ let ``Execute handles variables and errors on incorrect type`` () =
     let ast = parse """query q($input: TestInputObject) {
           fieldWithObjectInput(input: $input)
         }"""
-    let params: Map<string, obj> = Map.ofList ["input", upcast "foo bar"]
+    let params : Map<string, obj> = Map.ofList ["input", upcast "foo bar"]
     let actual = sync <| schema.AsyncExecute(ast, variables = params)
     let errMsg = "Variable '$input' got invalid value: expected 'TestInputObject', found not an object"
     hasError errMsg actual.Errors.Value
@@ -191,7 +191,7 @@ let ``Execute handles variables and errors on omission of nested non-nulls`` () 
     let ast = parse """query q($input: TestInputObject) {
           fieldWithObjectInput(input: $input)
         }"""
-    let params: Map<string, obj> = Map.ofList [
+    let params : Map<string, obj> = Map.ofList [
         "input", upcast Map.ofList [
             "a", "foo" :> obj
             "b", upcast ["bar"]]]
@@ -205,7 +205,7 @@ let ``Execute handles variables and errors on deep nested errors and with many e
     let ast = parse """query q($input: TestNestedInputObject) {
             fieldWithNestedObjectInput(input: $input)
           }"""
-    let params: Map<string, obj> = Map.ofList [
+    let params : Map<string, obj> = Map.ofList [
         "input", upcast Map.ofList [ "na", Map.ofList [ "a", "foo" :> obj ] :> obj ]]
     let actual = sync <| schema.AsyncExecute(ast, variables = params)
     equals 1 actual.Errors.Value.Length
@@ -217,13 +217,13 @@ let ``Execute handles variables and errors on addition of unknown input field`` 
     let ast = parse """query q($input: TestInputObject) {
           fieldWithObjectInput(input: $input)
         }"""
-    let params: Map<string, obj> = Map.ofList [
+    let params : Map<string, obj> = Map.ofList [
         "input", upcast Map.ofList [
-            "a", "foo" :> obj
+            "a", box "foo"
             "b", upcast "bar"
             "c", upcast "baz"]]
     let actual = sync <| schema.AsyncExecute(ast, variables = params)
-    let expected: Map<string, obj> = Map.ofList [ "fieldWithObjectInput", upcast Map.ofList [
+    let expected = NameValueLookup.ofList [ "fieldWithObjectInput", upcast NameValueLookup.ofList [
         "a", "foo" :> obj
         "b", upcast ["bar"]
         "c", upcast "baz" 
@@ -236,9 +236,9 @@ let ``Execute handles variables and errors on addition of unknown input field`` 
 let ``Execute handles variables and allows nullable inputs to be omitted`` () =
     let ast = parse """{ fieldWithNullableStringInput }"""
     let actual = sync <| schema.AsyncExecute(ast)
-    let expected: Map<string, obj> = Map.ofList [ "fieldWithNullableStringInput", null ]
+    let expected = NameValueLookup.ofList [ "fieldWithNullableStringInput", null ]
     noErrors actual
-    equals expected actual.Data.Value
+    actual.Data.Value |> equals (upcast expected)
     
 [<Fact>]
 let ``Execute handles variables and allows nullable inputs to be omitted in a variable`` () =
@@ -246,9 +246,9 @@ let ``Execute handles variables and allows nullable inputs to be omitted in a va
         fieldWithNullableStringInput(input: $value)
       }"""
     let actual = sync <| schema.AsyncExecute(ast)
-    let expected: Map<string, obj> = Map.ofList [ "fieldWithNullableStringInput", null ]
+    let expected = NameValueLookup.ofList [ "fieldWithNullableStringInput", null ]
     noErrors actual
-    equals expected actual.Data.Value
+    actual.Data.Value |> equals (upcast expected)
     
 [<Fact>]
 let ``Execute handles variables and allows nullable inputs to be omitted in an unlisted variable`` () =
@@ -256,9 +256,9 @@ let ``Execute handles variables and allows nullable inputs to be omitted in an u
         fieldWithNullableStringInput(input: $value)
       }"""
     let actual = sync <| schema.AsyncExecute(ast)
-    let expected: Map<string, obj> = Map.ofList [ "fieldWithNullableStringInput", null ]
+    let expected = NameValueLookup.ofList [ "fieldWithNullableStringInput", null ]
     noErrors actual
-    equals expected actual.Data.Value
+    actual.Data.Value |> equals (upcast expected)
     
 [<Fact>]
 let ``Execute handles variables and allows nullable inputs to be set to null in a variable`` () =
@@ -266,9 +266,9 @@ let ``Execute handles variables and allows nullable inputs to be set to null in 
         fieldWithNullableStringInput(input: $value)
       }"""
     let actual = sync <| schema.AsyncExecute(ast, variables = Map.ofList [ "value", null ])
-    let expected: Map<string, obj> = Map.ofList [ "fieldWithNullableStringInput", null ]
+    let expected = NameValueLookup.ofList [ "fieldWithNullableStringInput", null ]
     noErrors actual
-    equals expected actual.Data.Value
+    actual.Data.Value |> equals (upcast expected)
     
 [<Fact>]
 let ``Execute handles variables and allows nullable inputs to be set to a value in a variable`` () =
@@ -276,17 +276,17 @@ let ``Execute handles variables and allows nullable inputs to be set to a value 
         fieldWithNullableStringInput(input: $value)
       }"""
     let actual = sync <| schema.AsyncExecute(ast, variables = Map.ofList [ "value", "a" :> obj ])
-    let expected: Map<string, obj> = Map.ofList [ "fieldWithNullableStringInput", upcast "a" ]
+    let expected = NameValueLookup.ofList [ "fieldWithNullableStringInput", upcast "a" ]
     noErrors actual
-    equals expected actual.Data.Value
+    actual.Data.Value |> equals (upcast expected)
     
 [<Fact>]
 let ``Execute handles variables and allows nullable inputs to be set to a value directly`` () =
     let ast = parse """{ fieldWithNullableStringInput(input: "a") }"""
     let actual = sync <| schema.AsyncExecute(ast)
-    let expected: Map<string, obj> = Map.ofList [ "fieldWithNullableStringInput", upcast "a" ]
+    let expected = NameValueLookup.ofList [ "fieldWithNullableStringInput", upcast "a" ]
     noErrors actual
-    equals expected actual.Data.Value
+    actual.Data.Value |> equals (upcast expected)
 
 [<Fact>]
 let ``Execute handles non-nullable scalars and does not allow non-nullable inputs to be omitted in a variable`` () =
@@ -302,25 +302,25 @@ let ``Execute handles non-nullable scalars and allows non-nullable inputs to be 
           fieldWithNonNullableStringInput(input: $value)
         }"""
     let actual = sync <| schema.AsyncExecute(ast, variables = Map.ofList [ "value", "a" :> obj ])
-    let expected: Map<string, obj> = Map.ofList [ "fieldWithNonNullableStringInput", upcast "a" ]
+    let expected = NameValueLookup.ofList [ "fieldWithNonNullableStringInput", upcast "a" ]
     noErrors actual
-    equals expected actual.Data.Value
+    actual.Data.Value |> equals (upcast expected)
     
 [<Fact>]
 let ``Execute handles non-nullable scalars and allows non-nullable inputs to be set to a value directly`` () =
     let ast = parse """{ fieldWithNonNullableStringInput(input: "a") }"""
     let actual = sync <| schema.AsyncExecute(ast)
-    let expected: Map<string, obj> = Map.ofList [ "fieldWithNonNullableStringInput", upcast "a" ]
+    let expected = NameValueLookup.ofList [ "fieldWithNonNullableStringInput", upcast "a" ]
     noErrors actual
-    equals expected actual.Data.Value
+    actual.Data.Value |> equals (upcast expected)
     
 [<Fact>]
 let ``Execute handles non-nullable scalars and passes along null for non-nullable inputs if explcitly set in the query`` () =
     let ast = parse """{ fieldWithNonNullableStringInput }"""
     let actual = sync <| schema.AsyncExecute(ast)
-    let expected: Map<string, obj> = Map.ofList [ "fieldWithNonNullableStringInput", null ]
+    let expected = NameValueLookup.ofList [ "fieldWithNonNullableStringInput", null ]
     noErrors actual
-    equals expected actual.Data.Value
+    actual.Data.Value |> equals (upcast expected)
     
 [<Fact>]
 let ``Execute handles list inputs and nullability and allows lists to be null`` () =
@@ -328,9 +328,9 @@ let ``Execute handles list inputs and nullability and allows lists to be null`` 
           list(input: $input)
         }"""
     let actual = sync <| schema.AsyncExecute(ast, variables = Map.ofList [ "input", null ])
-    let expected: Map<string, obj> = Map.ofList [ "list", null ]
+    let expected = NameValueLookup.ofList [ "list", null ]
     noErrors actual
-    equals expected actual.Data.Value
+    actual.Data.Value |> equals (upcast expected)
     
 [<Fact>]
 let ``Execute handles list inputs and nullability and allows lists to contain values`` () =
@@ -338,9 +338,9 @@ let ``Execute handles list inputs and nullability and allows lists to contain va
           list(input: $input)
         }"""
     let actual = sync <| schema.AsyncExecute(ast, variables = Map.ofList [ "input", [ "A" ] :> obj ])
-    let expected: Map<string, obj> = Map.ofList [ "list", upcast [ "A" ]]
+    let expected = NameValueLookup.ofList [ "list", upcast [ "A" ]]
     noErrors actual
-    equals expected actual.Data.Value
+    actual.Data.Value |> equals (upcast expected)
     
 [<Fact>]
 let ``Execute handles list inputs and nullability and allows lists to contain null`` () =
@@ -348,9 +348,9 @@ let ``Execute handles list inputs and nullability and allows lists to contain nu
           list(input: $input)
         }"""
     let actual = sync <| schema.AsyncExecute(ast, variables = Map.ofList [ "input", [ "A":> obj, null, "B" :> obj ] :> obj ])
-    let expected: Map<string, obj> = Map.ofList [ "list", upcast [ "A":> obj, null, "B" :> obj ]]
+    let expected = NameValueLookup.ofList [ "list", upcast [ "A":> obj, null, "B" :> obj ]]
     noErrors actual
-    equals expected actual.Data.Value
+    actual.Data.Value |> equals (upcast expected)
     
 [<Fact>]
 let ``Execute handles list inputs and nullability and does not allow non-null lists to be null`` () =
@@ -366,9 +366,9 @@ let ``Execute handles list inputs and nullability and allows non-null lists to c
           nnList(input: $input)
         }"""
     let actual = sync <| schema.AsyncExecute(ast, variables = Map.ofList [ "input", [ "A" ] :> obj ])
-    let expected: Map<string, obj> = Map.ofList [ "nnList", upcast [ "A" ]]
+    let expected = NameValueLookup.ofList [ "nnList", upcast [ "A" ]]
     noErrors actual
-    equals expected actual.Data.Value
+    actual.Data.Value |> equals (upcast expected)
     
 [<Fact>]
 let ``Execute handles list inputs and nullability and allows non-null lists to contain null`` () =
@@ -376,9 +376,9 @@ let ``Execute handles list inputs and nullability and allows non-null lists to c
           nnList(input: $input)
         }"""
     let actual = sync <| schema.AsyncExecute(ast, variables = Map.ofList [ "input", [ "A":> obj, null, "B" :> obj ] :> obj ])
-    let expected: Map<string, obj> = Map.ofList [ "nnList", upcast [ "A":> obj, null, "B" :> obj ]]
+    let expected = NameValueLookup.ofList [ "nnList", upcast [ "A":> obj, null, "B" :> obj ]]
     noErrors actual
-    equals expected actual.Data.Value
+    actual.Data.Value |> equals (upcast expected)
     
 [<Fact>]
 let ``Execute handles list inputs and nullability and allows lists of non-nulls to be null`` () =
@@ -386,9 +386,9 @@ let ``Execute handles list inputs and nullability and allows lists of non-nulls 
           listNN(input: $input)
         }"""
     let actual = sync <| schema.AsyncExecute(ast, variables = Map.ofList [ "input", null ])
-    let expected: Map<string, obj> = Map.ofList [ "listNN", null ]
+    let expected = NameValueLookup.ofList [ "listNN", null ]
     noErrors actual
-    equals expected actual.Data.Value
+    actual.Data.Value |> equals (upcast expected)
     
 [<Fact>]
 let ``Execute handles list inputs and nullability and allows lists of non-nulls to contain values`` () =
@@ -396,9 +396,9 @@ let ``Execute handles list inputs and nullability and allows lists of non-nulls 
           listNN(input: $input)
         }"""
     let actual = sync <| schema.AsyncExecute(ast, variables = Map.ofList [ "input", [ "A" ] :> obj ])
-    let expected: Map<string, obj> = Map.ofList [ "listNN", upcast [ "A" ]]
+    let expected = NameValueLookup.ofList [ "listNN", upcast [ "A" ]]
     noErrors actual
-    equals expected actual.Data.Value
+    actual.Data.Value |> equals (upcast expected)
     
 [<Fact>]
 let ``Execute handles list inputs and nullability and does not allow lists of non-nulls to contain null`` () =
@@ -422,9 +422,9 @@ let ``Execute handles list inputs and nullability and does not allow non-null li
           nnListNN(input: $input)
         }"""
     let actual = sync <| schema.AsyncExecute(ast, variables = Map.ofList [ "input", [ "A" ] :> obj ])
-    let expected: Map<string, obj> = Map.ofList [ "nnListNN", upcast [ "A" ]]
+    let expected = NameValueLookup.ofList [ "nnListNN", upcast [ "A" ]]
     noErrors actual
-    equals expected actual.Data.Value
+    actual.Data.Value |> equals (upcast expected)
     
 [<Fact>]
 let ``Execute handles list inputs and nullability and does not allow non-null lists of non-nulls to contain null`` () =
@@ -454,9 +454,9 @@ let ``Execute handles list inputs and nullability and does not allow unknown typ
 let ``Execute uses argument default value when no argument was provided`` () =
     let ast = parse """{ fieldWithDefaultArgumentValue }"""
     let actual = sync <| schema.AsyncExecute(ast)
-    let expected: Map<string, obj> = Map.ofList [ "fieldWithDefaultArgumentValue", upcast "hello world" ]
+    let expected = NameValueLookup.ofList [ "fieldWithDefaultArgumentValue", upcast "hello world" ]
     noErrors actual
-    equals expected actual.Data.Value
+    actual.Data.Value |> equals (upcast expected)
     
 [<Fact>]
 let ``Execute uses argument default value when nullable variable provided`` () =
@@ -464,14 +464,14 @@ let ``Execute uses argument default value when nullable variable provided`` () =
         fieldWithDefaultArgumentValue(input: $optional)
       }"""
     let actual = sync <| schema.AsyncExecute(ast, variables = Map.ofList ["optional", null ])
-    let expected: Map<string, obj> = Map.ofList [ "fieldWithDefaultArgumentValue", upcast "hello world" ]
+    let expected = NameValueLookup.ofList [ "fieldWithDefaultArgumentValue", upcast "hello world" ]
     noErrors actual
-    equals expected actual.Data.Value
+    actual.Data.Value |> equals (upcast expected)
     
 [<Fact>]
 let ``Execute uses argument default value when argument provided cannot be parsed`` () =
     let ast = parse """{ fieldWithDefaultArgumentValue(input: WRONG_TYPE) }"""
     let actual = sync <| schema.AsyncExecute(ast)
-    let expected: Map<string, obj> = Map.ofList [ "fieldWithDefaultArgumentValue", upcast "hello world" ]
+    let expected = NameValueLookup.ofList [ "fieldWithDefaultArgumentValue", upcast "hello world" ]
     noErrors actual
-    equals expected actual.Data.Value
+    actual.Data.Value |> equals (upcast expected)


### PR DESCRIPTION
### NamedValueLookup

This is a new class, used as result collector. It takes internal buffer of ordered key-value pairs and unlike F# maps, it maintains that order. Since it also collects all fields ahead of time, it allows for thread-safe concurrent insertions despite being partially mutable.
### Added GC stats to benchmark project

From now `FSharp.Data.GraphQL.Benchmarks` will show not only CPU performance but also number of allocated bytes. At the present moment numbers are:

``` ini

BenchmarkDotNet=v0.9.6.0
OS=Microsoft Windows NT 6.2.9200.0
Processor=Intel(R) Core(TM) i5-4430 CPU @ 3.00GHz, ProcessorCount=4
Frequency=2929684 ticks, Resolution=341.3337 ns, Timer=TSC
HostCLR=MS.NET 4.0.30319.42000, Arch=32-bit RELEASE [AttachedDebugger]
JitModules=clrjit-v4.6.1055.0

Type=SimpleExecutionBenchmark  Mode=Throughput  

```

| Method | Median | StdDev | Mean | Min | Max | Op/s | Gen 0 | Gen 1 | Gen 2 | Bytes Allocated/Op |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| BenchmarkSimpleQueryUnparsed | 110.4364 us | 0.9887 us | 110.5299 us | 108.5026 us | 112.1493 us | 9047.33 | 46,99 | - | - | 6 901,32 |
| BenchmarkSimpleQueryParsed | 62.2445 us | 1.3409 us | 62.3496 us | 60.2781 us | 64.5345 us | 16038.6 | 23,28 | - | - | 3 240,05 |
| BenchmarkFlatQueryUnparsed | 314.3379 us | 4.1057 us | 314.7196 us | 310.6677 us | 327.5917 us | 3177.43 | 98,56 | - | - | 14 735,30 |
| BenchmarkFlatQueryParsed | 232.5219 us | 3.4575 us | 232.3427 us | 226.4013 us | 238.6288 us | 4303.99 | 20,41 | 8,37 | - | 7 619,13 |
| BenchmarkNestedQueryUnparsed | 597.3064 us | 13.6238 us | 601.0427 us | 584.9094 us | 638.4054 us | 1663.78 | 658,00 | - | - | 108 675,72 |
| BenchmarkNestedQueryParsed | 361.5514 us | 16.2406 us | 366.6151 us | 335.5641 us | 402.8925 us | 2727.66 | 371,22 | 1,41 | - | 66 694,19 |

Lowered performance was mentioned in previous PR and it's addressed as part of #32.
