### PR TITLE
Removed Hopac dependency

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -5,7 +5,6 @@ nuget FParsec
 nuget FSCheck
 nuget FSharp.Data.TypeProviders
 nuget FSharp.Quotations.Evaluator
-nuget Hopac
 nuget Newtonsoft.Json
 nuget Suave
 nuget System.Collections.Immutable

--- a/src/FSharp.Data.GraphQL.Server/Execution.fs
+++ b/src/FSharp.Data.GraphQL.Server/Execution.fs
@@ -296,10 +296,9 @@ and internal compileField possibleTypesFn (fieldDef: FieldDef) : ExecuteField =
         let compiled = boxified.Compile()
         fun resolveFieldCtx value -> 
             try
-                let res = compiled resolveFieldCtx value
-                if Object.ReferenceEquals(res, null)
-                then AsyncVal.empty
-                else completed resolveFieldCtx res
+                compiled resolveFieldCtx value
+                |> AsyncVal.ofAsync
+                |> AsyncVal.bind (completed resolveFieldCtx)
             with
             | ex -> 
                 resolveFieldCtx.AddError(ex)

--- a/src/FSharp.Data.GraphQL.Server/FSharp.Data.GraphQL.Server.fsproj
+++ b/src/FSharp.Data.GraphQL.Server/FSharp.Data.GraphQL.Server.fsproj
@@ -131,25 +131,4 @@
       </ItemGroup>
     </When>
   </Choose>
-  <Choose>
-    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v1.2' Or $(TargetFrameworkVersion) == 'v1.3' Or $(TargetFrameworkVersion) == 'v1.4' Or $(TargetFrameworkVersion) == 'v1.5')) Or ($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2'))">
-      <ItemGroup>
-        <Reference Include="Hopac.Core">
-          <HintPath>..\..\packages\Hopac\lib\net45\Hopac.Core.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-        <Reference Include="Hopac.Platform">
-          <HintPath>..\..\packages\Hopac\lib\net45\Hopac.Platform.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-        <Reference Include="Hopac">
-          <HintPath>..\..\packages\Hopac\lib\net45\Hopac.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-  </Choose>
 </Project>

--- a/src/FSharp.Data.GraphQL.Server/paket.references
+++ b/src/FSharp.Data.GraphQL.Server/paket.references
@@ -1,3 +1,2 @@
 FSharp.Core
-Hopac
 FSharp.Quotations.Evaluator

--- a/src/FSharp.Data.GraphQL.Shared/AsyncVal.fs
+++ b/src/FSharp.Data.GraphQL.Shared/AsyncVal.fs
@@ -10,6 +10,10 @@ type AsyncVal<'T> =
     new (async: Async<'T>) = { Value = Unchecked.defaultof<'T>; Async = async }
     member x.IsAsync = not (System.Object.ReferenceEquals(x.Async, null))
     member x.IsSync = System.Object.ReferenceEquals(x.Async, null)
+    override x.ToString () = 
+        if x.IsSync 
+        then "AsyncVal(" + x.Value.ToString() + ")"
+        else "AsyncVal(Async<>)"
     static member Zero = AsyncVal<'T>(Unchecked.defaultof<'T>)
     
 [<RequireQualifiedAccess>]

--- a/src/FSharp.Data.GraphQL.Shared/AsyncVal.fs
+++ b/src/FSharp.Data.GraphQL.Shared/AsyncVal.fs
@@ -125,12 +125,16 @@ module AsyncVal =
             ofAsync x
         | immediates, awaitings ->
             //TODO: optimize
+            let len =  immediates.Length
             let asyncs = awaitings |> Array.map (fun v -> v.Async)
-            let x = 
-                immediates
-                |> Array.map (toAsync)
-                |> Array.append asyncs
-                |> Async.Parallel
+            let results = Array.zeroCreate (len + asyncs.Length)
+            for i = 0 to len - 1 do
+                results.[i] <- immediates.[i].Value
+            let x = async {
+                let! asyncResults = asyncs |> Async.Parallel
+                Array.Copy(asyncResults, 0, results, len, asyncResults.Length)
+                return results
+            }
             ofAsync x
 
 type AsyncValBuilder () =

--- a/src/FSharp.Data.GraphQL.Shared/AsyncVal.fs
+++ b/src/FSharp.Data.GraphQL.Shared/AsyncVal.fs
@@ -1,0 +1,173 @@
+﻿namespace FSharp.Data.GraphQL
+
+open System
+
+[<Struct>]
+type AsyncVal<'T> =
+    val Value : 'T
+    val Async : Async<'T>
+    new (value: 'T) = { Value = value; Async = Unchecked.defaultof<Async<'T>> }
+    new (async: Async<'T>) = { Value = Unchecked.defaultof<'T>; Async = async }
+    member x.IsAsync = not (System.Object.ReferenceEquals(x.Async, null))
+    member x.IsSync = System.Object.ReferenceEquals(x.Async, null)
+    static member Zero = AsyncVal<'T>(Unchecked.defaultof<'T>)
+    
+[<RequireQualifiedAccess>]
+module AsyncVal =
+    
+    /// Returns true if AsyncVal wraps an Async computation, otherwise false.
+    let inline isAsync (x: AsyncVal<'T>) = x.IsAsync
+
+    /// Returns true if AsyncVal contains immediate result, otherwise false.
+    let inline isSync (x: AsyncVal<'T>) = x.IsSync
+
+    /// Returns value wrapped by current AsyncVal. If it's part of Async computation,
+    /// it's executed synchronously and then value is returned.
+    let get (x: AsyncVal<'T>) = 
+        if x.IsSync 
+        then x.Value
+        else x.Async |> Async.RunSynchronously
+
+    /// Create new AsyncVal from Async computation.
+    let inline ofAsync (a: Async<'T>) = AsyncVal<'T>(a)
+
+    /// Returns an AsyncVal wrapper around provided Async computation.
+    let inline wrap (v: 'T) = AsyncVal<'T>(v)
+    
+    /// Converts AsyncVal to Async computation.
+    let toAsync (x: AsyncVal<'T>) =
+        if x.IsSync
+        then async.Return x.Value
+        else x.Async
+
+    /// Returns an empty AsyncVal with immediatelly executed value.
+    let inline empty<'T> : AsyncVal<'T> = AsyncVal<'T>.Zero
+
+    /// Maps content of AsyncVal using provided mapping function, returning new 
+    /// AsyncVal as the result.
+    let map (fn: 'T -> 'Res) (x: AsyncVal<'T>) =
+        if x.IsSync
+        then AsyncVal<'Res>(fn x.Value)
+        else AsyncVal<'Res> (async {
+            let! result = x.Async
+            return fn result })
+
+    /// Folds content of AsyncVal over provided initial state zero using provided fn.
+    /// Returns new AsyncVal as a result.
+    let fold (fn: 'State -> 'T -> 'State) (zero: 'State) (x: AsyncVal<'T>) : AsyncVal<'State> =
+        if x.IsSync
+        then AsyncVal<_> (fn zero x.Value)
+        else ofAsync <| async {
+            let! res = x.Async 
+            return fn zero res }
+
+    /// Binds AsyncVal using binder function to produce new AsyncVal.
+    let bind (binder: 'T -> AsyncVal<'U>) (x: AsyncVal<'T>) : AsyncVal<'U> =
+        if x.IsSync
+        then binder x.Value
+        else ofAsync <| async {
+            let! value = x.Async
+            let bound = binder value
+            if bound.IsSync
+            then return bound.Value
+            else return! bound.Async }
+            
+    /// Converts array of AsyncVals into AsyncVal with array results.
+    /// In case when are non-immediate values in provided array, they are 
+    /// executed asynchronously, one by one with regard to their order in array.
+    let collectSequential (values: AsyncVal<'T> []) : AsyncVal<'T []> =
+        let i, a = values |> Array.partition isSync
+        match i, a with
+        | [||], [||] -> AsyncVal<_> [||]
+        | immediates, [||] -> 
+            let x = immediates |> Array.map (fun v -> v.Value)
+            AsyncVal<_> x
+        | [||], awaitings -> 
+            let asyncs = awaitings |> Array.map (fun v -> v.Async)
+            let x = async {
+                let results = Array.zeroCreate asyncs.Length
+                let mutable i = 0
+                for a in asyncs do
+                    let! res = a
+                    results.[i] <- res
+                    i <- i + 1
+                return results
+            }
+            ofAsync x
+        | immediates, awaitings ->
+            //TODO: optimize
+            let ready = immediates |> Array.map (fun v -> v.Value)
+            let asyncs = awaitings |> Array.map (fun v -> v.Async)
+            let x = async {
+                let results = Array.zeroCreate (ready.Length + asyncs.Length)
+                Array.Copy(ready, results, ready.Length)
+                let mutable i = ready.Length
+                for a in asyncs do
+                    let! res = a
+                    results.[i] <- res
+                    i <- i + 1
+                return results
+            }
+            ofAsync x
+
+    /// Converts array of AsyncVals into AsyncVal with array results.
+    /// In case when are non-immediate values in provided array, they are 
+    /// executed all in parallel, in unordered fashion.
+    let collectParallel (values: AsyncVal<'T> []) : AsyncVal<'T []> =
+        let i, a = values |> Array.partition isSync
+        match i, a with
+        | [||], [||] -> AsyncVal<_> [||]
+        | immediates, [||] -> 
+            let x = immediates |> Array.map (fun v -> v.Value)
+            AsyncVal<_> x
+        | [||], awaitings -> 
+            let x = awaitings |> Array.map (fun v -> v.Async) |> Async.Parallel
+            ofAsync x
+        | immediates, awaitings ->
+            //TODO: optimize
+            let asyncs = awaitings |> Array.map (fun v -> v.Async)
+            let x = 
+                immediates
+                |> Array.map (toAsync)
+                |> Array.append asyncs
+                |> Async.Parallel
+            ofAsync x
+
+type AsyncValBuilder () =
+    member x.Zero () = AsyncVal.empty
+    member x.Return v = AsyncVal.wrap v
+    member x.ReturnFrom (v: AsyncVal<_>) = v
+    member x.ReturnFrom (a: Async<_>) = AsyncVal.ofAsync a
+    member x.Bind (v: AsyncVal<'T>, binder: 'T -> AsyncVal<'U>) = 
+        AsyncVal.bind binder v
+    member x.Bind (a: Async<'T>, binder: 'T -> AsyncVal<'U>) = 
+        AsyncVal.ofAsync <| async {
+            let! value = a
+            let bound = binder value
+            if bound.IsSync
+            then return bound.Value
+            else return! bound.Async }
+            
+[<AutoOpen>]
+module AsyncExtensions =
+    
+    /// Computation expression for working on AsyncVals.
+    let asyncVal = AsyncValBuilder ()
+    
+    /// Active pattern used for checking if AsyncVal contains immediate value.
+    let (|Immediate|_|) (x: AsyncVal<'T>) = if x.IsSync then Some x.Value else None
+
+    /// Active patter used for checking if AsyncVal wraps an Async computation.
+    let (|Async|_|) (x: AsyncVal<'T>) = if x.IsAsync then Some x.Async else None
+
+    type Microsoft.FSharp.Control.AsyncBuilder with
+
+        member x.ReturnFrom (v: AsyncVal<'T>) =
+            if v.IsSync 
+            then async.Return v.Value
+            else async.ReturnFrom v.Async
+
+        member x.Bind (v: AsyncVal<'T>, binder) =
+            if v.IsSync
+            then async.Bind (async.Return v.Value, binder)
+            else async.Bind (v.Async, binder)

--- a/src/FSharp.Data.GraphQL.Shared/FSharp.Data.GraphQL.Shared.fsproj
+++ b/src/FSharp.Data.GraphQL.Shared/FSharp.Data.GraphQL.Shared.fsproj
@@ -40,6 +40,7 @@
     <Compile Include="Extensions.fs" />
     <Compile Include="Prolog.fs" />
     <Compile Include="Ast.fs" />
+    <Compile Include="AsyncVal.fs" />
     <Compile Include="TypeSystem.fs" />
     <Compile Include="Validation.fs" />
     <Compile Include="Introspection.fs" />

--- a/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
+++ b/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
@@ -351,7 +351,7 @@ and ResolveFieldContext =
     
     member x.Arg(name : string) : 't = downcast Map.find name x.Args
 
-and ExecuteField = ResolveFieldContext -> obj -> Async<obj>
+and ExecuteField = ResolveFieldContext -> obj -> AsyncVal<obj>
 
 and FieldDef = 
     interface

--- a/tests/FSharp.Data.GraphQL.Benchmarks/App.config
+++ b/tests/FSharp.Data.GraphQL.Benchmarks/App.config
@@ -7,7 +7,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.3.0.0" newVersion="4.3.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.4.0.0" newVersion="4.4.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/tests/FSharp.Data.GraphQL.Benchmarks/AsyncValBenchmark.fs
+++ b/tests/FSharp.Data.GraphQL.Benchmarks/AsyncValBenchmark.fs
@@ -1,0 +1,79 @@
+﻿/// The MIT License (MIT)
+/// Copyright (c) 2016 Bazinga Technologies Inc
+
+module FSharp.Data.GraphQL.AsyncValBenchmark
+
+open System
+open BenchmarkDotNet
+open FSharp.Data.GraphQL
+open FSharp.Data.GraphQL.Parser
+
+// TEST 1 - immediatelly return a value
+
+let asyncReturnImmediate () = 
+    let v = async { return 1337 } |> Async.RunSynchronously 
+    ()
+
+let asyncValImmediate () = 
+    let v = asyncVal { return 1337 } |> AsyncVal.get
+    ()
+
+let asyncValAwaiting () = 
+    let v = asyncVal { return async { return 1337 } } |> AsyncVal.get
+    ()
+
+// TEST 2 - immediatelly return a collection of async values
+
+let asyncValCollection vals = 
+    let v = 
+        vals
+        |> AsyncVal.collectParallel 
+        |> AsyncVal.get
+    ()
+
+let asyncCollection vals = 
+    let v = 
+        vals
+        |> Async.Parallel
+        |> Async.RunSynchronously
+    ()
+
+open BenchmarkDotNet.Attributes
+
+[<Config(typeof<GraphQLBenchConfig>)>]
+type AsyncValBenchmark() = 
+    let rand = Random()
+
+    let prepareAsyncs n = 
+        let a = Array.zeroCreate n
+        for i=0 to n-1 do
+            let x = rand.Next()
+            a.[i] <- async { return x }
+        a
+
+    let prepareAsyncVals nsync nasync = 
+        let n = nsync + nasync
+        let a = Array.zeroCreate n
+        for i=0 to nsync-1 do
+            a.[i] <- AsyncVal.wrap (rand.Next())
+        for i=nsync to n-1 do
+            let x = rand.Next ()
+            a.[i] <- AsyncVal.ofAsync (async { return x })
+        a
+
+    let mutable allImmediate : AsyncVal<_> [] = [||]
+    let mutable sync90async10 : AsyncVal<_> [] = [||]
+    let mutable allAsyncVals : AsyncVal<_> [] = [||]
+    let mutable allAsync : Async<_> [] = [||]
+    [<Setup>] member x.Setup () = 
+        allImmediate <- prepareAsyncVals 100 0
+        sync90async10 <- prepareAsyncVals 90 10
+        allAsyncVals <- prepareAsyncVals 0 100
+        allAsync <- prepareAsyncs 100
+    [<Benchmark>] member x.AsyncValImmediate () = asyncValImmediate ()
+    [<Benchmark>] member x.AsyncValAwaiting () = asyncValAwaiting ()
+    [<Benchmark>] member x.AsyncReturnImmediatelly () = asyncReturnImmediate ()
+    [<Benchmark>] member x.AsyncValCollectionAllSync () = asyncValCollection allImmediate
+    [<Benchmark>] member x.AsyncValCollectionAllAsync () = asyncValCollection allAsyncVals
+    [<Benchmark>] member x.AsyncCollection () = asyncCollection allAsync
+    [<Benchmark>] member x.AsyncValCollectionMixed90x10 () = asyncValCollection sync90async10

--- a/tests/FSharp.Data.GraphQL.Benchmarks/FSharp.Data.GraphQL.Benchmarks.fsproj
+++ b/tests/FSharp.Data.GraphQL.Benchmarks/FSharp.Data.GraphQL.Benchmarks.fsproj
@@ -11,7 +11,7 @@
     <AssemblyName>FSharp.Data.GraphQL.Benchmarks</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
+    <TargetFSharpCoreVersion>4.4.0.0</TargetFSharpCoreVersion>
     <Name>FSharp.Data.GraphQL.Benchmarks</Name>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/tests/FSharp.Data.GraphQL.Benchmarks/FSharp.Data.GraphQL.Benchmarks.fsproj
+++ b/tests/FSharp.Data.GraphQL.Benchmarks/FSharp.Data.GraphQL.Benchmarks.fsproj
@@ -107,6 +107,7 @@
     </Content>
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="Prolog.fs" />
+    <Compile Include="AsyncValBenchmark.fs" />
     <Compile Include="ParsingBenchmark.fs" />
     <Compile Include="ExecutionBenchmark.fs" />
     <Compile Include="Program.fs" />

--- a/tests/FSharp.Data.GraphQL.Benchmarks/FSharp.Data.GraphQL.Benchmarks.fsproj
+++ b/tests/FSharp.Data.GraphQL.Benchmarks/FSharp.Data.GraphQL.Benchmarks.fsproj
@@ -202,27 +202,6 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v1.2' Or $(TargetFrameworkVersion) == 'v1.3' Or $(TargetFrameworkVersion) == 'v1.4' Or $(TargetFrameworkVersion) == 'v1.5')) Or ($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2'))">
-      <ItemGroup>
-        <Reference Include="Hopac.Core">
-          <HintPath>..\..\packages\Hopac\lib\net45\Hopac.Core.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-        <Reference Include="Hopac.Platform">
-          <HintPath>..\..\packages\Hopac\lib\net45\Hopac.Platform.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-        <Reference Include="Hopac">
-          <HintPath>..\..\packages\Hopac\lib\net45\Hopac.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-  </Choose>
-  <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2')">
       <ItemGroup>
         <Reference Include="Microsoft.CodeAnalysis">

--- a/tests/FSharp.Data.GraphQL.Benchmarks/Program.fs
+++ b/tests/FSharp.Data.GraphQL.Benchmarks/Program.fs
@@ -5,10 +5,11 @@ open System.IO
 open System.Collections.Concurrent
 open BenchmarkDotNet.Attributes
 open BenchmarkDotNet.Running
+open FSharp.Data.GraphQL.AsyncValBenchmark
 open FSharp.Data.GraphQL.ParsingBenchmark
 open FSharp.Data.GraphQL.ExecutionBenchmark
 
-let defaultSwitch () = BenchmarkSwitcher [| typeof<SimpleExecutionBenchmark>; typeof<ParsingBenchmark>  |]
+let defaultSwitch () = BenchmarkSwitcher [| typeof<AsyncValBenchmark>; typeof<SimpleExecutionBenchmark>; typeof<ParsingBenchmark>  |]
 
 [<EntryPoint>]
 let Main args =

--- a/tests/FSharp.Data.GraphQL.Benchmarks/paket.references
+++ b/tests/FSharp.Data.GraphQL.Benchmarks/paket.references
@@ -1,6 +1,5 @@
 FSharp.Core
 BenchmarkDotNet
 BenchmarkDotNet.Diagnostics.Windows
-Hopac
 System.Reflection.Metadata
 System.Collections.Immutable

--- a/tests/FSharp.Data.GraphQL.Tests.Sql/FSharp.Data.GraphQL.Tests.Sql.fsproj
+++ b/tests/FSharp.Data.GraphQL.Tests.Sql/FSharp.Data.GraphQL.Tests.Sql.fsproj
@@ -78,6 +78,30 @@
   <Target Name="AfterBuild">
   </Target>
   -->
+  <ItemGroup>
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="Helpers.fs" />
+    <Compile Include="LinqToSqlTests.fs" />
+    <None Include="paket.references" />
+    <Content Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.Linq" />
+    <Reference Include="System.Numerics" />
+    <ProjectReference Include="..\..\src\FSharp.Data.GraphQL.Server\FSharp.Data.GraphQL.Server.fsproj">
+      <Name>FSharp.Data.GraphQL.Server</Name>
+      <Project>{474179d3-0090-49e9-88f8-2971c0966077}</Project>
+      <Private>True</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\FSharp.Data.GraphQL.Shared\FSharp.Data.GraphQL.Shared.fsproj">
+      <Name>FSharp.Data.GraphQL.Shared</Name>
+      <Project>{6768ea38-1335-4b8e-bc09-ccded1f9aaf6}</Project>
+      <Private>True</Private>
+    </ProjectReference>
+  </ItemGroup>
   <Choose>
     <When Condition="($(TargetFrameworkIdentifier) == '.NETCore') Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile44')">
       <ItemGroup>
@@ -425,28 +449,4 @@
       </ItemGroup>
     </When>
   </Choose>
-  <ItemGroup>
-    <Compile Include="AssemblyInfo.fs" />
-    <Compile Include="Helpers.fs" />
-    <Compile Include="LinqToSqlTests.fs" />
-    <None Include="paket.references" />
-    <Content Include="App.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="mscorlib" />
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Data.Linq" />
-    <Reference Include="System.Numerics" />
-    <ProjectReference Include="..\..\src\FSharp.Data.GraphQL.Server\FSharp.Data.GraphQL.Server.fsproj">
-      <Name>FSharp.Data.GraphQL.Server</Name>
-      <Project>{474179d3-0090-49e9-88f8-2971c0966077}</Project>
-      <Private>True</Private>
-    </ProjectReference>
-    <ProjectReference Include="..\..\src\FSharp.Data.GraphQL.Shared\FSharp.Data.GraphQL.Shared.fsproj">
-      <Name>FSharp.Data.GraphQL.Shared</Name>
-      <Project>{6768ea38-1335-4b8e-bc09-ccded1f9aaf6}</Project>
-      <Private>True</Private>
-    </ProjectReference>
-  </ItemGroup>
 </Project>

--- a/tests/FSharp.Data.GraphQL.Tests/AsyncValTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/AsyncValTests.fs
@@ -1,0 +1,68 @@
+﻿/// The MIT License (MIT)
+/// Copyright (c) 2016 Bazinga Technologies Inc
+
+module FSharp.Data.GraphQL.Tests.AsyncValTests
+
+open System
+open FSharp.Data.GraphQL
+open Xunit
+open FsCheck
+
+[<Fact>]
+let ``AsyncVal computation allows to return constant values`` () =
+    let v = asyncVal { return 1 }
+    v.IsAsync |> equals false
+    v.IsSync |> equals true
+    v.Value |> equals 1
+    
+[<Fact>]
+let ``AsyncVal computation allows to return from async computation`` () =
+    let v = asyncVal { return! async { return 1 } }
+    v.IsAsync |> equals true
+    v.IsSync |> equals false
+    v |> AsyncVal.get |> equals 1
+    
+[<Fact>]
+let ``AsyncVal computation allows to return from another AsyncVal`` () =
+    let v = asyncVal { return! asyncVal { return 1 } }
+    v.IsAsync |> equals false
+    v.IsSync |> equals true
+    v.Value |> equals 1
+
+[<Fact>]
+let ``AsyncVal computation allows to bind async computations`` () =
+    let v = asyncVal { 
+        let! value = async { return 1 }
+        return value }
+    v.IsAsync |> equals true
+    v.IsSync |> equals false
+    v |> AsyncVal.get |> equals 1
+
+[<Fact>]
+let ``AsyncVal computation allows to bind another AsyncVal`` () =
+    let v = asyncVal { 
+        let! value = asyncVal { return 1 }
+        return value }
+    v.IsAsync |> equals false
+    v.IsSync |> equals true
+    v.Value |> equals 1
+    
+[<Fact>]
+let ``AsyncVal computation defines zero value`` () =
+    let v = asyncVal { printf "aa" }
+    v.IsAsync |> equals false
+    v.IsSync |> equals true
+    
+[<Fact>]
+let ``AsyncVal can be returned from Async computation`` () =
+    let a = async { return! asyncVal { return 1 } }
+    let res = a |> sync
+    res |> equals 1
+    
+[<Fact>]
+let ``AsyncVal can be bound inside Async computation`` () =
+    let a = async { 
+        let! v = asyncVal { return 1 }
+        return v }
+    let res = a |> sync
+    res |> equals 1

--- a/tests/FSharp.Data.GraphQL.Tests/FSharp.Data.GraphQL.Tests.fsproj
+++ b/tests/FSharp.Data.GraphQL.Tests/FSharp.Data.GraphQL.Tests.fsproj
@@ -69,6 +69,7 @@
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="Helpers.fs" />
+    <Compile Include="AsyncValTests.fs" />
     <Compile Include="Relay\NodeTests.fs" />
     <Compile Include="Relay\ConnectionTests.fs" />
     <Compile Include="Relay\MutationTests.fs" />
@@ -114,27 +115,6 @@
       <Private>True</Private>
     </ProjectReference>
   </ItemGroup>
-  <Choose>
-    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v1.2' Or $(TargetFrameworkVersion) == 'v1.3' Or $(TargetFrameworkVersion) == 'v1.4' Or $(TargetFrameworkVersion) == 'v1.5')) Or ($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2'))">
-      <ItemGroup>
-        <Reference Include="Hopac.Core">
-          <HintPath>..\..\packages\Hopac\lib\net45\Hopac.Core.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-        <Reference Include="Hopac.Platform">
-          <HintPath>..\..\packages\Hopac\lib\net45\Hopac.Platform.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-        <Reference Include="Hopac">
-          <HintPath>..\..\packages\Hopac\lib\net45\Hopac.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-  </Choose>
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v1.2')">
       <ItemGroup>

--- a/tests/FSharp.Data.GraphQL.Tests/paket.references
+++ b/tests/FSharp.Data.GraphQL.Tests/paket.references
@@ -1,6 +1,5 @@
 FSharp.Core
 Newtonsoft.Json
-Hopac
 group Test
 xunit
 FSCheck


### PR DESCRIPTION
This PR introduces removing of the Hopac ( #41 ) dependencies inside the project. It's going back to F# `Async<>` with special sugar in form of `AsyncVal<>` - a dedicated structure, that's going to simplify most common scenario, where data is retrieved synchronously.

Some benchmarks:
### Current dev

``` ini

Host Process Environment Information:
BenchmarkDotNet.Core=v0.9.9.0
OS=Microsoft Windows NT 6.2.9200.0
Processor=Intel(R) Core(TM) i5-6300HQ CPU 2.30GHz, ProcessorCount=4
Frequency=2250003 ticks, Resolution=444.4439 ns, Timer=TSC
CLR=MS.NET 4.0.30319.42000, Arch=32-bit RELEASE
GC=Concurrent Workstation
JitModules=clrjit-v4.6.1080.0

Type=SimpleExecutionBenchmark  Mode=Throughput  

```

| Method | Median | StdDev | Mean | Min | Max | Op/s | Gen 0 | Gen 1 | Gen 2 | Bytes Allocated/Op |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| BenchmarkSimpleQueryUnparsed | 157.3269 us | 5.6500 us | 158.2112 us | 148.5248 us | 172.2940 us | 6320.66 | 24.02 | - | - | 5 605,29 |
| BenchmarkSimpleQueryParsed | 146.4599 us | 8.1424 us | 148.6951 us | 134.4616 us | 168.3049 us | 6725.17 | 12.21 | - | - | 3 693,64 |
| BenchmarkSimpleQueryPlanned | 181.3533 us | 7.7570 us | 182.6536 us | 168.9308 us | 201.0036 us | 5474.84 | 9.94 | - | - | 2 994,85 |
| BenchmarkFlatQueryUnparsed | 1,026.3858 us | 179.5066 us | 981.0037 us | 468.7164 us | 1,309.8351 us | 1019.36 | 61.85 | - | - | 16 243,82 |
| BenchmarkFlatQueryParsed | 595.1850 us | 120.4812 us | 582.7553 us | 259.1585 us | 897.2696 us | 1715.99 | 51.53 | - | - | 12 600,62 |
| BenchmarkFlatQueryPlanned | 322.9032 us | 88.0148 us | 342.8616 us | 216.6768 us | 745.2664 us | 2916.63 | 41.38 | - | - | 10 396,88 |
| BenchmarkNestedQueryUnparsed | 847.3400 us | 26.5663 us | 846.2497 us | 800.5788 us | 903.7332 us | 1181.68 | 215.00 | - | - | 55 156,48 |
| BenchmarkNestedQueryParsed | 259.7336 us | 4.2310 us | 259.9037 us | 251.7067 us | 271.2696 us | 3847.58 | 165.29 | - | - | 37 102,93 |
| BenchmarkNestedQueryPlanned | 250.5577 us | 2.2592 us | 250.7361 us | 247.6127 us | 255.7093 us | 3988.26 | 149.10 | - | - | 33 618,53 |
### AsyncVals

``` ini

Host Process Environment Information:
BenchmarkDotNet.Core=v0.9.9.0
OS=Microsoft Windows NT 6.2.9200.0
Processor=Intel(R) Core(TM) i5-6300HQ CPU 2.30GHz, ProcessorCount=4
Frequency=2250003 ticks, Resolution=444.4439 ns, Timer=TSC
CLR=MS.NET 4.0.30319.42000, Arch=32-bit RELEASE
GC=Concurrent Workstation
JitModules=clrjit-v4.6.1080.0

Type=SimpleExecutionBenchmark  Mode=Throughput  

```

| Method | Median | StdDev | Mean | Min | Max | Op/s | Gen 0 | Gen 1 | Gen 2 | Bytes Allocated/Op |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| BenchmarkSimpleQueryUnparsed | 56.0447 us | 1.2391 us | 55.9036 us | 53.4428 us | 59.2214 us | 17887.92 | 16.82 | - | - | 2 892,18 |
| BenchmarkSimpleQueryParsed | 37.5909 us | 0.8322 us | 37.7219 us | 36.4099 us | 39.9745 us | 26509.8 | 11.19 | - | - | 1 903,26 |
| BenchmarkSimpleQueryPlanned | 36.7179 us | 0.6371 us | 36.8037 us | 35.8933 us | 38.0362 us | 27171.21 | 8.62 | - | - | 1 519,35 |
| BenchmarkFlatQueryUnparsed | 118.6983 us | 4.4283 us | 120.1088 us | 116.6450 us | 134.9538 us | 8325.78 | 29.80 | 14.31 | - | 7 330,10 |
| BenchmarkFlatQueryParsed | 94.5388 us | 4.1212 us | 94.7174 us | 88.7297 us | 100.8304 us | 10557.73 | 4.69 | 4.22 | - | 3 419,43 |
| BenchmarkFlatQueryPlanned | 87.3928 us | 2.0692 us | 87.5802 us | 82.0037 us | 92.1323 us | 11418.11 | 4.73 | 2.17 | - | 2 339,76 |
| BenchmarkNestedQueryUnparsed | 683.2747 us | 23.5373 us | 682.2727 us | 597.9384 us | 716.7725 us | 1465.69 | 136.62 | - | - | 23 553,46 |
| BenchmarkNestedQueryParsed | 541.7645 us | 13.5400 us | 544.4594 us | 523.8335 us | 577.7102 us | 1836.68 | 107.00 | - | - | 19 198,92 |
| BenchmarkNestedQueryPlanned | 510.8088 us | 2.9108 us | 510.2895 us | 502.5219 us | 513.8596 us | 1959.67 | 106.02 | - | - | 18 659,60 |
### Description

As we may see, good point is that heap allocations have gone down by 35%-50% on average in favor of the new approach. 

When it comes to operations per sec, values differ significantly:
- For simple queries, new approach is almost 3 times faster - which is fairly close to using branch where `Async<>` where used before Hopac.
- For case, where query has a lot of fields on the same level of depth, new approach is around 7 times faster.
- For case, where we have a query with deep level of nesting, new approach is a little faster than the old one (around 20%).

Those comparisons take into account unparsed versions of the tests - so the case when we get raw query string. For cases when we have prefetched query, **Hopac can be faster than new approach**, however the reason for that is unknown and need further investigantion.

---
## Comparison of `Async<>` vs `AsyncVal<>` in common scenarios

``` ini

Host Process Environment Information:
BenchmarkDotNet.Core=v0.9.9.0
OS=Microsoft Windows NT 6.2.9200.0
Processor=Intel(R) Core(TM) i5-6300HQ CPU 2.30GHz, ProcessorCount=4
Frequency=2250003 ticks, Resolution=444.4439 ns, Timer=TSC
CLR=MS.NET 4.0.30319.42000, Arch=32-bit RELEASE
GC=Concurrent Workstation
JitModules=clrjit-v4.6.1080.0

Type=AsyncValBenchmark  Mode=Throughput  

```

| Method | Median | StdDev | Mean | Min | Max | Op/s | Gen 0 | Gen 1 | Gen 2 | Bytes Allocated/Op |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| AsyncValImmediate | 2.0300 ns | 0.2742 ns | 2.1011 ns | 1.7335 ns | 3.1936 ns | 475947646.76 | - | - | - | 0,00 |
| AsyncValAwaiting | 13.2080 ns | 1.1620 ns | 13.7225 ns | 12.8344 ns | 17.7117 ns | 72873061.83 | 0.49 | - | - | 16,40 |
| AsyncReturnImmediatelly | 6,024.7790 ns | 166.8665 ns | 6,064.8655 ns | 5,762.1858 ns | 6,406.6484 ns | 164884.12 | 5.81 | - | - | 219,33 |
| AsyncValCollectionAllSync | 495.9702 ns | 16.3894 ns | 494.1212 ns | 473.6449 ns | 524.1607 ns | 2023794.80 | 5.93 | - | - | 204,86 |
| AsyncValCollectionAllAsync | 102,270.2629 ns | 3,614.2131 ns | 100,790.5879 ns | 92,410.3586 ns | 105,359.9941 ns | 9921.56 | 609.00 | 18.00 | - | 23 723,62 |
| AsyncCollection | 52,520.7091 ns | 239.5974 ns | 52,563.3468 ns | 52,274.1273 ns | 53,388.1667 ns | 19024.66 | 467.80 | 9.11 | - | 18 529,63 |
| AsyncValCollectionMixed90x10 | 19,946.5473 ns | 135.0883 ns | 19,983.9279 ns | 19,837.2945 ns | 20,282.5522 ns | 50040.21 | 86.77 | 2.22 | - | 3 109,31 |
### Description

For the most common case - returning a value immediatelly - using `AsyncVal.wrap` instead of `async.Return` results in ~3000 times faster execution with no heap allocations!

When working on flattening collections of `Async`/`AsyncVal`, numbers can be different:
- If all collection values can be received synchronously, `AsyncVal` is over 100 times faster than `Async`.
- If all collection values as asynchronous, `AsyncVal` can be twice slower - I belive we can improve this inside implementation.
- If we have mix of sync/async values (ratio: 90% sync, 10% async), `AsyncVal` is over two times faster. However I think, the exact numbers may vary - `AsyncVal` will be faster if async values will be put at the end of an array. To make it even faster, we should actually partition input array by sync/async and optimize path for each case - this however cannot be done in presented approach as indexes of inputs &rArr; outputs must match. 
