### PR TITLE
WIP: Client Type Provider

### DIFF
--- a/FSharp.Data.GraphQL.sln
+++ b/FSharp.Data.GraphQL.sln
@@ -73,6 +73,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{DFA5AAFF
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FSharp.Data.GraphQL.Client", "src\FSharp.Data.GraphQL.Client\FSharp.Data.GraphQL.Client.fsproj", "{7C9CC625-FB4E-4215-9F7C-494AA6043821}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "client-provider", "client-provider", "{3D948D55-3CD2-496D-A04C-3B4E7BB69140}"
+	ProjectSection(SolutionItems) = preProject
+		samples\client-provider\query.fsx = samples\client-provider\query.fsx
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -134,5 +139,6 @@ Global
 		{9B25360F-2CE4-43D2-AFF0-5EAA693E98F7} = {B0C25450-74BF-40C2-9E02-09AADBAE2C2F}
 		{E7139F5F-22CA-4392-8C1C-481A39EEB554} = {9B25360F-2CE4-43D2-AFF0-5EAA693E98F7}
 		{DFA5AAFF-31B8-4203-822C-8ACC4D7A7D74} = {9B25360F-2CE4-43D2-AFF0-5EAA693E98F7}
+		{3D948D55-3CD2-496D-A04C-3B4E7BB69140} = {B0C25450-74BF-40C2-9E02-09AADBAE2C2F}
 	EndGlobalSection
 EndGlobal

--- a/samples/client-provider/query.fsx
+++ b/samples/client-provider/query.fsx
@@ -1,0 +1,10 @@
+﻿#r "../../src/FSharp.Data.GraphQL.Client/bin/Debug/FSharp.Data.GraphQL.Client.dll"
+
+open FSharp.Data.GraphQL
+
+let [<Literal>] serverUrl = "http://localhost:8083"
+let [<Literal>] query = "{ hero(id: \"1000\") { name } }"
+
+type MyClient = GraphQLProvider<serverUrl>
+
+MyClient.Query<query>() |> Async.RunSynchronously |> printfn "%A"

--- a/samples/client-provider/query.fsx
+++ b/samples/client-provider/query.fsx
@@ -6,7 +6,7 @@ open System.Collections.Generic
 let [<Literal>] serverUrl = "http://localhost:8083"
 
 // The name and arguments of the query will be automatically set by the type provider
-let [<Literal>] queryFields = "{ id, name, friends { name } }"
+let [<Literal>] queryFields = "{ id, name, appearsIn, friends { name } }"
 
 type MyClient = GraphQLProvider<serverUrl>
 
@@ -23,6 +23,8 @@ match hero with
 | None -> ()
 | Some hero ->
     printfn "My hero is %A" hero.name
+    printfn "Appears in %O: %b" MyClient.Episode.Empire
+        (hero.appearsIn |> Array.exists ((=) MyClient.Episode.Empire))
     printfn "My hero's friends are:"
     hero.friends
     |> Array.choose (fun x -> x.name)

--- a/samples/client-provider/query.fsx
+++ b/samples/client-provider/query.fsx
@@ -1,10 +1,19 @@
 ﻿#r "../../src/FSharp.Data.GraphQL.Client/bin/Debug/FSharp.Data.GraphQL.Client.dll"
 
 open FSharp.Data.GraphQL
+open System.Collections.Generic
 
 let [<Literal>] serverUrl = "http://localhost:8083"
-let [<Literal>] query = "{ hero(id: \"1000\") { name } }"
+let [<Literal>] query = "{ hero(id: \"1000\") { id, name } }"
+
+let (?) (o: obj) (k: string) = (o :?> IDictionary<string,obj>).Item(k)
 
 type MyClient = GraphQLProvider<serverUrl>
 
-MyClient.Query<query>() |> Async.RunSynchronously |> printfn "%A"
+MyClient.Query<query>()
+|> Async.RunSynchronously
+|> function
+    // We get an error if we try to access an optional field like `name`
+    // because the cast from Option<obj> to Option<string> is not possible
+    | Choice1Of2 data -> printfn "My hero is %A" (data?hero :?> MyClient.Human).id
+    | Choice2Of2 errors -> printfn "Error: %A" errors

--- a/samples/client-provider/query.fsx
+++ b/samples/client-provider/query.fsx
@@ -4,24 +4,31 @@ open FSharp.Data.GraphQL
 open System.Collections.Generic
 
 let [<Literal>] serverUrl = "http://localhost:8083"
-let [<Literal>] query = "{ id, name, friends { name } }"
+
+// The name and arguments of the query will be automatically set by the type provider
+let [<Literal>] queryFields = "{ id, name, friends { name } }"
 
 type MyClient = GraphQLProvider<serverUrl>
 
 let hero =
-    MyClient.QueryHero<query>("1000")
+    MyClient.QueryHero<queryFields>("1000")
+    |> Async.RunSynchronously
+
+let droid =
+    MyClient.QueryDroid<queryFields>("2000")
     |> Async.RunSynchronously
 
 // Result is an option type
-printfn "My hero is %A" (hero |> Option.map (fun h -> h.name))
+match hero with
+| None -> ()
+| Some hero ->
+    printfn "My hero is %A" hero.name
+    printfn "My hero's friends are:"
+    hero.friends
+    |> Array.choose (fun x -> x.name)
+    |> Array.iter (printfn "- %s")
 
-//printfn "My hero's friends are:"
-//hero.friends
-//|> Array.choose (fun x -> x.name)
-//|> Array.iter (printfn "- %s")
-
-
-let [<Literal>] query2 = "{ hero(id: \"1000\") { id, name }"
+let [<Literal>] queryFields2 = "{ id, name"
 // This code won't compile as the query is not properly formed
-// MyClient.QueryHuman<query2>()
+// MyClient.QueryHero<queryFields2>("1000")
 

--- a/samples/client-provider/query.fsx
+++ b/samples/client-provider/query.fsx
@@ -4,13 +4,20 @@ open FSharp.Data.GraphQL
 open System.Collections.Generic
 
 let [<Literal>] serverUrl = "http://localhost:8083"
-let [<Literal>] query = "{ hero(id: \"1000\") { id, name } }"
+let [<Literal>] query = "{ hero(id: \"1000\") { id, name, friends { name } } }"
 
 type MyClient = GraphQLProvider<serverUrl>
 
-MyClient.QueryHuman<query>()
-|> Async.RunSynchronously
-|> function hero -> printfn "My hero is %A" hero.name
+let hero =
+    MyClient.QueryHuman<query>()
+    |> Async.RunSynchronously
+
+printfn "My hero is %A" hero.name
+printfn "My hero's friends are:"
+hero.friends
+|> Array.choose (fun x -> x.name)
+|> Array.iter (printfn "- %s")
+
 
 let [<Literal>] query2 = "{ hero(id: \"1000\") { id, name }"
 // This code won't compile as the query is not properly formed

--- a/samples/client-provider/query.fsx
+++ b/samples/client-provider/query.fsx
@@ -13,7 +13,5 @@ type MyClient = GraphQLProvider<serverUrl>
 MyClient.Query<query>()
 |> Async.RunSynchronously
 |> function
-    // We get an error if we try to access an optional field like `name`
-    // because the cast from Option<obj> to Option<string> is not possible
-    | Choice1Of2 data -> printfn "My hero is %A" (data?hero :?> MyClient.Human).id
+    | Choice1Of2 data -> printfn "My hero is %A" (data?hero :?> MyClient.Human).name
     | Choice2Of2 errors -> printfn "Error: %A" errors

--- a/samples/client-provider/query.fsx
+++ b/samples/client-provider/query.fsx
@@ -31,15 +31,17 @@ match hero with
     |> Array.choose (fun x -> x.name)
     |> Array.iter (printfn "- %s")
 
-let freeQuery = "{ hero(id: \"1000\"){ i, name, appearsIn, friends { name } } }"
+let freeQuery = "{ hero(id: \"1000\"){ id, name, appearsIn, friends { name } } }"
 
 let hero2 =
     MyClient.Query(freeQuery)
     |> Async.Catch
     |> Async.RunSynchronously
     |> function
-    | Choice1Of2 hero -> Some (hero :?> MyClient.Types.Human)
+    | Choice1Of2 data -> (data :?> IDictionary<string,obj>).["hero"] :?> MyClient.Types.Human |> Some
     | Choice2Of2 err -> printfn "ERROR: %s" err.Message; None
+
+printfn "%A" hero2.Value.name
 
 let [<Literal>] queryFields2 = "{ id, name"
 // This code won't compile as the query is not properly formed

--- a/samples/client-provider/query.fsx
+++ b/samples/client-provider/query.fsx
@@ -7,11 +7,12 @@ let [<Literal>] serverUrl = "http://localhost:8083"
 
 // The name and arguments of the query will be automatically set by the type provider
 let [<Literal>] queryFields = "{ id, name, appearsIn, friends { name } }"
+let [<Literal>] queryFieldsWithFragments = "{ ...data, friends { name } } fragment data on Human { id, name, appearsIn }"
 
 type MyClient = GraphQLProvider<serverUrl>
 
 let hero =
-    MyClient.QueryHero<queryFields>("1000")
+    MyClient.QueryHero<queryFieldsWithFragments>("1000")
     |> Async.RunSynchronously
 
 let droid =
@@ -32,5 +33,5 @@ match hero with
 
 let [<Literal>] queryFields2 = "{ id, name"
 // This code won't compile as the query is not properly formed
-// MyClient.QueryHero<queryFields2>("1000")
+//MyClient.QueryHero<queryFields2>("1000")
 

--- a/samples/client-provider/query.fsx
+++ b/samples/client-provider/query.fsx
@@ -12,11 +12,11 @@ let [<Literal>] queryFieldsWithFragments = "{ ...data, friends { name } } fragme
 type MyClient = GraphQLProvider<serverUrl>
 
 let hero =
-    MyClient.QueryHero<queryFieldsWithFragments>("1000")
+    MyClient.Queries.Hero<queryFieldsWithFragments>("1000")
     |> Async.RunSynchronously
 
 let droid =
-    MyClient.QueryDroid<queryFields>("2000")
+    MyClient.Queries.Droid<queryFields>("2000")
     |> Async.RunSynchronously
 
 // Result is an option type
@@ -24,12 +24,22 @@ match hero with
 | None -> ()
 | Some hero ->
     printfn "My hero is %A" hero.name
-    printfn "Appears in %O: %b" MyClient.Episode.Empire
-        (hero.appearsIn |> Array.exists ((=) MyClient.Episode.Empire))
+    printfn "Appears in %O: %b" MyClient.Types.Episode.Empire
+        (hero.appearsIn |> Array.exists ((=) MyClient.Types.Episode.Empire))
     printfn "My hero's friends are:"
     hero.friends
     |> Array.choose (fun x -> x.name)
     |> Array.iter (printfn "- %s")
+
+let freeQuery = "{ hero(id: \"1000\"){ i, name, appearsIn, friends { name } } }"
+
+let hero2 =
+    MyClient.Query(freeQuery)
+    |> Async.Catch
+    |> Async.RunSynchronously
+    |> function
+    | Choice1Of2 hero -> Some (hero :?> MyClient.Types.Human)
+    | Choice2Of2 err -> printfn "ERROR: %s" err.Message; None
 
 let [<Literal>] queryFields2 = "{ id, name"
 // This code won't compile as the query is not properly formed

--- a/samples/client-provider/query.fsx
+++ b/samples/client-provider/query.fsx
@@ -6,12 +6,13 @@ open System.Collections.Generic
 let [<Literal>] serverUrl = "http://localhost:8083"
 let [<Literal>] query = "{ hero(id: \"1000\") { id, name } }"
 
-let (?) (o: obj) (k: string) = (o :?> IDictionary<string,obj>).Item(k)
-
 type MyClient = GraphQLProvider<serverUrl>
 
-MyClient.Query<query>()
+MyClient.QueryHuman<query>()
 |> Async.RunSynchronously
-|> function
-    | Choice1Of2 data -> printfn "My hero is %A" (data?hero :?> MyClient.Human).name
-    | Choice2Of2 errors -> printfn "Error: %A" errors
+|> function hero -> printfn "My hero is %A" hero.name
+
+let [<Literal>] query2 = "{ hero(id: \"1000\") { id, name }"
+// This code won't compile as the query is not properly formed
+// MyClient.QueryHuman<query2>()
+

--- a/samples/client-provider/query.fsx
+++ b/samples/client-provider/query.fsx
@@ -4,19 +4,21 @@ open FSharp.Data.GraphQL
 open System.Collections.Generic
 
 let [<Literal>] serverUrl = "http://localhost:8083"
-let [<Literal>] query = "{ hero(id: \"1000\") { id, name, friends { name } } }"
+let [<Literal>] query = "{ id, name, friends { name } }"
 
 type MyClient = GraphQLProvider<serverUrl>
 
 let hero =
-    MyClient.QueryHuman<query>()
+    MyClient.QueryHero<query>("1000")
     |> Async.RunSynchronously
 
-printfn "My hero is %A" hero.name
-printfn "My hero's friends are:"
-hero.friends
-|> Array.choose (fun x -> x.name)
-|> Array.iter (printfn "- %s")
+// Result is an option type
+printfn "My hero is %A" (hero |> Option.map (fun h -> h.name))
+
+//printfn "My hero's friends are:"
+//hero.friends
+//|> Array.choose (fun x -> x.name)
+//|> Array.iter (printfn "- %s")
 
 
 let [<Literal>] query2 = "{ hero(id: \"1000\") { id, name }"

--- a/samples/graphiql-client/server.fsx
+++ b/samples/graphiql-client/server.fsx
@@ -89,9 +89,9 @@ let EpisodeType =
     name = "Episode",
     description = "One of the films in the Star Wars Trilogy",
     options = [
-        Define.EnumValue("NEWHOPE", Episode.NewHope, "Released in 1977.")
-        Define.EnumValue("EMPIRE", Episode.Empire, "Released in 1980.")
-        Define.EnumValue("JEDI", Episode.Jedi, "Released in 1983.") ])
+        Define.EnumValue("NewHope", Episode.NewHope, "Released in 1977.")
+        Define.EnumValue("Empire", Episode.Empire, "Released in 1980.")
+        Define.EnumValue("Jedi", Episode.Jedi, "Released in 1983.") ])
 
 let rec CharacterType =
   Define.Union(

--- a/samples/graphiql-client/server.fsx
+++ b/samples/graphiql-client/server.fsx
@@ -84,7 +84,8 @@ open FSharp.Data.GraphQL
 open FSharp.Data.GraphQL.Types
 open FSharp.Data.GraphQL.Execution
 
-let EpisodeType = Define.Enum(
+let EpisodeType =
+  Define.Enum(
     name = "Episode",
     description = "One of the films in the Star Wars Trilogy",
     options = [
@@ -92,7 +93,8 @@ let EpisodeType = Define.Enum(
         Define.EnumValue("EMPIRE", Episode.Empire, "Released in 1980.")
         Define.EnumValue("JEDI", Episode.Jedi, "Released in 1983.") ])
 
-let rec CharacterType = Define.Union(
+let rec CharacterType =
+  Define.Union(
     name = "Character",
     description = "A character in the Star Wars Trilogy",
     options = [ HumanType; DroidType ],
@@ -105,7 +107,8 @@ let rec CharacterType = Define.Union(
         | Human _ -> upcast HumanType
         | Droid _ -> upcast DroidType))
 
-and HumanType : ObjectDef<Human> = Define.Object<Human>(
+and HumanType : ObjectDef<Human> =
+  Define.Object<Human>(
     name = "Human",
     description = "A humanoid creature in the Star Wars universe.",
     isTypeOf = (fun o -> o :? Human),
@@ -120,7 +123,8 @@ and HumanType : ObjectDef<Human> = Define.Object<Human>(
         Define.Field("appearsIn", ListOf EpisodeType, "Which movies they appear in.", fun _ h -> upcast h.AppearsIn)
         Define.Field("homePlanet", Nullable String, "The home planet of the human, or null if unknown.", fun _ h -> h.HomePlanet) ])
         
-and DroidType = Define.Object<Droid>(
+and DroidType =
+  Define.Object<Droid>(
     name = "Droid",
     description = "A mechanical creature in the Star Wars universe.",
     isTypeOf = (fun o -> o :? Droid),
@@ -132,7 +136,8 @@ and DroidType = Define.Object<Droid>(
         Define.Field("appearsIn", ListOf EpisodeType, "Which movies they appear in.", fun _ d -> upcast d.AppearsIn)
         Define.Field("primaryFunction", Nullable String, "The primary function of the droid.", fun _ d -> d.PrimaryFunction) ])
 
-let Query = Define.Object(
+let Query =
+  Define.Object(
     name = "Query",
     fields = [
         Define.Field("hero", Nullable HumanType, "Gets human hero", [ Define.Input("id", String) ], fun ctx () -> getHuman (ctx.Arg("id").Value))

--- a/samples/graphiql-client/server.fsx
+++ b/samples/graphiql-client/server.fsx
@@ -140,8 +140,8 @@ let Query =
   Define.Object(
     name = "Query",
     fields = [
-        Define.Field("hero", Nullable HumanType, "Gets human hero", [ Define.Input("id", String) ], fun ctx () -> getHuman (ctx.Arg("id").Value))
-        Define.Field("droid", Nullable DroidType, "Gets droid", [ Define.Input("id", String) ], fun ctx () -> getDroid (ctx.Arg("id").Value)) ])
+        Define.Field("hero", Nullable HumanType, "Gets human hero", [ Define.Input("id", String) ], fun ctx () -> getHuman (ctx.Arg("id")))
+        Define.Field("droid", Nullable DroidType, "Gets droid", [ Define.Input("id", String) ], fun ctx () -> getDroid (ctx.Arg("id"))) ])
 
 let schema = Schema(Query)
 

--- a/src/FSharp.Data.GraphQL.Client/FSharp.Data.GraphQL.Client.fsproj
+++ b/src/FSharp.Data.GraphQL.Client/FSharp.Data.GraphQL.Client.fsproj
@@ -25,7 +25,7 @@
     <DocumentationFile>bin\Debug\FSharp.Data.GraphQL.Client.XML</DocumentationFile>
     <StartAction>Program</StartAction>
     <StartProgram>C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\devenv.exe</StartProgram>
-    <StartArguments>"C:\Users\Alfonso\Documents\GitHub\Test.fsx"</StartArguments>
+    <StartArguments>"../../../../samples/client-provider/query.fsx"</StartArguments>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/FSharp.Data.GraphQL.Client/FSharp.Data.GraphQL.Client.fsproj
+++ b/src/FSharp.Data.GraphQL.Client/FSharp.Data.GraphQL.Client.fsproj
@@ -20,9 +20,12 @@
     <Optimize>false</Optimize>
     <Tailcalls>false</Tailcalls>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NO_GENERATIVE</DefineConstants>
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>bin\Debug\FSharp.Data.GraphQL.Client.XML</DocumentationFile>
+    <StartAction>Program</StartAction>
+    <StartProgram>C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\devenv.exe</StartProgram>
+    <StartArguments>"C:\Users\Alfonso\Documents\GitHub\Test.fsx"</StartArguments>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/FSharp.Data.GraphQL.Client/GraphQlProvider.fs
+++ b/src/FSharp.Data.GraphQL.Client/GraphQlProvider.fs
@@ -19,6 +19,7 @@ open QuotationHelpers
 
 module Util =
     open System.Text.RegularExpressions
+    open FSharp.Data.GraphQL
 
     let requestSchema (url: string) =
         async {
@@ -70,7 +71,7 @@ module Util =
         | _ ->
             (token :?> JValue).Value
 
-    let launchQuery (serverUrl: string) (query: string) =
+    let launchQuery (serverUrl: string) (query: string) (queryName: string) =
         async {
             use client = new WebClient()
             let queryJson = Map["query", query] |> JsonConvert.SerializeObject
@@ -78,10 +79,32 @@ module Util =
             let res = JToken.Parse json |> jsonToObject :?> IDictionary<string,obj>
             if res.ContainsKey("errors") then
                 res.["errors"] :?> string[] |> String.concat "\n" |> failwith
-            // TODO: Find a more structured way to get the query name
-            let queryName = Regex.Match(query, "^.*?(\w+)").Groups.[1].Value
-            return (res.["data"] :?> IDictionary<string,obj>).[queryName]
+            let data = res.["data"]
+            return
+                // Using options gives problems with quotations and provided methods
+                // so we have to use null here instead
+                match queryName with
+                | null -> data
+                | queryName -> (res.["data"] :?> IDictionary<string,obj>).[queryName]
         }
+
+    let getQueryName (serverUrl: string) (query: string) =
+        // This will fail if the query is not well formed
+        let doc = Parser.parse query
+        (None, doc.Definitions) ||> List.fold (fun queryOp def ->
+            match queryOp, def with
+            | None, Ast.OperationDefinition({ OperationType = Ast.Query } as q) -> Some q 
+            | _ -> queryOp)
+        |> function
+        | None -> failwith "Cannot find query operation"
+        | Some queryOp ->
+            match queryOp.SelectionSet with
+            | [Ast.Field { Name=name}] -> name // TODO: Check other possibilities
+            | _ -> null
+        // TODO: Make a first flight to be sure the query is accepted by the server?
+//        launchQuery serverUrl query |> Async.Catch |> Async.RunSynchronously |> function
+//        | Choice1Of2 _ -> ()
+//        | Choice2Of2 ex -> failwith ex.Message
 
     let createStaticMethod (tdef: ProvidedTypeDefinition) (resType: Type) (serverUrl) =
         let asyncType = typeof<Async<obj>>.GetGenericTypeDefinition().MakeGenericType(resType)
@@ -90,13 +113,10 @@ module Util =
         m.DefineStaticParameters(sargs, fun methName parameterValues ->
             match parameterValues with 
             | [| :? string as query |] ->
-                // Make a first flight to be sure the query is accepted by the server
-                launchQuery serverUrl query |> Async.Catch |> Async.RunSynchronously |> function
-                | Choice1Of2 _ -> ()
-                | Choice2Of2 ex -> failwith ex.Message
+                let queryName = getQueryName serverUrl query
                 let m2 = ProvidedMethod(methName, [], asyncType, IsStaticMethod = true) 
                 m2.InvokeCode <- fun _ ->
-                    <@@ launchQuery serverUrl query @@>
+                    <@@ launchQuery serverUrl query queryName @@>
                 tdef.AddMember m2
                 m2
             | _ -> failwith "unexpected parameter values")

--- a/src/FSharp.Data.GraphQL.Client/IntrospectionParser.fs
+++ b/src/FSharp.Data.GraphQL.Client/IntrospectionParser.fs
@@ -74,6 +74,7 @@ module TypeCompiler =
         // in order to prevent errors at runtime
         let name = ifield.Name
         p.GetterCode <- 
+            // TODO Union types. Also, Option must be of the specific property type, not obj 
             match ifield.Type.Kind with
             | TypeKind.NON_NULL -> fun args -> <@@ ((%%(args.[0]): obj) :?> IDictionary<string,obj>).Item(name) @@>
             | TypeKind.LIST ->

--- a/src/FSharp.Data.GraphQL.Client/IntrospectionParser.fs
+++ b/src/FSharp.Data.GraphQL.Client/IntrospectionParser.fs
@@ -159,10 +159,10 @@ module TypeCompiler =
         
     let initType (ctx: ProviderSessionContext) (itype: IntrospectionType) = 
         match itype.Kind with
-        | TypeKind.OBJECT -> ProvidedTypeDefinition(ctx.Assembly, ctx.Namespace, itype.Name, Some typeof<obj>)
-        | TypeKind.INPUT_OBJECT -> ProvidedTypeDefinition(ctx.Assembly, ctx.Namespace, itype.Name, Some typeof<obj>)
-        | TypeKind.SCALAR -> ProvidedTypeDefinition(ctx.Assembly, ctx.Namespace, itype.Name, Some typeof<obj>)
-        | TypeKind.UNION -> ProvidedTypeDefinition(ctx.Assembly, ctx.Namespace, itype.Name, Some typeof<obj>)
-        | TypeKind.ENUM -> ProvidedTypeDefinition(ctx.Assembly, ctx.Namespace, itype.Name, Some typeof<Enum>)
-        | TypeKind.INTERFACE -> ProvidedTypeDefinition(ctx.Assembly, ctx.Namespace, itype.Name, Some typeof<obj>)
+        | TypeKind.OBJECT -> ProvidedTypeDefinition(itype.Name, Some typeof<obj>)
+        | TypeKind.INPUT_OBJECT -> ProvidedTypeDefinition(itype.Name, Some typeof<obj>)
+        | TypeKind.SCALAR -> ProvidedTypeDefinition(itype.Name, Some typeof<obj>)
+        | TypeKind.UNION -> ProvidedTypeDefinition(itype.Name, Some typeof<obj>)
+        | TypeKind.ENUM -> ProvidedTypeDefinition(itype.Name, Some typeof<Enum>)
+        | TypeKind.INTERFACE -> ProvidedTypeDefinition(itype.Name, Some typeof<obj>)
         | _ -> failwithf "Illegal type kind %s" (itype.Kind.ToString())


### PR DESCRIPTION
Here comes the promised PR for the Type Provider. At the end I'm trying a mixed approach: I read the Query objects from the schema and build methods based on that (with the query as a static argument so it can be checked at design time) so the query names and arguments are automatically added (the SelectionSet must still be passed as a string). @Horusiath please have a look and tell me what you think and which features we should focus on. I'm writing some ideas below.
- [ ] Improve query validation: right now it's just running `parse` on the query string. It should validate the name of the fields, etc, as it's done by [graphiql](https://github.com/graphql/graphiql)
- [ ] Support mutations
- [ ] Build types for queries according to the fields requested? Though according to what we talked this probably doesn't add much value for the work involved
- [ ] Anything else?
