### PR TITLE
Typed queries

### DIFF
--- a/samples/client-provider/query.fsx
+++ b/samples/client-provider/query.fsx
@@ -17,7 +17,7 @@ async {
                 Fields(
                     c.name,
                     Selection(c.friends, fun f -> Fields(f.name)),
-                    On<MyClient.Types.Human>("Human", fun h -> Fields(h.appearsIn))
+                    MyClient.Types.Human.On(fun h -> Fields(h.appearsIn))
                 ))
     match hero with
     | None -> ()

--- a/samples/client-provider/query.fsx
+++ b/samples/client-provider/query.fsx
@@ -25,7 +25,8 @@ async {
                 Fields(
                     c.name,
                     c.appearsIn,
-                    fun (friends: MyClient.Types.Character) -> Fields(friends.name)
+                    Selection(c.friends, fun f -> Fields(f.[0].name))
+                    // On<MyClient.Types.Human>(fun h -> Fields(h.appearsIn))
                 ))
     match hero with
     | None -> ()

--- a/samples/client-provider/query.fsx
+++ b/samples/client-provider/query.fsx
@@ -3,7 +3,7 @@
 open FSharp.Data.GraphQL
 open System.Collections.Generic
 
-#if FABLE
+#if FABLE_COMPILER
 #r "node_modules/fable-core/Fable.Core.dll"
 Fable.Core.JsInterop.importAll<unit> "isomorphic-fetch"
 #endif
@@ -21,7 +21,12 @@ type MyClient = GraphQLProvider<serverUrl>
 //     |> Async.RunSynchronously
 
 async {
-    let! hero = MyClient.Queries.Hero<queryFieldsWithFragments>("1000")
+    let! hero = MyClient.Queries.Hero("1000", fun c ->
+                Fields(
+                    c.name,
+                    c.appearsIn,
+                    fun (friends: MyClient.Types.Character) -> Fields(friends.name)
+                ))
     match hero with
     | None -> ()
     | Some hero ->

--- a/samples/client-provider/query.fsx
+++ b/samples/client-provider/query.fsx
@@ -24,9 +24,9 @@ async {
     let! hero = MyClient.Queries.Hero("1000", fun c ->
                 Fields(
                     c.name,
-                    c.appearsIn,
-                    Selection(c.friends, fun f -> Fields(f.[0].name))
-                    // On<MyClient.Types.Human>(fun h -> Fields(h.appearsIn))
+                    // c.appearsIn,
+                    Selection(c.friends, fun f -> Fields(f.[0].name)),
+                    On<MyClient.Types.Human>("Human", fun h -> Fields(h.appearsIn))
                 ))
     match hero with
     | None -> ()

--- a/samples/graphiql-client/server.fsx
+++ b/samples/graphiql-client/server.fsx
@@ -188,6 +188,7 @@ let graphiql : WebPart =
         async {
             match tryParse "query" http.request.rawForm with
             | Some query ->
+                printfn "Received query: %s" query
                 // at the moment parser is not parsing new lines correctly, so we need to get rid of them
                 let q = query.Trim().Replace("\r\n", " ")
                 let! result = schema.AsyncExecute(q)   

--- a/samples/todo-graphql/client.fsx
+++ b/samples/todo-graphql/client.fsx
@@ -1,4 +1,4 @@
-﻿#r "../../src/FSharp.Data.GraphQL.Client/bin/Debug/FSharp.Data.GraphQL.Client.dll"
+﻿#r "../../bin/FSharp.Data.GraphQL.Client/FSharp.Data.GraphQL.Client.dll"
 
 open FSharp.Data.GraphQL
 open System.Collections.Generic
@@ -23,7 +23,8 @@ async {
 } |> Async.StartImmediate
 
 async {
-    let! task = MyClient.Queries.Task<queryFields>(taskId)
+    let projection = <@@ fun (t: MyClient.Types.Task) -> t.description, t.completed @@>
+    let! task = MyClient.Queries.Task(taskId, projection)
     match task with
     | None -> ()
     | Some task ->

--- a/samples/todo-graphql/client.fsx
+++ b/samples/todo-graphql/client.fsx
@@ -23,8 +23,8 @@ async {
 } |> Async.StartImmediate
 
 async {
-    let projection = <@@ fun (t: MyClient.Types.Task) -> t.description, t.completed @@>
-    let! task = MyClient.Queries.Task(taskId, projection)
+    // let projection = <@@ fun (t: MyClient.Types.Task) -> t.description, t.completed @@>
+    let! task = MyClient.Queries.Task(taskId, fun t -> upcast (t.description, t.completed))
     match task with
     | None -> ()
     | Some task ->

--- a/samples/todo-graphql/client.fsx
+++ b/samples/todo-graphql/client.fsx
@@ -23,8 +23,7 @@ async {
 } |> Async.StartImmediate
 
 async {
-    // let projection = <@@ fun (t: MyClient.Types.Task) -> t.description, t.completed @@>
-    let! task = MyClient.Queries.Task(taskId, fun t -> upcast (t.description, t.completed))
+    let! task = MyClient.Queries.Task(taskId, fun t -> Fields(t.description, t.completed))
     match task with
     | None -> ()
     | Some task ->

--- a/src/FSharp.Data.GraphQL.Client/FSharp.Data.GraphQL.Client.fsproj
+++ b/src/FSharp.Data.GraphQL.Client/FSharp.Data.GraphQL.Client.fsproj
@@ -45,7 +45,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
   </ItemGroup>
-  <ItemGroup Condition="$(DefineConstants.Contains('FABLE'))">
+  <ItemGroup>
     <Reference Include="Fable.Core">
       <HintPath>npm/node_modules/fable-core/Fable.Core.dll</HintPath>
       <Private>True</Private>

--- a/src/FSharp.Data.GraphQL.Client/FSharp.Data.GraphQL.Client.fsproj
+++ b/src/FSharp.Data.GraphQL.Client/FSharp.Data.GraphQL.Client.fsproj
@@ -32,7 +32,7 @@
     <Optimize>true</Optimize>
     <Tailcalls>true</Tailcalls>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;NO_GENERATIVE</DefineConstants>
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>bin\Release\FSharp.Data.GraphQL.Client.XML</DocumentationFile>
   </PropertyGroup>

--- a/src/FSharp.Data.GraphQL.Client/GraphQlProvider.fs
+++ b/src/FSharp.Data.GraphQL.Client/GraphQlProvider.fs
@@ -89,7 +89,7 @@ module Util =
             @@>
         m
 
-    let createMethod (tdef: ProvidedTypeDefinition) (schemaTypes: Map<string,TypeReference>)
+    let createMethod (schemaTypes: Map<string,TypeReference>)
                      (serverUrl: string) (opName: string) (opField: IntrospectionField) =
         let findType (t: IntrospectionTypeRef) =
             TypeReference.findType t schemaTypes
@@ -135,34 +135,6 @@ module Util =
                             |> buildQuery opField (extractFields (%%Expr.Coerce(List.last argValues, typeof<Expr>))) argNames
                             |> launchRequest serverUrl opName opField id
                         @@>
-            // let sargs = [ProvidedStaticParameter("content", typeof<string>)]
-            // m.DefineStaticParameters(sargs, fun methName sargValues ->
-            //     match sargValues with 
-            //     | [| :? string as resFields |] ->
-            //         // This will fail if the query is not well formed
-            //         do Parser.parse resFields |> ignore
-            //         let opField = opField.Name
-            //         let argNames = args |> Seq.map (fun x -> x.Name) |> Seq.toArray
-            //         let m2 = ProvidedMethod(methName, args, asyncType, IsStaticMethod = true)
-            //         m2.InvokeCode <-
-            //             if resType.Name = "FSharpOption`1" then
-            //                 fun argValues ->
-            //                 <@@
-            //                     (%%makeExprArray argValues: obj[])
-            //                     |> buildQuery opField resFields argNames
-            //                     |> launchRequest serverUrl opName opField Option.ofObj
-            //                 @@>                      
-            //             else
-            //                 fun argValues ->
-            //                 <@@
-            //                     (%%makeExprArray argValues: obj[])
-            //                     |> buildQuery opField resFields argNames
-            //                     |> launchRequest serverUrl opName opField id
-            //                 @@>
-            //         tdef.AddMember m2
-            //         m2
-            //     | _ -> failwith "unexpected parameter values")
-            // m.InvokeCode <- fun _ -> <@@ null @@> // Dummy code
             m
 
     let createMethods (tdef: ProvidedTypeDefinition) (serverUrl: string)
@@ -181,7 +153,7 @@ module Util =
                 if t.Name = opName && t.Fields.IsSome && not (Array.isEmpty t.Fields.Value) then
                     let wrapper = ProvidedTypeDefinition(wrapperName, Some typeof<obj>)
                     t.Fields.Value
-                    |> Seq.map (createMethod wrapper schemaTypes serverUrl (opPrefix + opName))
+                    |> Seq.map (createMethod schemaTypes serverUrl (opPrefix + opName))
                     |> Seq.toList
                     |> wrapper.AddMembers
                     tdef.AddMember wrapper)
@@ -194,7 +166,7 @@ type internal ProviderSchemaConfig =
 [<TypeProvider>]
 type GraphQlProvider (config : TypeProviderConfig) as this =
     inherit TypeProviderForNamespaces ()
-    
+
     let asm = System.Reflection.Assembly.GetExecutingAssembly()
 
     do

--- a/src/FSharp.Data.GraphQL.Client/GraphQlProvider.fs
+++ b/src/FSharp.Data.GraphQL.Client/GraphQlProvider.fs
@@ -114,7 +114,7 @@ module Util =
                 let resType =
                     if resType.Name = "FSharpOption`1"
                     then resType.GenericTypeArguments.[0] else resType
-                let funType = typedefof<obj->obj>.MakeGenericType(resType, typeof<obj>)
+                let funType = typedefof<obj->obj>.MakeGenericType(resType, typeof<Fields>)
                 typedefof<Expr<obj>>.MakeGenericType(funType)
             let projection = ProvidedParameter("projection", projType, IsReflectedDefinition=true)
             let m = ProvidedMethod(firstToUpper opField.Name, args@[projection], asyncType, IsStaticMethod=true)

--- a/src/FSharp.Data.GraphQL.Client/IntrospectionParser.fs
+++ b/src/FSharp.Data.GraphQL.Client/IntrospectionParser.fs
@@ -198,6 +198,7 @@ module TypeCompiler =
         match itype.Kind with
         | TypeKind.OBJECT ->
             let t = ProvidedTypeDefinition(itype.Name, Some typeof<obj>)
+            // TODO: This is not working, attributes are being erased
             CustomAttributeDataExt.Make(
                 typeof<DisplayNameAttribute>.GetConstructor([|typeof<string>|]),
                 [| CustomAttributeTypedArgument(typeof<DisplayNameAttribute>, itype.Name) |])

--- a/src/FSharp.Data.GraphQL.Client/IntrospectionParser.fs
+++ b/src/FSharp.Data.GraphQL.Client/IntrospectionParser.fs
@@ -187,22 +187,17 @@ module TypeCompiler =
 //        | TypeKind.SCALAR -> genScalar ctx itype t
 //        | _ -> failwithf "Illegal type kind %s" (itype.Kind.ToString())
 
-    type CustomAttributeDataExt =
-        static member Make(ctorInfo, ?args, ?namedArgs) = 
-            { new CustomAttributeData() with 
-                member __.Constructor =  ctorInfo
-                member __.ConstructorArguments = defaultArg args [||] :> IList<_>
-                member __.NamedArguments = defaultArg namedArgs [||] :> IList<_> }
-
     let initType (ctx: ProviderSessionContext) (itype: IntrospectionType) = 
         match itype.Kind with
         | TypeKind.OBJECT ->
-            let t = ProvidedTypeDefinition(itype.Name, Some typeof<obj>)
-            // TODO: This is not working, attributes are being erased
-            CustomAttributeDataExt.Make(
-                typeof<DisplayNameAttribute>.GetConstructor([|typeof<string>|]),
-                [| CustomAttributeTypedArgument(typeof<DisplayNameAttribute>, itype.Name) |])
-            |> t.AddCustomAttribute
+            let typeName = itype.Name
+            let t = ProvidedTypeDefinition(typeName, Some typeof<obj>)
+            let funType = typedefof<obj->obj>.MakeGenericType(t, typeof<Fields>)
+            let m = ProvidedMethod("On", [ProvidedParameter("selection", funType)], typeof<obj>)
+            m.IsStaticMethod <- true
+            m.InvokeCode <- fun args ->
+                <@@ InlineFragment(typeName, %%args.Head) @@>
+            t.AddMember m
             t
         | TypeKind.INPUT_OBJECT -> ProvidedTypeDefinition(itype.Name, Some typeof<obj>)
         | TypeKind.SCALAR -> ProvidedTypeDefinition(itype.Name, Some typeof<obj>)

--- a/src/FSharp.Data.GraphQL.Client/ProvidedTypes.fsi
+++ b/src/FSharp.Data.GraphQL.Client/ProvidedTypes.fsi
@@ -23,6 +23,7 @@ type ProvidedParameter =
     // [<CompilerMessage("Please create a ProvidedTypesContext and use ctxt.ProvidedParameter to create a provided parameter. This will help allow your type provider to target portable profiles where that makes sense. Some argument names and values may need adjusting.", 8796)>]
     new : parameterName: string * parameterType: Type * ?isOut:bool * ?optionalValue:obj -> ProvidedParameter
     member IsParamArray : bool with get,set
+    member IsReflectedDefinition : bool with get,set
 
 /// Represents a provided static parameter.
 type ProvidedStaticParameter =

--- a/src/FSharp.Data.GraphQL.Client/QuotationHelpers.fs
+++ b/src/FSharp.Data.GraphQL.Client/QuotationHelpers.fs
@@ -110,8 +110,10 @@ module QuotationHelpers =
                 failwithf "Only projections of the form p.Prop are supported! Got %A" e
         // printfn "%A" projection
         match projection with
+        | Lambda(var, Coerce(NewTuple args,_))
         | Lambda(var, NewTuple args) ->
             List.map (translatePropGet var.Name) args
+        | Lambda(var, Coerce(arg,_))
         | Lambda(var, arg) ->
             [translatePropGet var.Name arg]
         | _ -> failwithf "Unsupported projection: %A" projection

--- a/src/FSharp.Data.GraphQL.Client/QuotationHelpers.fs
+++ b/src/FSharp.Data.GraphQL.Client/QuotationHelpers.fs
@@ -9,8 +9,11 @@ type Fields([<System.ParamArray>] fields: obj[]) =
     class end
 
 /// Dummy type to wrap a field with a selection in a GraphQL query projection
-type Selection<'T>(field: 'T, selection: 'T->Fields) =
-    class end
+type Selection<'T> private () =
+    new (fields: 'T[] option, selection: 'T->Fields) = Selection()
+    new (fields: 'T option, selection: 'T->Fields) = Selection()
+    new (fields: 'T[], selection: 'T->Fields) = Selection()
+    new (fields: 'T, selection: 'T->Fields) = Selection()
 
 /// Dummy type to wrap an inline fragment with type condition in a GraphQL query projection
 type On<'T>(typeName: string, selection: 'T->Fields) =


### PR DESCRIPTION
This is the first proof of concept for typed queries. In its current form the GraphQL type provider just uses a literal string to specify which fields the user wants to receive from the server. For example:

``` fsharp
let [<Literal>] queryFields = "{ id, name, appearsIn, friends { name } }"
let [<Literal>] queryFieldsWithFragments = "{ ...data, friends { name } } fragment data on Human { id, name, appearsIn }"

type MyClient = GraphQLProvider<serverUrl>

async {
    let! hero = MyClient.Queries.Hero<queryFieldsWithFragments>("1000")
    ...
}
```

There're a couple of advantages of these approach but not many:
- It's not necessary to write the name and arguments of the query (here: `{ hero(id:"1000") ... }`) as this is determined by the provided method.
- The string is checked a compile time (that's why the string must be a literal passed a a static argument) so the code won't compile if the query is malformed.

However, these advantages don't seem to be enough to justify a type provider, so it's worth exploring some ways to make the projection in a type-safe manner with intellisense. With this goal, first I tried to implement a custom query expression builder, as in [this article](http://tomasp.net/blog/2015/query-translation/), which could look like this:

``` fsharp
query { 
  for h in MyClient.Queries.Hero do
  where (h.id = 10)
  select (h.name, h.appearsIn) }
```

However, I discarded this approach because of two reasons:
- In query expressions, the user decides the query source. In the GraphQL the source is defined by the provided query method, which also defines the arguments valid for that query.
- The operations in GraphQL (filtering, grouping...) are defined by the arguments, so we only need a simple projection for the result and building a whole query expression seems overkill for that.

The projection may be expressed with a simple lambda and that's what I'm trying to do at the moment: 

``` fsharp
MyClient.Queries.Task(taskId,
    <@@ fun (t: MyClient.Types.Task) -> t.description, t.completed @@>)
```

> Ideally a simple lambda should be enough instead of a explicit quotation. 

For testing purposes, I'm just removing the old methods which accepted a literal string as a static argument. We need to decide if we want to have both solutions side by side, or we focus on this new approach to avoid confusion (and maybe add a simple method to easily send string queries at runtime in case of need).
