### PR TITLE
Enabled generic collections in ListOf

### DIFF
--- a/docs/content/index.fsx
+++ b/docs/content/index.fsx
@@ -1,7 +1,7 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
+#I "../../src/FSharp.Data.GraphQL.Server/bin/Release"
 
 (**
 FSharp.Data.GraphQL
@@ -26,7 +26,7 @@ Example
 This example demonstrates using a function defined in this sample library.
 
 *)
-#r "FSharp.Data.GraphQL/FSharp.Data.GraphQL.dll"
+#r "../../src/FSharp.Data.GraphQL.Server/bin/Release/FSharp.Data.GraphQL.Shared.dll"
 open FSharp.Data.GraphQL
 
 

--- a/docs/content/tutorial.fsx
+++ b/docs/content/tutorial.fsx
@@ -1,7 +1,7 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
+#I "../../src/FSharp.Data.GraphQL.Server/bin/Release"
 
 (**
 Introducing your project
@@ -10,10 +10,9 @@ Introducing your project
 Say more
 
 *)
-#r "FSharp.Data.GraphQL.dll"
+#r "../../src/FSharp.Data.GraphQL.Server/bin/Release/FSharp.Data.GraphQL.Shared.dll"
 open FSharp.Data.GraphQL
 
-Library.hello 0
 (**
 Some more info
 *)

--- a/samples/graphiql-client/server.fsx
+++ b/samples/graphiql-client/server.fsx
@@ -1,11 +1,11 @@
 #r "../../packages/Suave/lib/net40/Suave.dll"
 #r "../../packages/Newtonsoft.Json/lib/net40/Newtonsoft.Json.dll"
 #r "../../packages/System.Runtime/lib/net462/System.Runtime.dll"
-#r "../../bin/FSharp.Data.GraphQL/Hopac.dll"
-#r "../../bin/FSharp.Data.GraphQL/Hopac.Core.dll"
-#r "../../bin/FSharp.Data.GraphQL/Hopac.Platform.dll"
-#r "../../bin/FSharp.Data.GraphQL/FSharp.Data.GraphQL.Shared.dll"
-#r "../../bin/FSharp.Data.GraphQL/FSharp.Data.GraphQL.dll"
+#r "../../bin/FSharp.Data.GraphQL.Server/Hopac.dll"
+#r "../../bin/FSharp.Data.GraphQL.Server/Hopac.Core.dll"
+#r "../../bin/FSharp.Data.GraphQL.Server/Hopac.Platform.dll"
+#r "../../bin/FSharp.Data.GraphQL.Server/FSharp.Data.GraphQL.Shared.dll"
+#r "../../bin/FSharp.Data.GraphQL.Server/FSharp.Data.GraphQL.Server.dll"
 
 open System
 

--- a/samples/relay-starter-kit/server.fsx
+++ b/samples/relay-starter-kit/server.fsx
@@ -1,7 +1,7 @@
 #r "../../packages/Suave/lib/net40/Suave.dll"
 #r "../../packages/Newtonsoft.Json/lib/net40/Newtonsoft.Json.dll"
-#r "../../src/FSharp.Data.GraphQL/bin/Debug/FSharp.Data.GraphQL.dll"
-#r "../../src/FSharp.Data.GraphQL.Relay/bin/Debug/FSharp.Data.GraphQL.Relay.dll"
+#r "../../src/FSharp.Data.GraphQL.Server/bin/Debug/FSharp.Data.GraphQL.Shared.dll"
+#r "../../src/FSharp.Data.GraphQL.Server/bin/Debug/FSharp.Data.GraphQL.Server.dll"
 
 open System
 
@@ -49,7 +49,7 @@ and User = Define.Object<User>(
         Define.Field("name", String, fun _ w -> w.Name)
         Define.Field("widgets", ConnectionOf Widget, "A person's collection of widgets", Connection.allArgs, fun ctx user -> 
             let widgets = user.Widgets |> List.toArray
-            Connection.ofArray ctx widgets )])
+            Connection.ofArray widgets )])
 
 and Node = Define.Node<obj>(fun () -> [ User; Widget ])
 

--- a/src/FSharp.Data.GraphQL.Server/Relay/Connections.fs
+++ b/src/FSharp.Data.GraphQL.Server/Relay/Connections.fs
@@ -100,4 +100,18 @@ module Connection =
         Define.Input("before", Nullable String) ]
     
     let allArgs = forwardArgs @ backwardArgs
+
+    let ofArray array =
+        let edges = 
+            array
+            |> Array.mapi (fun idx elem -> { Cursor = Cursor.ofOffset idx; Node = elem })
+        let first = if edges.Length = 0 then None else Some edges.[0].Cursor
+        let last = if edges.Length = 0 then None else Some edges.[edges.Length-1].Cursor
+        { TotalCount = Array.length array |> Some
+          PageInfo = 
+            { HasNextPage = false
+              HasPreviousPage = false
+              StartCursor = first
+              EndCursor = last }
+          Edges = edges }
     

--- a/src/FSharp.Data.GraphQL.Shared/Introspection.fs
+++ b/src/FSharp.Data.GraphQL.Shared/Introspection.fs
@@ -180,7 +180,7 @@ and __Field = Define.Object<IntrospectionField>(
     fieldsFn = fun () -> [
         Define.Field("name", String, fun _ f -> f.Name)
         Define.Field("description", Nullable String, fun _ f -> f.Description)
-        Define.Field("args", ListOf __InputValue, fun _ f -> upcast f.Args)
+        Define.Field("args", ListOf __InputValue, fun _ f -> f.Args)
         Define.Field("type", __Type, fun _ f -> f.Type)
         Define.Field("isDeprecated", Boolean, resolve = fun _ f -> f.IsDeprecated)
         Define.Field("deprecationReason", Nullable String, fun _ f -> f.DeprecationReason)
@@ -202,8 +202,8 @@ and __Directive = Define.Object<IntrospectionDirective>(
     fieldsFn = fun () -> [
         Define.Field("name", String, fun _ directive -> directive.Name)
         Define.Field("description", Nullable String, fun _ directive -> directive.Description)
-        Define.Field("locations", ListOf __DirectiveLocation, resolve = fun _ directive -> upcast directive.Locations)
-        Define.Field("args", ListOf __InputValue, fun _ directive -> upcast directive.Args)
+        Define.Field("locations", ListOf __DirectiveLocation, resolve = fun _ directive -> directive.Locations)
+        Define.Field("args", ListOf __InputValue, fun _ directive -> directive.Args)
         Define.Field("onOperation", Boolean, resolve = fun _ d -> d.Locations |> Seq.exists (fun l -> l.HasFlag(DirectiveLocation.QUERY ||| DirectiveLocation.MUTATION ||| DirectiveLocation.SUBSCRIPTION)))
         Define.Field("onFragment", Boolean, resolve = fun _ d -> d.Locations |> Seq.exists (fun l -> l.HasFlag(DirectiveLocation.FRAGMENT_SPREAD ||| DirectiveLocation.INLINE_FRAGMENT ||| DirectiveLocation.FRAGMENT_DEFINITION)))
         Define.Field("onField", Boolean, resolve = fun _ d -> d.Locations |> Seq.exists (fun l -> l.HasFlag(DirectiveLocation.FIELD)))
@@ -213,9 +213,9 @@ and __Schema = Define.Object<IntrospectionSchema>(
     name = "__Schema",
     description = "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.",
     fieldsFn = fun () -> [
-        Define.Field("types", ListOf __Type, description = "A list of all types supported by this server.", resolve = fun _ schema -> upcast (schema.Types |> Array.map IntrospectionTypeRef.Named))
+        Define.Field("types", ListOf __Type, description = "A list of all types supported by this server.", resolve = fun _ schema -> schema.Types |> Array.map IntrospectionTypeRef.Named)
         Define.Field("queryType", __Type, description = "The type that query operations will be rooted at.", resolve = fun _ schema -> schema.QueryType)
         Define.Field("mutationType", Nullable __Type, description = "If this server supports mutation, the type that mutation operations will be rooted at.", resolve = fun _ schema -> schema.MutationType)
         Define.Field("subscriptionType", Nullable __Type, description = "If this server support subscription, the type that subscription operations will be rooted at.", resolve = fun _ _ -> None)
-        Define.Field("directives", ListOf __Directive, description = "A list of all directives supported by this server.", resolve = fun _  schema -> upcast schema.Directives)
+        Define.Field("directives", ListOf __Directive, description = "A list of all directives supported by this server.", resolve = fun _  schema -> schema.Directives)
     ])

--- a/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
+++ b/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
@@ -331,7 +331,7 @@ and [<CustomEquality; NoComparison>] ScalarDefinition<'Val> =
             let nullable: NullableDefinition<_> = { OfType = x }
             upcast nullable
         member x.MakeList() = 
-            let list: ListOfDefinition<_> = { OfType = x }
+            let list: ListOfDefinition<_,_> = { OfType = x }
             upcast list
         
     interface OutputDef with
@@ -418,7 +418,7 @@ and EnumDefinition<'Val> =
             let nullable: NullableDefinition<_> = { OfType = x }
             upcast nullable
         member x.MakeList() = 
-            let list: ListOfDefinition<_> = { OfType = x }
+            let list: ListOfDefinition<_,_> = { OfType = x }
             upcast list
         
     interface OutputDef with
@@ -475,7 +475,7 @@ and [<CustomEquality; NoComparison>] ObjectDefinition<'Val> =
             let nullable: NullableDefinition<_> = { OfType = x }
             upcast nullable
         member x.MakeList() = 
-            let list: ListOfDefinition<_> = { OfType = x }
+            let list: ListOfDefinition<_,_> = { OfType = x }
             upcast list
         
     interface OutputDef with
@@ -599,7 +599,7 @@ and [<CustomEquality; NoComparison>] InterfaceDefinition<'Val> =
             let nullable: NullableDefinition<_> = { OfType = x }
             upcast nullable
         member x.MakeList() = 
-            let list: ListOfDefinition<_> = { OfType = x }
+            let list: ListOfDefinition<_,_> = { OfType = x }
             upcast list
         
     interface OutputDef with
@@ -671,7 +671,7 @@ and [<CustomEquality; NoComparison>] UnionDefinition<'In, 'Out> =
             let nullable: NullableDefinition<_> = { OfType = x }
             upcast nullable
         member x.MakeList() = 
-            let list: ListOfDefinition<_> = { OfType = x }
+            let list: ListOfDefinition<_,_> = { OfType = x }
             upcast list
         
     interface OutputDef with
@@ -713,26 +713,26 @@ and ListOfDef =
         inherit OutputDef
     end
 
-and ListOfDef<'Val> = 
+and ListOfDef<'Val, 'Seq when 'Seq :> 'Val seq> = 
     interface
         abstract OfType : TypeDef<'Val>
-        inherit TypeDef<'Val seq>
-        inherit InputDef<'Val seq>
-        inherit OutputDef<'Val seq>
+        inherit TypeDef<'Seq>
+        inherit InputDef<'Seq>
+        inherit OutputDef<'Seq>
     end
 
-and ListOfDefinition<'Val> = 
+and ListOfDefinition<'Val, 'Seq when 'Seq :> 'Val seq> = 
     { OfType : TypeDef<'Val> }
     
     interface InputDef with
-        member __.InputType = typeof<'Val seq>
+        member __.InputType = typeof<'Seq>
 
     interface TypeDef with
         member x.MakeNullable() = 
             let nullable: NullableDefinition<_> = { OfType = x }
             upcast nullable
         member x.MakeList() = 
-            let list: ListOfDefinition<_> = { OfType = x }
+            let list: ListOfDefinition<_, _> = { OfType = x }
             upcast list
         
     interface OutputDef with
@@ -741,7 +741,7 @@ and ListOfDefinition<'Val> =
     interface ListOfDef with
         member x.OfType = upcast x.OfType
     
-    interface ListOfDef<'Val> with
+    interface ListOfDef<'Val, 'Seq> with
         member x.OfType = x.OfType
     
     override x.ToString() = 
@@ -772,7 +772,7 @@ and NullableDefinition<'Val> =
     interface TypeDef with
         member x.MakeNullable() = upcast x
         member x.MakeList() = 
-            let list: ListOfDefinition<_> = { OfType = x }
+            let list: ListOfDefinition<_,_> = { OfType = x }
             upcast list
         
     interface OutputDef with
@@ -821,7 +821,7 @@ and InputObjectDefinition<'Val> =
             let nullable: NullableDefinition<_> = { OfType = x }
             upcast nullable
         member x.MakeList() = 
-            let list: ListOfDefinition<_> = { OfType = x }
+            let list: ListOfDefinition<_,_> = { OfType = x }
             upcast list
 
 and ExecuteInput = Map<string,obj> -> Value -> obj
@@ -1080,7 +1080,7 @@ module SchemaDefinitions =
         | _ -> None
     
     let Nullable(innerDef : #TypeDef<'Val>) : NullableDefinition<'Val> = { OfType = innerDef }
-    let ListOf(innerDef : #TypeDef<'Val>) : ListOfDefinition<'Val> = { OfType = innerDef }
+    let ListOf(innerDef : #TypeDef<'Val>) : ListOfDefinition<'Val, 'Seq> = { OfType = innerDef }
     
     let (|Scalar|_|) (tdef : TypeDef) = 
         match tdef with

--- a/tests/FSharp.Data.GraphQL.Tests/AbstractionTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/AbstractionTests.fs
@@ -57,7 +57,7 @@ let ``Execute handles execution of abstract types: isTypeOf is used to resolve r
         ])
     let schema = Schema(
         query = Define.Object("Query", fun () -> [
-            Define.Field("pets", ListOf PetType, fun _ _ -> upcast [ { Name = "Odie"; Woofs = true } :> IPet ; upcast { Name = "Garfield"; Meows = false } ])
+            Define.Field("pets", ListOf PetType, fun _ _ -> [ { Name = "Odie"; Woofs = true } :> IPet ; upcast { Name = "Garfield"; Meows = false } ])
         ]), 
         config = { SchemaConfig.Default with Types = [CatType; DogType] })
     let query = """{
@@ -102,7 +102,7 @@ let ``Execute handles execution of abstract types: isTypeOf is used to resolve r
     let PetType = Define.Union("Pet", [ DogType; CatType ], resolvePet)
     let schema = Schema(
         query = Define.Object("Query", fun () -> [
-            Define.Field("pets", ListOf PetType, fun _ _ -> upcast [ DogCase { Name = "Odie"; Woofs = true }; CatCase { Name = "Garfield"; Meows = false } ])
+            Define.Field("pets", ListOf PetType, fun _ _ -> [ DogCase { Name = "Odie"; Woofs = true }; CatCase { Name = "Garfield"; Meows = false } ])
         ]))
     let query = """{
       pets {

--- a/tests/FSharp.Data.GraphQL.Tests/ExecutionTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/ExecutionTests.fs
@@ -93,7 +93,7 @@ let ``Execution handles basic tasks: executes arbitrary code`` () =
     let DeepDataType = Define.Object<DeepTestSubject>("DeepDataType", [
         Define.Field("a", String, (fun _ dt -> dt.a))
         Define.Field("b", String, (fun _ dt -> dt.b))
-        Define.Field("c", (ListOf String), (fun _ dt -> upcast dt.c))
+        Define.Field("c", (ListOf String), (fun _ dt -> dt.c))
     ])
     let rec DataType = Define.Object<TestSubject>("DataType", fieldsFn = fun () -> [
         Define.Field("a", String, fun _ dt -> dt.a)

--- a/tests/FSharp.Data.GraphQL.Tests/PlanningTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/PlanningTests.fs
@@ -120,7 +120,7 @@ let ``Planning should work with parallel fragments``() =
 
 [<Fact>]
 let ``Planning should work with lists``() = 
-    let Query = Define.Object("Query", [ Define.Field("people", ListOf Person, fun _ () -> upcast people) ])
+    let Query = Define.Object("Query", [ Define.Field("people", ListOf Person, fun _ () -> people) ])
     let schema = Schema(Query)
     let query = """{
         people {
@@ -142,7 +142,7 @@ let ``Planning should work with lists``() =
 
 [<Fact>]
 let ``Planning should work with interfaces``() = 
-    let Query = Define.Object("Query", [ Define.Field("names", ListOf INamed, fun _ () -> upcast []) ])
+    let Query = Define.Object("Query", [ Define.Field("names", ListOf INamed, fun _ () -> []) ])
     let schema = Schema(query = Query, config = { SchemaConfig.Default with Types = [ Person; Animal ] })
     let query = """query Example {
         names {
@@ -173,7 +173,7 @@ let ``Planning should work with interfaces``() =
 
 [<Fact>]
 let ``Planning should work with unions``() = 
-    let Query = Define.Object("Query", [ Define.Field("names", ListOf UNamed, fun _ () -> upcast []) ])
+    let Query = Define.Object("Query", [ Define.Field("names", ListOf UNamed, fun _ () -> []) ])
     let schema = Schema(Query)
     let query = """query Example {
         names {

--- a/tests/FSharp.Data.GraphQL.Tests/UnionInterfaceTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/UnionInterfaceTests.fs
@@ -76,7 +76,7 @@ let PersonType = Define.Object(
     interfaces = [ NamedType ],
     fields = [
         Define.Field("name", String)
-        Define.Field("pets", ListOf PetType, fun _ person -> upcast person.Pets)
+        Define.Field("pets", ListOf PetType, fun _ person -> person.Pets)
         Define.Field("friends", ListOf NamedType)
     ])
 


### PR DESCRIPTION
So far, usage of `ListOf` was always constraining an output type to be `'a seq`, eg.:  `Define.Field("pets", ListOf PetType, fun _ person -> upcast [])`. Upcasting the result was necessary here. Moreover, a information about original type returned was lost (or at least it was hard to determine at runtime using only field definition data).

Now `ListOf` will be able to carry on the information not only about the generic type param (`PetType` in the example), but also about the returned data type (which has been constrained to any type deriving from `seq`). Therefore we can now use `Define.Field("pets", ListOf PetType, fun _ person -> [])` and know what collection type was actually returned.

This is necessary for #61 as casting to seq/enumerable from fields marked originally as `IQueryable` would result in implicit N+1 SELECT problems.
