### PR TITLE
Adds support for Subscription

### DIFF
--- a/src/FSharp.Data.GraphQL/Ast.fs
+++ b/src/FSharp.Data.GraphQL/Ast.fs
@@ -29,6 +29,7 @@ and OperationDefinition = {
 and OperationType = 
     | Query
     | Mutation
+    | Subscription
 
 /// 2.2.2 Selection Sets
 and Selection = 

--- a/src/FSharp.Data.GraphQL/Execution.fs
+++ b/src/FSharp.Data.GraphQL/Execution.fs
@@ -490,6 +490,11 @@ type Define with
                          |> Array.filter (fun f -> f.Name = name)
                          |> Array.fold (fun _ f -> f.SelectionSet) []
 
+                     let label =
+                         ctx.Fields
+                         |> Array.filter (fun f -> f.Name = name)
+                         |> Array.fold (fun _ f -> f.AliasOrName) name
+
                      let execute x =
                         collectFields ctx.ExecutionContext typedef set (ref [])
                         |> executeFields ctx.ExecutionContext typedef x
@@ -498,7 +503,7 @@ type Define with
                      |> Async.Global.ofJob
                      |> Async.RunSynchronously
                      |> Observable.map (fun x ->
-                        [name,
+                        [label,
                             execute x
                             |> Async.Global.ofJob
                             |> Async.RunSynchronously

--- a/src/FSharp.Data.GraphQL/Execution.fs
+++ b/src/FSharp.Data.GraphQL/Execution.fs
@@ -481,9 +481,10 @@ type Define with
     /// Single subscription defined inside either object types or interfaces 
     static member Subscription(name : string, typedef : ObjectDef<'Res>,
                                subscribe : ResolveFieldContext -> 'Val -> IObservable<NameValueLookup> -> unit,
-                               ?resolve: ResolveFieldContext -> 'Val -> IObservable<'Res>) : FieldDef<'Val> =
+                               ?resolve: ResolveFieldContext -> 'Val -> IObservable<'Res>,
+                               ?description: string, ?args : InputFieldDef list, ?deprecationReason : string) : FieldDef<'Val> =
         upcast { Name = name
-                 Description = None
+                 Description = description
                  Type = typedef
                  Resolve = fun ctx value -> job {
                      let set =
@@ -516,6 +517,6 @@ type Define with
                         |> NameValueLookup.ofList)
                      |> subscribe ctx value
                      return Unchecked.defaultof<'Res> }
-                 Args = [||]
-                 DeprecationReason = None
+                 Args = defaultArg args [] |> List.toArray
+                 DeprecationReason = deprecationReason
                  Execute = Unchecked.defaultof<ExecuteField> }

--- a/src/FSharp.Data.GraphQL/Parser.fs
+++ b/src/FSharp.Data.GraphQL/Parser.fs
@@ -262,9 +262,7 @@ module internal Internal =
   //    OperationDefinition List
   let definitions =
     let operationType = 
-      // leaving out subscriptions for now.
-      // (stoken_ws "subscription" >>% Subscription) 
-      (stoken_ws "query" >>% Query) <|> (stoken_ws "mutation" >>% Mutation) 
+      (stoken_ws "query" >>% Query) <|> (stoken_ws "mutation" >>% Mutation) <|> (stoken_ws "subscription" >>% Subscription)
       
     let namedOperationDefinition = 
       let variableDefinition =

--- a/src/FSharp.Data.GraphQL/TypeSystem.fs
+++ b/src/FSharp.Data.GraphQL/TypeSystem.fs
@@ -151,6 +151,7 @@ type ISchema =
         abstract TypeMap : Map<string, NamedDef>
         abstract Query : ObjectDef
         abstract Mutation : ObjectDef option
+        abstract Subscription : ObjectDef option
         abstract Directives : DirectiveDef []
         abstract TryFindType : string -> NamedDef option
         abstract GetPossibleTypes : AbstractDef -> ObjectDef []

--- a/tests/FSharp.Data.GraphQL.Tests/FSharp.Data.GraphQL.Tests.fsproj
+++ b/tests/FSharp.Data.GraphQL.Tests/FSharp.Data.GraphQL.Tests.fsproj
@@ -78,6 +78,7 @@
     <Compile Include="ReflectedSchemaTests.fs" />
     <Compile Include="ExecutionTests.fs" />
     <Compile Include="MutationTests.fs" />
+    <Compile Include="SubscriptionTests.fs" />
     <Compile Include="ResolveTests.fs" />
     <Compile Include="UnionInterfaceTests.fs" />
     <Compile Include="VariablesTests.fs" />

--- a/tests/FSharp.Data.GraphQL.Tests/SubscriptionTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/SubscriptionTests.fs
@@ -18,19 +18,33 @@ let event = Event<NumberChanged>()
 let observable =
     event.Publish
     |> Observable.map id
-let mutable observed : NameValueLookup list = []
 
 let NumberHolder = Define.Object("NumberHolder", [ Define.Field("theNumber", Int, fun _ x -> x.Number) ])
 let NumberChanged = Define.Object("NumberChanged", [ Define.Field("number", NumberHolder, fun _ (x : NumberChanged) -> x.NumberHolder) ])
 
-let schema = Schema(
+let schema f = Schema(
     query = Define.Object("Query", [ Define.Field("numberHolder", NumberHolder, fun _ x -> x.NumberHolder) ]),
     subscription = Define.Object("Subscription", [
-        Define.Subscription("numberChangedSubscribe", NumberChanged, (fun _ _ o -> o.Add(fun x -> observed <- x :: observed)))
+        Define.Subscription("numberChangedSubscribe", NumberChanged, (fun _ _ o -> o.Add f))
     ]))
+
+let rec toLookup x =
+    let convert x =
+        match box x with
+        | :? ((string * _) list) as l -> toLookup l :> obj
+        | _ -> x
+
+    let rec traverse = function
+        | [] -> []
+        | (x,l) :: xs -> (x, convert l) :: traverse xs
+        
+    traverse x
+    |> NameValueLookup.ofList
 
 [<Fact>]
 let ``Execute subscription returns null`` () =
+    let mutable observed : NameValueLookup list = []
+    let schema = schema (fun x -> observed <- x :: observed)
     let query = """subscription M {
       numberChangedSubscribe {
         number {
@@ -47,3 +61,35 @@ let ``Execute subscription returns null`` () =
     let expected = NameValueLookup.ofList ["numberChangedSubscribe", null]
     noErrors result
     result.["data"] |> equals (upcast expected)
+
+[<Fact>]
+let ``Execute subscription triggers observable when event is triggered after subscription`` () =
+    let mutable observed : NameValueLookup list = []
+    let schema = schema (fun x -> observed <- x :: observed)
+    let query = """subscription M {
+      numberChangedSubscribe {
+        number {
+          theNumber
+        }
+      }
+    }"""
+    let root =
+        { NumberHolder = { Number = 1 }
+          NumberChangedSubscribe = observable }
+
+    event.Trigger { NumberHolder = { Number = 1 } }
+
+    let result = sync <| schema.AsyncExecute(parse query, root)
+
+    event.Trigger { NumberHolder = { Number = 2 } }
+    event.Trigger { NumberHolder = { Number = 3 } }
+
+    let expected = NameValueLookup.ofList ["numberChangedSubscribe", null]
+    noErrors result
+    result.["data"] |> equals (upcast expected)
+
+    let expected =
+        [ [ "numberChangedSubscribe", box ["number", box [ "theNumber", box 2 ] ] ]
+          [ "numberChangedSubscribe", box ["number", box [ "theNumber", box 3 ] ] ] ]
+        |> List.map toLookup
+    observed |> List.rev |> equals expected

--- a/tests/FSharp.Data.GraphQL.Tests/SubscriptionTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/SubscriptionTests.fs
@@ -1,0 +1,49 @@
+﻿module FSharp.Data.GraphQL.Tests.SubscriptionTests
+
+open System
+open Xunit
+open FSharp.Data.GraphQL
+open FSharp.Data.GraphQL.Types
+open FSharp.Data.GraphQL.Parser
+open FSharp.Data.GraphQL.Execution
+
+
+type NumberHolder = { Number: int }
+type NumberChanged = { NumberHolder: NumberHolder }
+type Root =
+    { NumberHolder: NumberHolder
+      NumberChangedSubscribe: IObservable<NumberChanged> }
+
+let event = Event<NumberChanged>()
+let observable =
+    event.Publish
+    |> Observable.map id
+let mutable observed : NameValueLookup list = []
+
+let NumberHolder = Define.Object("NumberHolder", [ Define.Field("theNumber", Int, fun _ x -> x.Number) ])
+let NumberChanged = Define.Object("NumberChanged", [ Define.Field("number", NumberHolder, fun _ (x : NumberChanged) -> x.NumberHolder) ])
+
+let schema = Schema(
+    query = Define.Object("Query", [ Define.Field("numberHolder", NumberHolder, fun _ x -> x.NumberHolder) ]),
+    subscription = Define.Object("Subscription", [
+        Define.Subscription("numberChangedSubscribe", NumberChanged, (fun _ _ o -> o.Add(fun x -> observed <- x :: observed)))
+    ]))
+
+[<Fact>]
+let ``Execute subscription returns null`` () =
+    let query = """subscription M {
+      numberChangedSubscribe {
+        number {
+          theNumber
+        }
+      }
+    }"""
+    let root =
+        { NumberHolder = { Number = 1 }
+          NumberChangedSubscribe = observable }
+
+    let result = sync <| schema.AsyncExecute(parse query, root)
+
+    let expected = NameValueLookup.ofList ["numberChangedSubscribe", null]
+    noErrors result
+    result.["data"] |> equals (upcast expected)


### PR DESCRIPTION
This PR introduces experimental support for subscriptions.

The specs for subscriptions were not released yet, but there are some info around it
- http://graphql.org/blog/subscriptions-in-graphql-and-relay/
- https://gist.github.com/OlegIlyenko/a5a9ab1b000ba0b5b1ad
