### PR TITLE
fixed field alias parsing in case of no whitespace after colon character

### DIFF
--- a/src/FSharp.Data.GraphQL.Shared/Parser.fs
+++ b/src/FSharp.Data.GraphQL.Shared/Parser.fs
@@ -226,7 +226,7 @@ module internal Internal =
   // 2.5 Fields
   //   (Alias opt) Name (Arguments opt) (Directives opt) (SelectionSet opt)
   let field = 
-    let alias = token_ws name .>> ctoken_ws ':' 
+    let alias = token_ws name .>> pchar ':' .>> whitespaces
     pipe5 (opt(attempt alias)) (token_ws name) (opt(token_ws arguments)) (opt directives) (opt selectionSet)
       (fun oalias name oargs directives oselection ->
          (Field { Alias = oalias; Name = name; Arguments = someOrEmpty oargs;

--- a/tests/FSharp.Data.GraphQL.Tests/ParserTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/ParserTests.fs
@@ -337,7 +337,7 @@ let ``parser should parse query with field alias``() =
         id
         name
         smallPic: profilePic(size: 64)
-        bigPic: profilePic(size: 1024)
+        bigPic:profilePic(size: 1024)
       }
     }"""
 


### PR DESCRIPTION
This is important issue because Relay client creates aliases without whitespace. E.g. 

```
query Routes {
          me {...F0  }
        }
        fragment F0 on Me {
          _channel2sNmIg:channel(key:\"sales\") {
              name,
              items {
                   id,
                   name,
                   author {login},
                   _meta {updatedAt, id}
              }
          }
        }
```
