### PR TITLE
Object inferface validation

### DIFF
--- a/src/FSharp.Data.GraphQL/Schema.fs
+++ b/src/FSharp.Data.GraphQL/Schema.fs
@@ -178,7 +178,7 @@ type Schema<'Root> (query: ObjectDef<'Root>, ?mutation: ObjectDef<'Root>, ?confi
             let possibleTypes = 
                 getPossibleTypes idef
                 |> Array.map (fun tdef -> Map.find tdef.Name namedTypes)
-            IntrospectionType.Interface(idef.Name, idef.Description, fields, possibleTypes )
+            IntrospectionType.Interface(idef.Name, idef.Description, fields, possibleTypes)
 
     let introspectSchema types : IntrospectionSchema =
         let inamed = 
@@ -213,6 +213,9 @@ type Schema<'Root> (query: ObjectDef<'Root>, ?mutation: ObjectDef<'Root>, ?confi
     let introspected = introspectSchema typeMap      
     do
         compileSchema getPossibleTypes typeMap
+        match Validation.validate typeMap with
+        | Validation.Success -> ()
+        | Validation.Error errors -> raise (GraphQLException (System.String.Join("\n", errors)))
         
     member this.AsyncExecute(ast: Document, ?data: 'Root, ?variables: Map<string, obj>, ?operationName: string): Async<IDictionary<string,obj>> =
         async {

--- a/src/FSharp.Data.GraphQL/TypeSystem.fs
+++ b/src/FSharp.Data.GraphQL/TypeSystem.fs
@@ -400,7 +400,6 @@ and EnumDefinition<'Val> =
             |> Seq.ofArray
             |> Seq.cast<EnumVal>
             |> Seq.toArray
-    
     interface NamedDef with
         member x.Name = x.Name
     

--- a/src/FSharp.Data.GraphQL/Validation.fs
+++ b/src/FSharp.Data.GraphQL/Validation.fs
@@ -5,13 +5,57 @@ module FSharp.Data.GraphQL.Validation
 
 open FSharp.Data.GraphQL.Types
 
-type ValidationErrorInfo = {
-    ObjectName: string
-    Description: string
-}
-
 type ValidationResult =
     | Success
-    | Error of ValidationErrorInfo list
+    | Error of string list
 
-let detectCyclesInFragment fragmentDefintion visited = false
+let (@) res1 res2 =
+    match res1, res2 with
+    | Success, Success -> Success
+    | Success, _ -> res2
+    | _, Success -> res1
+    | Error e1, Error e2 -> Error (e1 @ e2)
+
+let validateImplements (objdef: ObjectDef) (idef: InterfaceDef) =
+    let objectFields =
+        objdef.Fields
+        |> Array.map (fun f -> (f.Name, f))
+        |> Map.ofArray
+    let errors =
+        idef.Fields
+        |> Array.fold (fun acc f ->
+            match Map.tryFind f.Name objectFields with
+            | None -> (sprintf "'%s' field is defined by interface %s, but not implemented in object %s" f.Name idef.Name objdef.Name)::acc
+            | Some objf when objf = f -> acc
+            | Some _ -> (sprintf "'%s.%s' field signature does not match it's definition in interface %s" objdef.Name f.Name idef.Name)::acc) []
+    match errors with
+    | [] -> Success
+    | err -> Error err
+            
+let validateType (namedTypes: Map<string, NamedDef>) typedef =
+    match typedef with
+    | Scalar scalardef -> Success
+    | Object objdef -> 
+        let nonEmptyResult = if objdef.Fields.Length > 0 then Success else Error [ objdef.Name + " must have at least one field defined" ]
+        let implementsResult =
+            objdef.Implements
+            |> Array.fold (fun acc i -> acc @ validateImplements objdef i) Success
+        nonEmptyResult @ implementsResult
+    | InputObject indef -> 
+        let nonEmptyResult = if indef.Fields.Length > 0 then Success else Error [ indef.Name + " must have at least one field defined" ]
+        nonEmptyResult
+    | Union uniondef ->
+        let nonEmptyResult = if uniondef.Options.Length > 0 then Success else Error [ uniondef.Name + " must have at least one type definition option" ]
+        nonEmptyResult
+    | Enum enumdef -> 
+        let nonEmptyResult = if enumdef.Options.Length > 0 then Success else Error [ enumdef.Name + " must have at least one enum value defined" ]
+        nonEmptyResult
+    | Interface idef -> 
+        let nonEmptyResult = if idef.Fields.Length > 0 then Success else Error [ idef.Name + " must have at least one field defined" ]
+        nonEmptyResult
+
+let validate (namedTypes: Map<string, NamedDef>) : ValidationResult =
+    namedTypes
+    |> Map.toArray
+    |> Array.map snd
+    |> Array.fold (fun acc namedDef -> acc @ validateType namedTypes namedDef) Success

--- a/tests/FSharp.Data.GraphQL.Tests/ValidationTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/ValidationTests.fs
@@ -1,5 +1,68 @@
 ﻿/// The MIT License (MIT)
 /// Copyright (c) 2016 Bazinga Technologies Inc
-
 module FSharp.Data.GraphQL.Tests.ValidationTests
 
+open FSharp.Data.GraphQL
+open FSharp.Data.GraphQL.Validation
+open FSharp.Data.GraphQL.Types
+open Xunit
+open FsCheck
+
+type ITestInterface = 
+    interface
+        abstract TestProperty : string
+        abstract TestMethod : int -> string -> string
+    end
+
+type TestDataType = 
+    { TestProperty : string }
+    interface ITestInterface with
+        member x.TestProperty = x.TestProperty
+        member x.TestMethod i y = x.TestProperty + y + i.ToString()
+
+let TestInterface = 
+    Define.Interface<ITestInterface>("TestInterface", 
+                                     [ Define.Field("property", String)
+                                       Define.Field("method", String, "Test method", 
+                                                    [ Define.Input("x", Int)
+                                                      Define.Input("y", String) ], (fun _ _ -> "")) ])
+
+[<Fact>]
+let ``Validation should inform about not implemented fields``() = 
+    let TestData = 
+        Define.Object<TestDataType>
+            (name = "TestData", fields = [ Define.Field("property", String, (fun _ d -> d.TestProperty)) ], 
+             interfaces = [ TestInterface ])
+    let expected = 
+        Error [ "'method' field is defined by interface TestInterface, but not implemented in object TestData" ]
+    let result = validateImplements TestData TestInterface
+    equals expected result
+
+[<Fact>]
+let ``Validation should inform about fields with not matching signatures``() = 
+    let TestData = 
+        Define.Object<TestDataType>
+            (name = "TestData", 
+             fields = [ Define.Field("property", Int, (fun _ d -> 1))
+                        Define.Field("method", String, "Test method", [ Define.Input("x", Int) ], (fun _ _ -> "res")) ], 
+             interfaces = [ TestInterface ])
+    
+    let expected = 
+        Error 
+            [ "'TestData.method' field signature does not match it's definition in interface TestInterface"; 
+              "'TestData.property' field signature does not match it's definition in interface TestInterface" ]
+    let result = validateImplements TestData TestInterface
+    equals expected result
+    
+[<Fact>]
+let ``Validation should succeed if object implements interface correctly``() = 
+    let TestData = 
+        Define.Object<TestDataType>
+            (name = "TestData", 
+             fields = [ Define.Field("property", String, (fun _ d -> d.TestProperty))
+                        Define.Field("method", String, "Test method", [ Define.Input("x", Int); Define.Input("y", String) ], (fun _ _ -> "res")) ], 
+             interfaces = [ TestInterface ])
+    
+    let result = validateImplements TestData TestInterface
+    equals Success result
+    


### PR DESCRIPTION
This PR introduces some validations described in #24 - at least the ones that can be done at schema creation time:
- Checks if enums and unions doesn't contain empty list of available options.
- Checks if objects and interfaces are not empty (they must define at least one field).
- Checks if objects define all fields from interfaces they implements, and that the field signatures match each other.
