### PR TITLE
Typed schema + list initializers in Define

### DIFF
--- a/samples/graphiql-client/server.fsx
+++ b/samples/graphiql-client/server.fsx
@@ -87,15 +87,15 @@ open FSharp.Data.GraphQL.Execution
 let EpisodeType = Define.Enum(
     name = "Episode",
     description = "One of the films in the Star Wars Trilogy",
-    options = [|
+    options = [
         Define.EnumValue("NEWHOPE", Episode.NewHope, "Released in 1977.")
         Define.EnumValue("EMPIRE", Episode.Empire, "Released in 1980.")
-        Define.EnumValue("JEDI", Episode.Jedi, "Released in 1983.") |])
+        Define.EnumValue("JEDI", Episode.Jedi, "Released in 1983.") ])
 
 let rec CharacterType = Define.Union(
     name = "Character",
     description = "A character in the Star Wars Trilogy",
-    options = [| HumanType; DroidType |],
+    options = [ HumanType; DroidType ],
     resolveValue = (fun o ->
         match o with
         | Human h -> box h
@@ -109,7 +109,7 @@ and HumanType : ObjectDef<Human> = Define.Object<Human>(
     name = "Human",
     description = "A humanoid creature in the Star Wars universe.",
     isTypeOf = (fun o -> o :? Human),
-    fieldsFn = fun () -> [|
+    fieldsFn = fun () -> [
         Define.Field("id", String, "The id of the human.", fun _ h -> h.Id)
         Define.Field("name", Nullable String, "The name of the human.", fun _ h -> h.Name)
         Define.Field("friends", ListOf (Nullable CharacterType), "The friends of the human, or an empty list if they have none.",
@@ -118,25 +118,25 @@ and HumanType : ObjectDef<Human> = Define.Object<Human>(
                 |> List.map getCharacter 
                 |> List.toSeq)
         Define.Field("appearsIn", ListOf EpisodeType, "Which movies they appear in.", fun _ h -> upcast h.AppearsIn)
-        Define.Field("homePlanet", Nullable String, "The home planet of the human, or null if unknown.", fun _ h -> h.HomePlanet) |])
+        Define.Field("homePlanet", Nullable String, "The home planet of the human, or null if unknown.", fun _ h -> h.HomePlanet) ])
         
 and DroidType = Define.Object<Droid>(
     name = "Droid",
     description = "A mechanical creature in the Star Wars universe.",
     isTypeOf = (fun o -> o :? Droid),
-    fieldsFn = fun () -> [|
+    fieldsFn = fun () -> [
         Define.Field("id", String, "The id of the droid.", fun _ d -> d.Id)
         Define.Field("name", Nullable String, "The name of the Droid.", fun _ d -> d.Name)
         Define.Field("friends", ListOf (Nullable CharacterType), "The friends of the Droid, or an empty list if they have none.", 
             fun ctx d -> d.Friends |> List.map getCharacter |> List.toSeq)
         Define.Field("appearsIn", ListOf EpisodeType, "Which movies they appear in.", fun _ d -> upcast d.AppearsIn)
-        Define.Field("primaryFunction", Nullable String, "The primary function of the droid.", fun _ d -> d.PrimaryFunction) |])
+        Define.Field("primaryFunction", Nullable String, "The primary function of the droid.", fun _ d -> d.PrimaryFunction) ])
 
 let Query = Define.Object(
     name = "Query",
-    fields = [|
-        Define.Field("hero", Nullable HumanType, "Gets human hero", [| Define.Input("id", String) |], fun ctx () -> getHuman (ctx.Arg("id").Value))
-        Define.Field("droid", Nullable DroidType, "Gets droid", [| Define.Input("id", String) |], fun ctx () -> getDroid (ctx.Arg("id").Value)) |])
+    fields = [
+        Define.Field("hero", Nullable HumanType, "Gets human hero", [ Define.Input("id", String) ], fun ctx () -> getHuman (ctx.Arg("id").Value))
+        Define.Field("droid", Nullable DroidType, "Gets droid", [ Define.Input("id", String) ], fun ctx () -> getDroid (ctx.Arg("id").Value)) ])
 
 let schema = Schema(Query)
 

--- a/src/FSharp.Data.GraphQL.Relay/Connections.fs
+++ b/src/FSharp.Data.GraphQL.Relay/Connections.fs
@@ -56,12 +56,12 @@ module Definitions =
     let PageInfo = Define.Object<PageInfo>(
         name = "PageInfo",
         description = "Information about pagination in a connection.",
-        fields = [|
+        fields = [
             Define.Field("hasNextPage", Boolean, "When paginating forwards, are there more items?", fun _ pageInfo -> pageInfo.HasNextPage)
             Define.Field("hasPreviousPage", Boolean, "When paginating backwards, are there more items?", fun _ pageInfo -> pageInfo.HasPreviousPage)
             Define.Field("startCursor", Nullable String, "When paginating backwards, the cursor to continue.", fun _ pageInfo -> pageInfo.StartCursor)
             Define.Field("endCursor", Nullable String, "When paginating forwards, the cursor to continue.", fun _ pageInfo -> pageInfo.EndCursor)
-        |])
+        ])
     
     /// Converts existing output type defintion into an edge in a Relay connection.
     /// <paramref name="nodeType"/> must not be a List.
@@ -72,9 +72,9 @@ module Definitions =
             Define.Object<Edge<'Node>>(
                 name = n.Name + "Edge",
                 description = "An edge in a connection from an object to another object of type " + n.Name,
-                fields = [|
+                fields = [
                     Define.Field("cursor", String, "A cursor for use in pagination", fun _ edge -> edge.Cursor)
-                    Define.Field("node", nodeType, "The item at the end of the edge. Must NOT be an enumerable collection.", fun _ edge -> edge.Node) |]) 
+                    Define.Field("node", nodeType, "The item at the end of the edge. Must NOT be an enumerable collection.", fun _ edge -> edge.Node) ]) 
     
     /// Converts existing output type definition into Relay-compatible connection.
     /// <paramref name="nodeType"/> must not be a List.
@@ -83,23 +83,23 @@ module Definitions =
         Define.Object<Connection<'Node>>(
             name = n.Name + "Connection",
             description = "A connection from an object to a list of objects of type " + n.Name,
-            fields = [|
+            fields = [
                 Define.Field("totalCount", Nullable Int, """A count of the total number of objects in this connection, ignoring pagination. This allows a client to fetch the first five objects by passing \"5\" as the argument to `first`, then fetch the total count so it could display \"5 of 83\", for example. In cases where we employ infinite scrolling or don't have an exact count of entries, this field will return `null`.""", fun _ conn -> conn.TotalCount)
                 Define.Field("pageInfo", PageInfo, "Information to aid in pagination.", fun _ conn -> conn.PageInfo)
-                Define.Field("edges", ListOf(EdgeOf nodeType), "Information to aid in pagination.", fun _ conn -> conn.Edges)|])
+                Define.Field("edges", ListOf(EdgeOf nodeType), "Information to aid in pagination.", fun _ conn -> conn.Edges)])
 
 [<RequireQualifiedAccess>]
 module Connection =
 
-    let forwardArgs = [| 
+    let forwardArgs = [ 
         Define.Input("first", Nullable Int)
-        Define.Input("after", Nullable String) |]
+        Define.Input("after", Nullable String) ]
     
-    let backwardArgs = [| 
+    let backwardArgs = [ 
         Define.Input("last", Nullable Int)
-        Define.Input("before", Nullable String) |]
+        Define.Input("before", Nullable String) ]
     
-    let allArgs = Array.append forwardArgs backwardArgs
+    let allArgs = forwardArgs @ backwardArgs
     
     let ofArraySlice meta (SliceInfo args) (array: 't []) = 
         let startOffset, endOffset =

--- a/src/FSharp.Data.GraphQL.Relay/Node.fs
+++ b/src/FSharp.Data.GraphQL.Relay/Node.fs
@@ -60,7 +60,7 @@ module GlobalId =
                 name = "node",
                 typedef = Nullable nodeDef,
                 description = "Fetches an object given its ID",
-                args = [| Define.Input("id", ID, description = "Identifier of an object") |],
+                args = [ Define.Input("id", ID, description = "Identifier of an object") ],
                 resolve = fun ctx value -> 
                     let id = ctx.Arg("id")
                     resolve ctx value id)
@@ -68,6 +68,6 @@ module GlobalId =
         static member Node (possibleTypes: unit -> ObjectDef list) = Define.Interface(
             name = "Node",
             description = "An object that can be uniquely identified by its id",
-            fields = [| Define.Field("id", ID) |],
+            fields = [ Define.Field("id", ID) ],
             resolveType = resolveTypeFun possibleTypes)
         

--- a/src/FSharp.Data.GraphQL/Execution.fs
+++ b/src/FSharp.Data.GraphQL/Execution.fs
@@ -268,13 +268,13 @@ let TypeMetaFieldDef = Define.Field(
     name = "__type",
     description = "Request the type information of a single type.",
     typedef = __Type,
-    args = [|
+    args = [
         { Name = "name"
           Description = None
           Type = String
           DefaultValue = None
           ExecuteInput = variableOrElse(coerceStringInput >> Option.map box >> Option.toObj) }
-    |],
+    ],
     resolve = fun ctx (_:obj) -> 
         ctx.Schema.Introspected.Types 
         |> Seq.find (fun t -> t.Name = ctx.Arg("name")) 

--- a/src/FSharp.Data.GraphQL/Introspection.fs
+++ b/src/FSharp.Data.GraphQL/Introspection.fs
@@ -90,7 +90,7 @@ let introspectionQuery = """query IntrospectionQuery {
 let __TypeKind = Define.Enum(
     name = "__TypeKind", 
     description = "An enum describing what kind of type a given __Type is.",
-    options = [|
+    options = [
         Define.EnumValue("SCALAR", TypeKind.SCALAR, "Indicates this type is a scalar.")
         Define.EnumValue("OBJECT", TypeKind.OBJECT, "Indicates this type is an object. `fields` and `interfaces` are valid fields.")
         Define.EnumValue("INTERFACE", TypeKind.INTERFACE, "Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.")
@@ -99,12 +99,12 @@ let __TypeKind = Define.Enum(
         Define.EnumValue("INPUT_OBJECT", TypeKind.INPUT_OBJECT, "Indicates this type is an input object. `inputFields` is a valid field.")
         Define.EnumValue("LIST", TypeKind.LIST, "Indicates this type is a list. `ofType` is a valid field.")
         Define.EnumValue("NON_NULL", TypeKind.NON_NULL, "Indicates this type is a non-null. `ofType` is a valid field.")
-    |])
+    ])
 
 let __DirectiveLocation = Define.Enum(
     name = "__DirectiveLocation",
     description = "A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies.",
-    options = [|
+    options = [
         Define.EnumValue("QUERY", DirectiveLocation.QUERY, "Location adjacent to a query operation.")
         Define.EnumValue("MUTATION", DirectiveLocation.MUTATION, "Location adjacent to a mutation operation.")
         Define.EnumValue("SUBSCRIPTION", DirectiveLocation.SUBSCRIPTION, "Location adjacent to a subscription operation.")
@@ -112,19 +112,19 @@ let __DirectiveLocation = Define.Enum(
         Define.EnumValue("FRAGMENT_DEFINITION", DirectiveLocation.FRAGMENT_DEFINITION, "Location adjacent to a fragment definition.")
         Define.EnumValue("FRAGMENT_SPREAD", DirectiveLocation.FRAGMENT_SPREAD, "Location adjacent to a fragment spread.")
         Define.EnumValue("INLINE_FRAGMENT", DirectiveLocation.INLINE_FRAGMENT, "Location adjacent to an inline fragment.")
-    |])
+    ])
     
 let inline private findIntrospected (ctx: ResolveFieldContext) name = ctx.Schema.Introspected.Types |> Seq.find (fun x -> x.Name = name)
 
 let rec __Type = Define.Object<IntrospectionTypeRef>(
     name = "__Type",
     description = """The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum. Depending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.""",
-    fieldsFn = fun () -> [|
+    fieldsFn = fun () -> [
         Define.Field("kind", __TypeKind, fun _ t -> t.Kind)
         Define.Field("name", Nullable String, resolve = fun _ t -> t.Name)
         Define.Field("description", Nullable String, fun _ t -> t.Description)
         Define.Field("fields", Nullable (ListOf __Field), description = null,
-            args = [| Define.Input("includeDeprecated", Boolean, false) |],
+            args = [Define.Input("includeDeprecated", Boolean, false) ],
             resolve = fun ctx t ->
                 match t.Name with
                 | None -> None
@@ -146,7 +146,7 @@ let rec __Type = Define.Object<IntrospectionTypeRef>(
                 let found = findIntrospected ctx name
                 found.PossibleTypes |> Option.map Array.toSeq)
         Define.Field("enumValues", Nullable (ListOf __EnumValue), description = null,
-            args = [| Define.Input("includeDeprecated", Boolean, false) |], resolve = fun ctx t ->
+            args = [Define.Input("includeDeprecated", Boolean, false) ], resolve = fun ctx t ->
             match t.Name with 
             | None -> None
             | Some name ->
@@ -161,44 +161,44 @@ let rec __Type = Define.Object<IntrospectionTypeRef>(
                 let found = findIntrospected ctx name
                 found.InputFields |> Option.map Array.toSeq)
         Define.Field("ofType", Nullable __Type, resolve = fun _ t -> t.OfType)
-    |])
+    ])
    
 and __InputValue = Define.Object<IntrospectionInputVal>(
     name = "__InputValue",
     description = "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.",
-    fieldsFn = fun () -> [|
+    fieldsFn = fun () -> [
         Define.Field("name", String, fun _ f -> f.Name)
         Define.Field("description", Nullable String, fun _ f -> f.Description)
         Define.Field("type", __Type, fun _ f -> f.Type)
         Define.Field("defaultValue", Nullable String, fun _ f -> f.DefaultValue)
-    |])
+    ])
     
 and __Field = Define.Object<IntrospectionField>(
     name = "__Field",
     description = "Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.",
-    fieldsFn = fun () -> [|
+    fieldsFn = fun () -> [
         Define.Field("name", String, fun _ f -> f.Name)
         Define.Field("description", Nullable String, fun _ f -> f.Description)
         Define.Field("args", ListOf __InputValue, fun _ f -> upcast f.Args)
         Define.Field("type", __Type, fun _ f -> f.Type)
         Define.Field("isDeprecated", Boolean, resolve = fun _ f -> f.IsDeprecated)
         Define.Field("deprecationReason", Nullable String, fun _ f -> f.DeprecationReason)
-    |])
+    ])
     
 and __EnumValue = Define.Object<IntrospectionEnumVal>(
     name = "__EnumValue",
     description = "One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.",
-    fieldsFn = fun () -> [|
+    fieldsFn = fun () -> [
         Define.Field("name", String, fun _ e -> e.Name)
         Define.Field("description", Nullable String, fun _ e -> e.Description)
         Define.Field("isDeprecated", Boolean, fun _ e -> Option.isSome e.DeprecationReason)
         Define.Field("deprecationReason", Nullable String, fun _ e -> e.DeprecationReason)
-    |])
+    ])
 
 and __Directive = Define.Object<IntrospectionDirective>(
     name = "__Directive",
     description = """A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document. In some cases, you need to provide options to alter GraphQL’s execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.""",
-    fieldsFn = fun () -> [|
+    fieldsFn = fun () -> [
         Define.Field("name", String, fun _ directive -> directive.Name)
         Define.Field("description", Nullable String, fun _ directive -> directive.Description)
         Define.Field("locations", ListOf __DirectiveLocation, resolve = fun _ directive -> upcast directive.Locations)
@@ -206,15 +206,15 @@ and __Directive = Define.Object<IntrospectionDirective>(
         Define.Field("onOperation", Boolean, resolve = fun _ d -> d.Locations |> Seq.exists (fun l -> l.HasFlag(DirectiveLocation.QUERY ||| DirectiveLocation.MUTATION ||| DirectiveLocation.SUBSCRIPTION)))
         Define.Field("onFragment", Boolean, resolve = fun _ d -> d.Locations |> Seq.exists (fun l -> l.HasFlag(DirectiveLocation.FRAGMENT_SPREAD ||| DirectiveLocation.INLINE_FRAGMENT ||| DirectiveLocation.FRAGMENT_DEFINITION)))
         Define.Field("onField", Boolean, resolve = fun _ d -> d.Locations |> Seq.exists (fun l -> l.HasFlag(DirectiveLocation.FIELD)))
-    |])
+    ])
     
 and __Schema = Define.Object<IntrospectionSchema>(
     name = "__Schema",
     description = "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.",
-    fieldsFn = fun () -> [|
+    fieldsFn = fun () -> [
         Define.Field("types", ListOf __Type, description = "A list of all types supported by this server.", resolve = fun _ schema -> upcast (schema.Types |> Array.map IntrospectionTypeRef.Named))
         Define.Field("queryType", __Type, description = "The type that query operations will be rooted at.", resolve = fun _ schema -> schema.QueryType)
         Define.Field("mutationType", Nullable __Type, description = "If this server supports mutation, the type that mutation operations will be rooted at.", resolve = fun _ schema -> schema.MutationType)
         Define.Field("subscriptionType", Nullable __Type, description = "If this server support subscription, the type that subscription operations will be rooted at.", resolve = fun _ _ -> None)
         Define.Field("directives", ListOf __Directive, description = "A list of all directives supported by this server.", resolve = fun _  schema -> upcast schema.Directives)
-    |])
+    ])

--- a/tests/FSharp.Data.GraphQL.Benchmarks/ExecutionBenchmark.fs
+++ b/tests/FSharp.Data.GraphQL.Benchmarks/ExecutionBenchmark.fs
@@ -42,17 +42,17 @@ let getPerson id = humans |> List.tryFind (fun h -> h.Id = id)
 let rec Person = Define.Object(
     name = "Person",
     isTypeOf = (fun o -> o :? Person),
-    fieldsFn = fun() -> [|
+    fieldsFn = fun() -> [
         Define.Field("id", String, resolve = fun _ person -> person.Id)
         Define.Field("name", Nullable String, resolve = fun _ person -> person.Name)
         Define.Field("friends", Nullable (ListOf (Nullable Person)), resolve = fun _ person -> person.Friends |> List.map getPerson |> List.toSeq |> Some)
-        Define.Field("homePlanet", String) |])
+        Define.Field("homePlanet", String) ])
 
 let Query = Define.Object(
     name = "Query",
-    fields = [|
-        Define.Field("hero", Nullable Person, "Retrieves a person by provided id", [| Define.Input("id", String) |], fun ctx () -> getPerson (ctx.Arg("id")))
-    |])
+    fields = [
+        Define.Field("hero", Nullable Person, "Retrieves a person by provided id", [ Define.Input("id", String) ], fun ctx () -> getPerson (ctx.Arg("id")))
+    ])
 
 let schema = Schema(Query)
 

--- a/tests/FSharp.Data.GraphQL.Tests/AbstractionTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/AbstractionTests.fs
@@ -38,27 +38,27 @@ let resolvePet = function
 
 [<Fact>]
 let ``Execute handles execution of abstract types: isTypeOf is used to resolve runtime type for Interface`` () = 
-    let PetType = Define.Interface("Pet", fun () -> [| Define.Field("name", String) |])
+    let PetType = Define.Interface("Pet", fun () -> [ Define.Field("name", String) ])
     let DogType = Define.Object<Dog>(
         name = "Dog", 
         isTypeOf = is<Dog>,
-        interfaces = [| PetType |],
-        fields = [|
+        interfaces = [ PetType ],
+        fields = [
             Define.Field("name", String)
             Define.Field("woofs", Boolean)
-        |])
+        ])
     let CatType = Define.Object<Cat>(
         name = "Cat", 
         isTypeOf = is<Cat>,
-        interfaces = [| PetType |],
-        fields = [|
+        interfaces = [ PetType ],
+        fields = [
             Define.Field("name", String)
             Define.Field("meows", Boolean)
-        |])
+        ])
     let schema = Schema(
-        query = Define.Object("Query", fun () -> [|
+        query = Define.Object("Query", fun () -> [
             Define.Field("pets", ListOf PetType, fun _ _ -> upcast [ { Name = "Odie"; Woofs = true } :> IPet ; upcast { Name = "Garfield"; Meows = false } ])
-        |]), 
+        ]), 
         config = { SchemaConfig.Default with Types = [CatType; DogType] })
     let query = """{
       pets {
@@ -88,22 +88,22 @@ let ``Execute handles execution of abstract types: isTypeOf is used to resolve r
     let DogType = Define.Object<Dog>(
         name = "Dog", 
         isTypeOf = is<Dog>,
-        fields = [|
+        fields = [
             Define.Field("name", String)
             Define.Field("woofs", Boolean)
-        |])
+        ])
     let CatType = Define.Object<Cat>(
         name = "Cat", 
         isTypeOf = is<Cat>,
-        fields = [|
+        fields = [
             Define.Field("name", String)
             Define.Field("meows", Boolean)
-        |])
-    let PetType = Define.Union("Pet", [| DogType; CatType |], resolvePet)
+        ])
+    let PetType = Define.Union("Pet", [ DogType; CatType ], resolvePet)
     let schema = Schema(
-        query = Define.Object("Query", fun () -> [|
+        query = Define.Object("Query", fun () -> [
             Define.Field("pets", ListOf PetType, fun _ _ -> upcast [ DogCase { Name = "Odie"; Woofs = true }; CatCase { Name = "Garfield"; Meows = false } ])
-        |]))
+        ]))
     let query = """{
       pets {
         ... on Dog {

--- a/tests/FSharp.Data.GraphQL.Tests/DirectivesTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/DirectivesTests.fs
@@ -14,10 +14,10 @@ open FSharp.Data.GraphQL.Execution
 type Data = { A: string; B: string }
 let data = { A = "a"; B = "b" }
 
-let schema = Schema(Define.Object("TestType", [|
+let schema = Schema(Define.Object("TestType", [
     Define.Field("a", String)
     Define.Field("b", String)
-|]))
+]))
 
 let private execAndCompare query expected =
     let actual = sync <| schema.AsyncExecute(parse query, data)

--- a/tests/FSharp.Data.GraphQL.Tests/ExecutionTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/ExecutionTests.fs
@@ -90,21 +90,21 @@ let ``Execution handles basic tasks: executes arbitrary code`` () =
             ] 
         ]
 
-    let DeepDataType = Define.Object<DeepTestSubject>("DeepDataType", [|
+    let DeepDataType = Define.Object<DeepTestSubject>("DeepDataType", [
         Define.Field("a", String, (fun _ dt -> dt.a))
         Define.Field("b", String, (fun _ dt -> dt.b))
         Define.Field("c", (ListOf String), (fun _ dt -> upcast dt.c))
-    |])
-    let DataType = Define.Object<TestSubject>("DataType", fields = [|
+    ])
+    let DataType = Define.Object<TestSubject>("DataType", fields = [
         Define.Field("a", String, fun _ dt -> dt.a)
         Define.Field("b", String, fun _ dt -> dt.b)
         Define.Field("c", String, fun _ dt -> dt.c)
         Define.Field("d", String, fun _ dt -> dt.d)
         Define.Field("e", String, fun _ dt -> dt.e)
         Define.Field("f", String, fun _ dt -> dt.f)
-        Define.Field("pic", String, "Picture resizer", [| Define.Input("size", Nullable Int) |], fun ctx dt -> dt.pic(ctx.Arg("size")))
+        Define.Field("pic", String, "Picture resizer", [ Define.Input("size", Nullable Int) ], fun ctx dt -> dt.pic(ctx.Arg("size")))
         Define.Field("deep", DeepDataType, fun _ dt -> dt.deep) 
-    |])
+    ])
 
     let schema = Schema(DataType)
     let result = sync <| schema.AsyncExecute(ast, data, variables = Map.ofList [ "size", 100 :> obj], operationName = "Example")
@@ -129,12 +129,12 @@ let ``Execution handles basic tasks: merges parallel fragments`` () =
 
     let rec Type = Define.Object(
         name = "Type", 
-        fieldsFn = fun () -> [|
+        fieldsFn = fun () -> [
             Define.Field("a", String, fun _ _ -> "Apple")
             Define.Field("b", String, fun _ _ -> "Banana")
             Define.Field("c", String, fun _ _ -> "Cherry")
             Define.Field("deep", Type, fun _ v -> v)
-        |])
+        ])
 
     let schema = Schema(Type)
     let expected = NameValueLookup.ofList [
@@ -159,9 +159,9 @@ let ``Execution handles basic tasks: threads root value context correctly`` () =
     let query = "query Example { a }"
     let data = { Thing = "thing" }
     let mutable resolved = {Thing = ""};
-    let Thing = Define.Object<TestThing>("Type", [|
+    let Thing = Define.Object<TestThing>("Type", [
         Define.Field("a", String, fun _ _ -> resolved <- data; resolved.Thing)
-    |])
+    ])
     let result = sync <| Schema(Thing).AsyncExecute(parse query, data)
     noErrors result
     equals "thing" resolved.Thing
@@ -173,13 +173,13 @@ let ``Execution handles basic tasks: correctly threads arguments`` () =
       }"""
     let mutable numArg = None;
     let mutable stringArg = None;
-    let Type = Define.Object("Type", [|
-        Define.Field("b", Nullable String, "", [| Define.Input("numArg", Int); Define.Input("stringArg", String) |], 
+    let Type = Define.Object("Type", [
+        Define.Field("b", Nullable String, "", [ Define.Input("numArg", Int); Define.Input("stringArg", String) ], 
             fun ctx _ -> 
                 numArg <- ctx.TryArg("numArg")
                 stringArg <- ctx.TryArg("stringArg")
                 stringArg) 
-    |])
+    ])
 
     let result = sync <| Schema(Type).AsyncExecute(parse query, ())
     noErrors result
@@ -190,27 +190,27 @@ type InlineTest = { A: string }
 
 [<Fact>]
 let ``Execution handles basic tasks: uses the inline operation if no operation name is provided`` () =
-    let schema =  Schema(Define.Object<InlineTest>("Type", [|
+    let schema =  Schema(Define.Object<InlineTest>("Type", [
         Define.Field("a", String, fun _ x -> x.A)
-    |]))
+    ]))
     let result = sync <| schema.AsyncExecute(parse "{ a }", { A = "b" })
     noErrors result
     result.["data"] |> equals (upcast NameValueLookup.ofList ["a", "b" :> obj]) 
     
 [<Fact>]
 let ``Execution handles basic tasks: uses the only operation if no operation name is provided`` () =
-    let schema =  Schema(Define.Object<InlineTest>("Type", [|
+    let schema =  Schema(Define.Object<InlineTest>("Type", [
         Define.Field("a", String, fun _ x -> x.A)
-    |]))
+    ]))
     let result = sync <| schema.AsyncExecute(parse "query Example { a }", { A = "b" })
     noErrors result
     result.["data"] |> equals (upcast NameValueLookup.ofList ["a", "b" :> obj])
     
 [<Fact>]
 let ``Execution handles basic tasks: uses the named operation if operation name is provided`` () =
-    let schema =  Schema(Define.Object<InlineTest>("Type", [|
+    let schema =  Schema(Define.Object<InlineTest>("Type", [
         Define.Field("a", String, fun _ x -> x.A)
-    |]))
+    ]))
     let query = "query Example { first: a } query OtherExample { second: a }"
     let result = sync <| schema.AsyncExecute(parse query, { A = "b" }, operationName = "OtherExample")
     noErrors result
@@ -220,10 +220,10 @@ type TwiceTest = { A : string; B : int }
 
 [<Fact>]
 let ``Execution when querying the same field twice will return it`` () =
-    let schema = Schema(Define.Object<TwiceTest>("Type", [|
+    let schema = Schema(Define.Object<TwiceTest>("Type", [
         Define.Field("a", String, fun _ x -> x.A)
         Define.Field("b", Int, fun _ x -> x.B)
-    |]))
+    ]))
     let query = "query Example { a, b, a }"
     let result = sync <| schema.AsyncExecute(query, { A = "aa"; B = 2 });
     let expected = NameValueLookup.ofList [

--- a/tests/FSharp.Data.GraphQL.Tests/IntrospectionTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/IntrospectionTests.fs
@@ -14,8 +14,8 @@ open FSharp.Data.GraphQL.Client
 
 [<Fact(Skip="FIXME: investigate reason of failure")>]
 let ``Introspection schema should be serializable back and forth using json`` () =
-    let root = Define.Object("Query", [|
-        Define.Field("onlyField", String) |])
+    let root = Define.Object("Query", [
+        Define.Field("onlyField", String) ])
     let schema = Schema(root)
     let introResult = schema.AsyncExecute(Introspection.introspectionQuery) |> sync
     let json = Client.Serialization.toJson introResult
@@ -24,8 +24,8 @@ let ``Introspection schema should be serializable back and forth using json`` ()
 
 [<Fact>]
 let ``Core type definitions are considered nullable`` () =
-    let root = Define.Object("Query", [|
-        Define.Field("onlyField", String) |])
+    let root = Define.Object("Query", [
+        Define.Field("onlyField", String) ])
     let schema = Schema(root)
     let query = """{ __type(name: "String") {
       kind
@@ -54,8 +54,8 @@ let ``Core type definitions are considered nullable`` () =
     
 [<Fact>]
 let ``Default field type definitions are considered non-null`` () =
-    let root = Define.Object("Query", [|
-        Define.Field("onlyField", String) |])
+    let root = Define.Object("Query", [
+        Define.Field("onlyField", String) ])
     let schema = Schema(root)
     let query = """{ __type(name: "Query") {
       fields {
@@ -96,8 +96,8 @@ let ``Default field type definitions are considered non-null`` () =
     
 [<Fact>]
 let ``Nullabe field type definitions are considered nullable`` () =
-    let root = Define.Object("Query", [|
-        Define.Field("onlyField", Nullable String) |])
+    let root = Define.Object("Query", [
+        Define.Field("onlyField", Nullable String) ])
     let schema = Schema(root)
     let query = """{ __type(name: "Query") {
       fields {
@@ -135,8 +135,8 @@ let ``Nullabe field type definitions are considered nullable`` () =
     
 [<Fact>]
 let ``Default field args type definitions are considered non-null`` () =
-    let root = Define.Object("Query", [|
-        Define.Field("onlyField", String, "", [| Define.Input("onlyArg", Int) |], fun _ () -> null) |])
+    let root = Define.Object("Query", [
+        Define.Field("onlyField", String, "", [ Define.Input("onlyArg", Int) ], fun _ () -> null) ])
     let schema = Schema(root)
     let query = """{ __type(name: "Query") {
       fields {
@@ -181,8 +181,8 @@ let ``Default field args type definitions are considered non-null`` () =
     
 [<Fact>]
 let ``Nullable field args type definitions are considered nullable`` () =
-    let root = Define.Object("Query", [|
-        Define.Field("onlyField", String, "", [| Define.Input("onlyArg", Nullable Int) |], fun _ () -> null) |])
+    let root = Define.Object("Query", [
+        Define.Field("onlyField", String, "", [ Define.Input("onlyArg", Nullable Int) ], fun _ () -> null) ])
     let schema = Schema(root)
     let query = """{ __type(name: "Query") {
       fields {
@@ -224,9 +224,9 @@ let ``Nullable field args type definitions are considered nullable`` () =
 
 [<Fact(Skip = "Investigate and fix the test, introspeciton is already working")>]
 let ``Introspection executes an introspection query`` () =
-    let root = Define.Object("QueryRoot", [|
+    let root = Define.Object("QueryRoot", [
         Define.Field("onlyField", String)
-    |])
+    ])
     let schema = Schema(root)
     let (Object raw) = root
     let result = sync <| schema.AsyncExecute(parse Introspection.introspectionQuery, raw)

--- a/tests/FSharp.Data.GraphQL.Tests/MutationTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/MutationTests.fs
@@ -31,15 +31,15 @@ type Root =
             return failwith "Cannot change number"
         }
 
-let NumberHolder = Define.Object("NumberHolder", [| Define.Field("theNumber", Int, fun _ x -> x.Number) |])
+let NumberHolder = Define.Object("NumberHolder", [ Define.Field("theNumber", Int, fun _ x -> x.Number) ])
 let schema = Schema(
-    query = Define.Object("Query", [| Define.Field("numberHolder", NumberHolder, fun _ x -> x.NumberHolder) |]),
-    mutation = Define.Object("Mutation", [|
-        Define.Field("immediatelyChangeTheNumber", NumberHolder, "", [| Define.Input("newNumber", Int) |], fun ctx (x:Root) -> x.ChangeImmediatelly(ctx.Arg("newNumber")))
-        Define.AsyncField("promiseToChangeTheNumber", NumberHolder, "", [| Define.Input("newNumber", Int) |], fun ctx (x:Root) -> x.AsyncChange(ctx.Arg("newNumber")))
-        Define.Field("failToChangeTheNumber", NumberHolder, "", [| Define.Input("newNumber", Int) |], fun ctx (x:Root) -> x.ChangeFail(ctx.Arg("newNumber")))
-        Define.AsyncField("promiseAndFailToChangeTheNumber", NumberHolder, "", [| Define.Input("newNumber", Int) |], fun ctx (x:Root) -> x.AsyncChangeFail(ctx.Arg("newNumber")))
-    |]))
+    query = Define.Object("Query", [ Define.Field("numberHolder", NumberHolder, fun _ x -> x.NumberHolder) ]),
+    mutation = Define.Object("Mutation", [
+        Define.Field("immediatelyChangeTheNumber", NumberHolder, "", [ Define.Input("newNumber", Int) ], fun ctx (x:Root) -> x.ChangeImmediatelly(ctx.Arg("newNumber")))
+        Define.AsyncField("promiseToChangeTheNumber", NumberHolder, "", [ Define.Input("newNumber", Int) ], fun ctx (x:Root) -> x.AsyncChange(ctx.Arg("newNumber")))
+        Define.Field("failToChangeTheNumber", NumberHolder, "", [ Define.Input("newNumber", Int) ], fun ctx (x:Root) -> x.ChangeFail(ctx.Arg("newNumber")))
+        Define.AsyncField("promiseAndFailToChangeTheNumber", NumberHolder, "", [ Define.Input("newNumber", Int) ], fun ctx (x:Root) -> x.AsyncChangeFail(ctx.Arg("newNumber")))
+    ]))
 
 [<Fact>]
 let ``Execute handles mutation execution ordering: evaluates mutations serially`` () =

--- a/tests/FSharp.Data.GraphQL.Tests/Relay/ConnectionTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/Relay/ConnectionTests.fs
@@ -68,25 +68,25 @@ let petName = function
     | Cat (name, _) -> name
     | Dog (name, _) -> name
 
-let Cat = Define.Object("Cat", [|
+let Cat = Define.Object("Cat", [
     Define.Field("name", String, fun _ (Cat(name, _)) -> name)
-    Define.Field("meows", Boolean, fun _ (Cat(_, meows)) -> meows) |])
+    Define.Field("meows", Boolean, fun _ (Cat(_, meows)) -> meows) ])
 
-let Dog = Define.Object("Dog", [|
+let Dog = Define.Object("Dog", [
     Define.Field("name", String, fun _ (Dog(name, _)) -> name)
-    Define.Field("barks", Boolean, fun _ (Dog(_, barks)) -> barks) |])
+    Define.Field("barks", Boolean, fun _ (Dog(_, barks)) -> barks) ])
 
-let Pet = Define.Union("Pet", [| Dog; Cat |], id<Pet>, fun pet ->
+let Pet = Define.Union("Pet", [ Dog; Cat ], id<Pet>, fun pet ->
     match pet with
     | Cat _ -> upcast Cat
     | Dog _ -> upcast Dog)
 
-let Human = Define.Object("Human", [|
+let Human = Define.Object("Human", [
     Define.Field("name", String, fun _ human -> human.Name)
-    Define.Field("pets",  ConnectionOf Pet, "", Connection.forwardArgs, fun ctx human -> resolveSlice petName (human.Pets) ctx ()) |])
+    Define.Field("pets",  ConnectionOf Pet, "", Connection.forwardArgs, fun ctx human -> resolveSlice petName (human.Pets) ctx ()) ])
     
 let strings = ["one"; "two"; "three"; "four"; "five"]
-let Query = Define.Object("Query", [|
+let Query = Define.Object("Query", [
     Define.Field(
         name = "strings", 
         description = "",
@@ -98,7 +98,7 @@ let Query = Define.Object("Query", [|
         description = "",
         typedef = ConnectionOf Human, 
         args = Connection.forwardArgs, 
-        resolve = resolveSlice humanName people) |])
+        resolve = resolveSlice humanName people) ])
 
 let schema = Schema(Query, config = { SchemaConfig.Default with Types = [ Pet; Human ]})
 

--- a/tests/FSharp.Data.GraphQL.Tests/Relay/NodeTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/Relay/NodeTests.fs
@@ -23,18 +23,18 @@ let cars = [
 
 let rec Person = Define.Object<Person>(
     name = "Person",
-    interfaces = [| Node |],
-    fields = [|
+    interfaces = [ Node ],
+    fields = [
         Define.Field("id", ID, fun _ person -> toGlobalId "person" person.Id)
         Define.Field("name", String, fun _ person -> person.Name)
-        Define.Field("age", Int, fun _ person -> person.Age) |])
+        Define.Field("age", Int, fun _ person -> person.Age) ])
 
 and Car = Define.Object<Car>(
     name = "Car",
-    interfaces = [| Node |],
-    fields = [|
+    interfaces = [ Node ],
+    fields = [
         Define.Field("id", ID, fun _ car -> toGlobalId "car" car.Id)
-        Define.Field("model", String, fun _ car -> car.Model) |])
+        Define.Field("model", String, fun _ car -> car.Model) ])
 
 and resolve _ _ id =
     match id with
@@ -43,7 +43,7 @@ and resolve _ _ id =
 
 and Node = Define.Node (fun () -> [ Person; Car ])
 
-let schema = Schema(Define.Object("Query", [| Define.NodeField(Node, resolve) |]), config = { SchemaConfig.Default with Types = [ Person; Car ] })
+let schema = Schema<unit>(Define.Object("Query", [ Define.NodeField(Node, resolve) ]), config = { SchemaConfig.Default with Types = [ Person; Car ] })
 
 open Xunit
 

--- a/tests/FSharp.Data.GraphQL.Tests/ResolveTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/ResolveTests.fs
@@ -19,7 +19,7 @@ let testSchema testFields = Schema(Define.Object("Query", fields = testFields))
 
 [<Fact>]
 let ``Execute uses default resolve to accesses properties`` () =
-    let schema = testSchema [| Define.Field("test", String) |]
+    let schema = testSchema [ Define.Field("test", String) ]
     let expected = NameValueLookup.ofList [ "test", "testValue" :> obj ]
     let actual = sync <| schema.AsyncExecute(parse "{ test }", { Test = "testValue" })
     noErrors actual
@@ -27,8 +27,8 @@ let ``Execute uses default resolve to accesses properties`` () =
             
 [<Fact>]
 let ``Execute uses provided resolve function to accesses properties`` () =
-    let schema = testSchema [| 
-        Define.Field("test", String, "", [| Define.Input("a", String) |], resolve = fun ctx d -> d.Test + ctx.Arg("a")) |]
+    let schema = testSchema [ 
+        Define.Field("test", String, "", [ Define.Input("a", String) ], resolve = fun ctx d -> d.Test + ctx.Arg("a")) ]
     let expected = NameValueLookup.ofList [ "test", "testValueString" :> obj ]
     let actual = sync <| schema.AsyncExecute(parse "{ test(a: \"String\") }", { Test = "testValue" })
     noErrors actual

--- a/tests/FSharp.Data.GraphQL.Tests/SchemaTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/SchemaTests.fs
@@ -11,19 +11,19 @@ open FSharp.Data.GraphQL.Types
 
 [<Fact>]
 let ``Object type should be able to merge fields with matching signatures from different interfaces`` () = 
-    let MovableType = Define.Interface("Movable", [|
+    let MovableType = Define.Interface("Movable", [
         Define.Field("speed", Int)
-    |])
-    let Movable2Type = Define.Interface("Movable2", [|
+    ])
+    let Movable2Type = Define.Interface("Movable2", [
         Define.Field("speed", Int)
         Define.Field("acceleration", Int)
-    |])
+    ])
     let PersonType = Define.Object(
         name = "Person",
-        interfaces = [| MovableType; Movable2Type |],
-        fields = [|
+        interfaces = [ MovableType; Movable2Type ],
+        fields = [
             Define.Field("name", String)
             Define.Field("speed", Int)
-            Define.Field("acceleration", Int) |])
-    equals [| MovableType :> InterfaceDef; upcast Movable2Type |] PersonType.Implements
-    equals [| Define.Field("name", String) :> FieldDef; upcast Define.Field("speed", Int); upcast Define.Field("acceleration", Int) |] ( PersonType :> ObjectDef).Fields
+            Define.Field("acceleration", Int) ])
+    equals [ MovableType :> InterfaceDef; upcast Movable2Type ] (PersonType.Implements |> Array.toList )
+    equals [ Define.Field("name", String) :> FieldDef; upcast Define.Field("speed", Int); upcast Define.Field("acceleration", Int) ] (( PersonType :> ObjectDef).Fields |> Array.toList)

--- a/tests/FSharp.Data.GraphQL.Tests/UnionInterfaceTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/UnionInterfaceTests.fs
@@ -39,29 +39,29 @@ type Person =
 
 let NamedType = Define.Interface<INamed>(
     name = "Named",
-    fields = [| Define.Field("name", String) |])
+    fields = [ Define.Field("name", String) ])
 
 let DogType = Define.Object<Dog>(
     name = "Dog",
     isTypeOf = is<Dog>,
-    interfaces = [| NamedType |],
-    fields = [|
+    interfaces = [ NamedType ],
+    fields = [
         Define.Field("name", String)
         Define.Field("barks", Boolean)
-    |])
+    ])
     
 let CatType = Define.Object<Cat>(
     name = "Cat",
     isTypeOf = is<Cat>,
-    interfaces = [| NamedType |],
-    fields = [|
+    interfaces = [ NamedType ],
+    fields = [
         Define.Field("name", String)
         Define.Field("meows", Boolean)
-    |])
+    ])
 
 let PetType = Define.Union(
     name = "Pet",
-    options = [| CatType; DogType |],
+    options = [ CatType; DogType ],
     resolveType = (fun pet ->
         match pet with
         | Cat _ -> upcast CatType
@@ -74,12 +74,12 @@ let PetType = Define.Union(
 let PersonType = Define.Object(
     name = "Person",
     isTypeOf = is<Person>,
-    interfaces = [| NamedType |],
-    fields = [|
+    interfaces = [ NamedType ],
+    fields = [
         Define.Field("name", String)
         Define.Field("pets", ListOf PetType, fun _ person -> upcast person.Pets)
         Define.Field("friends", ListOf NamedType)
-    |])
+    ])
 
 let schema = Schema(query = PersonType, config = { SchemaConfig.Default with Types = [ PetType ] })
 

--- a/tests/FSharp.Data.GraphQL.Tests/VariablesTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/VariablesTests.fs
@@ -27,12 +27,12 @@ type TestInput = {
 }
 let TestInputObject = Define.InputObject<TestInput>(
     name = "TestInputObject",
-    fields = [|
+    fields = [
         Define.Input("a", Nullable String)
         Define.Input("b", Nullable(ListOf (Nullable String)))
         Define.Input("c", String)
         Define.Input("d", Nullable TestComplexScalar)
-    |])
+    ])
 
 type TestNestedInput = {
     na: TestInput option
@@ -40,10 +40,10 @@ type TestNestedInput = {
 }
 let TestNestedInputObject = Define.InputObject<TestNestedInput>(
     name = "TestNestedInputObject",
-    fields = [|
+    fields = [
         Define.Input("na", Nullable TestInputObject)
         Define.Input("nb", String)
-    |])
+    ])
 
 let stringifyArg name (ctx: ResolveFieldContext) () =
     let arg = ctx.TryArg name |> Option.toObj
@@ -53,17 +53,17 @@ let stringifyInput = stringifyArg "input"
 
 let TestType = Define.Object<unit>(
     name = "TestType",
-    fields = [|
-        Define.Field("fieldWithObjectInput", String, "", [| Define.Input("input", Nullable TestInputObject) |], stringifyInput)
-        Define.Field("fieldWithNullableStringInput", String, "", [| Define.Input("input", Nullable String) |], stringifyInput)
-        Define.Field("fieldWithNonNullableStringInput", String, "", [| Define.Input("input", String) |], stringifyInput)
-        Define.Field("fieldWithDefaultArgumentValue", String, "", [| Define.Input("input", Nullable String, Some "hello world") |], stringifyInput)
-        Define.Field("fieldWithNestedInputObject", String, "", [| Define.Input("input", TestNestedInputObject, { na = None; nb = "hello world"}) |], stringifyInput)
-        Define.Field("list", String, "", [| Define.Input("input", Nullable(ListOf (Nullable String))) |], stringifyInput)
-        Define.Field("nnList", String, "", [| Define.Input("input", ListOf (Nullable String)) |], stringifyInput)
-        Define.Field("listNN", String, "", [| Define.Input("input", Nullable (ListOf String)) |], stringifyInput)
-        Define.Field("nnListNN", String, "", [| Define.Input("input", ListOf String) |], stringifyInput)
-    |])
+    fields = [
+        Define.Field("fieldWithObjectInput", String, "", [ Define.Input("input", Nullable TestInputObject) ], stringifyInput)
+        Define.Field("fieldWithNullableStringInput", String, "", [ Define.Input("input", Nullable String) ], stringifyInput)
+        Define.Field("fieldWithNonNullableStringInput", String, "", [ Define.Input("input", String) ], stringifyInput)
+        Define.Field("fieldWithDefaultArgumentValue", String, "", [ Define.Input("input", Nullable String, Some "hello world") ], stringifyInput)
+        Define.Field("fieldWithNestedInputObject", String, "", [ Define.Input("input", TestNestedInputObject, { na = None; nb = "hello world"}) ], stringifyInput)
+        Define.Field("list", String, "", [ Define.Input("input", Nullable(ListOf (Nullable String))) ], stringifyInput)
+        Define.Field("nnList", String, "", [ Define.Input("input", ListOf (Nullable String)) ], stringifyInput)
+        Define.Field("listNN", String, "", [ Define.Input("input", Nullable (ListOf String)) ], stringifyInput)
+        Define.Field("nnListNN", String, "", [ Define.Input("input", ListOf String) ], stringifyInput)
+    ])
 
 let schema = Schema(TestType)
 


### PR DESCRIPTION
This PR returns list-based field and argument initializes in `Define` module. Also `Schema` is not typed to provide statically typed root object constraint.
