### PR TITLE
Introduced documentId for execution plans

### DIFF
--- a/paket.lock
+++ b/paket.lock
@@ -89,47 +89,47 @@ NUGET
     Microsoft.CodeAnalysis.CSharp (1.3.2) - framework: >= net45
       Microsoft.CodeAnalysis.Common (1.3.2)
     Microsoft.CSharp (4.0.1) - framework: >= netstandard10
-      System.Collections (>= 4.0.11) - framework: dnxcore50, >= netstandard13
-      System.Diagnostics.Debug (>= 4.0.11) - framework: dnxcore50, >= netstandard13
-      System.Dynamic.Runtime (>= 4.0.11) - framework: dnxcore50, netstandard10, >= netstandard13
-      System.Globalization (>= 4.0.11) - framework: dnxcore50, >= netstandard13
-      System.Linq (>= 4.1) - framework: dnxcore50, >= netstandard13
-      System.Linq.Expressions (>= 4.1) - framework: dnxcore50, netstandard10, >= netstandard13
-      System.ObjectModel (>= 4.0.12) - framework: dnxcore50, >= netstandard13
-      System.Reflection (>= 4.1) - framework: dnxcore50, >= netstandard13
-      System.Reflection.Extensions (>= 4.0.1) - framework: dnxcore50, >= netstandard13
-      System.Reflection.Primitives (>= 4.0.1) - framework: dnxcore50, >= netstandard13
-      System.Reflection.TypeExtensions (>= 4.1) - framework: dnxcore50, >= netstandard13
-      System.Resources.ResourceManager (>= 4.0.1) - framework: dnxcore50, >= netstandard13
-      System.Runtime (>= 4.1) - framework: dnxcore50, netstandard10, >= netstandard13
-      System.Runtime.Extensions (>= 4.1) - framework: dnxcore50, >= netstandard13
-      System.Runtime.InteropServices (>= 4.1) - framework: dnxcore50, >= netstandard13
-      System.Threading (>= 4.0.11) - framework: dnxcore50, >= netstandard13
+      System.Collections (>= 4.0.11) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Diagnostics.Debug (>= 4.0.11) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Dynamic.Runtime (>= 4.0.11) - framework: >= net46, dnxcore50, >= netstandard10, >= netstandard13
+      System.Globalization (>= 4.0.11) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Linq (>= 4.1) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Linq.Expressions (>= 4.1) - framework: >= net46, dnxcore50, >= netstandard10, >= netstandard13
+      System.ObjectModel (>= 4.0.12) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Reflection (>= 4.1) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Reflection.Extensions (>= 4.0.1) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Reflection.Primitives (>= 4.0.1) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Reflection.TypeExtensions (>= 4.1) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Resources.ResourceManager (>= 4.0.1) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Runtime (>= 4.1) - framework: >= net46, dnxcore50, >= netstandard10, >= netstandard13
+      System.Runtime.Extensions (>= 4.1) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Runtime.InteropServices (>= 4.1) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Threading (>= 4.0.11) - framework: >= net46, dnxcore50, >= netstandard13
     Microsoft.Diagnostics.Tracing.TraceEvent (1.0.41) - framework: >= net45
     Microsoft.DotNet.InternalAbstractions (1.0) - framework: >= netstandard15
-      System.AppContext (>= 4.1) - framework: >= netstandard13
-      System.Collections (>= 4.0.11) - framework: >= netstandard13
-      System.IO (>= 4.1) - framework: >= netstandard13
-      System.IO.FileSystem (>= 4.0.1) - framework: >= netstandard13
-      System.Reflection.TypeExtensions (>= 4.1) - framework: >= netstandard13
-      System.Runtime.Extensions (>= 4.1) - framework: >= netstandard13
-      System.Runtime.InteropServices (>= 4.1) - framework: >= netstandard13
-      System.Runtime.InteropServices.RuntimeInformation (>= 4.0) - framework: >= netstandard13
-    Microsoft.NETCore.Platforms (1.0.1) - framework: dnxcore50, >= netstandard10
-    Microsoft.NETCore.Targets (1.0.1) - framework: dnxcore50, >= netstandard10
+      System.AppContext (>= 4.1) - framework: >= net46, >= netstandard13
+      System.Collections (>= 4.0.11) - framework: >= net46, >= netstandard13
+      System.IO (>= 4.1) - framework: >= net46, >= netstandard13
+      System.IO.FileSystem (>= 4.0.1) - framework: >= net46, >= netstandard13
+      System.Reflection.TypeExtensions (>= 4.1) - framework: >= net46, >= netstandard13
+      System.Runtime.Extensions (>= 4.1) - framework: >= net46, >= netstandard13
+      System.Runtime.InteropServices (>= 4.1) - framework: >= net46, >= netstandard13
+      System.Runtime.InteropServices.RuntimeInformation (>= 4.0) - framework: >= net46, >= netstandard13
+    Microsoft.NETCore.Platforms (1.0.1) - framework: net451, net452, net453, net46, >= net46, dnxcore50, >= netstandard10, netstandard11, >= netstandard11, netstandard12, >= netstandard12, netstandard13, >= netstandard13, >= netstandard15
+    Microsoft.NETCore.Targets (1.0.1) - framework: net451, net452, net453, net46, >= net46, dnxcore50, >= netstandard10, netstandard11, >= netstandard11, netstandard12, >= netstandard12, netstandard13, >= netstandard13, >= netstandard15
     Microsoft.Win32.Primitives (4.0.1) - framework: >= netstandard15
-      Microsoft.NETCore.Platforms (>= 1.0.1) - framework: >= netstandard13
-      Microsoft.NETCore.Targets (>= 1.0.1) - framework: >= netstandard13
-      System.Runtime (>= 4.1) - framework: >= netstandard13
+      Microsoft.NETCore.Platforms (>= 1.0.1) - framework: >= net46, >= netstandard13
+      Microsoft.NETCore.Targets (>= 1.0.1) - framework: >= net46, >= netstandard13
+      System.Runtime (>= 4.1) - framework: >= net46, >= netstandard13
     Microsoft.Win32.Registry (4.0) - framework: >= netstandard15
-      Microsoft.NETCore.Platforms (>= 1.0.1) - framework: >= netstandard13
-      System.Collections (>= 4.0.11) - framework: >= netstandard13
-      System.Globalization (>= 4.0.11) - framework: >= netstandard13
-      System.Resources.ResourceManager (>= 4.0.1) - framework: >= netstandard13
-      System.Runtime (>= 4.1) - framework: >= netstandard13
-      System.Runtime.Extensions (>= 4.1) - framework: >= netstandard13
-      System.Runtime.Handles (>= 4.0.1) - framework: >= netstandard13
-      System.Runtime.InteropServices (>= 4.1) - framework: >= netstandard13
+      Microsoft.NETCore.Platforms (>= 1.0.1) - framework: >= net46, >= netstandard13
+      System.Collections (>= 4.0.11) - framework: >= net46, >= netstandard13
+      System.Globalization (>= 4.0.11) - framework: >= net46, >= netstandard13
+      System.Resources.ResourceManager (>= 4.0.1) - framework: >= net46, >= netstandard13
+      System.Runtime (>= 4.1) - framework: >= net46, >= netstandard13
+      System.Runtime.Extensions (>= 4.1) - framework: >= net46, >= netstandard13
+      System.Runtime.Handles (>= 4.0.1) - framework: >= net46, >= netstandard13
+      System.Runtime.InteropServices (>= 4.1) - framework: >= net46, >= netstandard13
     Newtonsoft.Json (9.0.1)
       Microsoft.CSharp (>= 4.0.1) - framework: >= netstandard10
       System.Collections (>= 4.0.11) - framework: >= netstandard10
@@ -156,15 +156,28 @@ NUGET
     runtime.native.System (4.0) - framework: >= netstandard15
       Microsoft.NETCore.Platforms (>= 1.0.1)
       Microsoft.NETCore.Targets (>= 1.0.1)
+    runtime.native.System.Security.Cryptography (4.0) - framework: >= net46
+      Microsoft.NETCore.Platforms (>= 1.0.1)
+      Microsoft.NETCore.Targets (>= 1.0.1)
     Suave (1.1.3)
       FSharp.Core (>= 3.1.2.5)
     System.AppContext (4.1) - framework: >= net46, >= netstandard15
-      System.Runtime (>= 4.1) - framework: dnxcore50, netstandard13, >= netstandard16
-    System.Collections (4.0.11) - framework: >= net46, dnxcore50, >= netstandard10
-      Microsoft.NETCore.Platforms (>= 1.0.1) - framework: dnxcore50, netstandard10, >= netstandard13
-      Microsoft.NETCore.Targets (>= 1.0.1) - framework: dnxcore50, netstandard10, >= netstandard13
-      System.Runtime (>= 4.1) - framework: dnxcore50, netstandard10, >= netstandard13
+      System.Runtime (>= 4.1) - framework: net46, >= net463, dnxcore50, >= netstandard13, >= netstandard16
+    System.Collections (4.0.11) - framework: >= net46, dnxcore50, >= netstandard10, >= netstandard13, >= netstandard15
+      Microsoft.NETCore.Platforms (>= 1.0.1) - framework: >= net46, dnxcore50, >= netstandard10, >= netstandard13
+      Microsoft.NETCore.Targets (>= 1.0.1) - framework: >= net46, dnxcore50, >= netstandard10, >= netstandard13
+      System.Runtime (>= 4.1) - framework: >= net46, dnxcore50, >= netstandard10, >= netstandard13
     System.Collections.Concurrent (4.0.12) - framework: >= net46
+      System.Collections (>= 4.0.11) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Diagnostics.Debug (>= 4.0.11) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Diagnostics.Tracing (>= 4.1) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Globalization (>= 4.0.11) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Reflection (>= 4.1) - framework: >= net46, >= netstandard13
+      System.Resources.ResourceManager (>= 4.0.1) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Runtime (>= 4.1) - framework: net45, >= net46, dnxcore50, >= netstandard11, >= netstandard13
+      System.Runtime.Extensions (>= 4.1) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Threading (>= 4.0.11) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Threading.Tasks (>= 4.0.11) - framework: net45, >= net46, dnxcore50, >= netstandard11, >= netstandard13
     System.Collections.Immutable (1.2)
       System.Collections (>= 4.0.11) - framework: >= netstandard10
       System.Diagnostics.Debug (>= 4.0.11) - framework: >= netstandard10
@@ -175,70 +188,89 @@ NUGET
       System.Runtime.Extensions (>= 4.1) - framework: >= netstandard10
       System.Threading (>= 4.0.11) - framework: >= netstandard10
     System.Console (4.0) - framework: >= net46, >= netstandard15
-      Microsoft.NETCore.Platforms (>= 1.0.1) - framework: >= netstandard13
-      Microsoft.NETCore.Targets (>= 1.0.1) - framework: >= netstandard13
-      System.IO (>= 4.1) - framework: >= netstandard13
-      System.Runtime (>= 4.1) - framework: >= netstandard13
-      System.Text.Encoding (>= 4.0.11) - framework: >= netstandard13
-    System.Diagnostics.Debug (4.0.11) - framework: >= net46, dnxcore50, >= netstandard10
-      Microsoft.NETCore.Platforms (>= 1.0.1) - framework: dnxcore50, netstandard10, >= netstandard13
-      Microsoft.NETCore.Targets (>= 1.0.1) - framework: dnxcore50, netstandard10, >= netstandard13
-      System.Runtime (>= 4.1) - framework: dnxcore50, netstandard10, >= netstandard13
+      Microsoft.NETCore.Platforms (>= 1.0.1) - framework: >= net46, >= netstandard13
+      Microsoft.NETCore.Targets (>= 1.0.1) - framework: >= net46, >= netstandard13
+      System.IO (>= 4.1) - framework: >= net46, >= netstandard13
+      System.Runtime (>= 4.1) - framework: >= net46, >= netstandard13
+      System.Text.Encoding (>= 4.0.11) - framework: >= net46, >= netstandard13
+    System.Diagnostics.Debug (4.0.11) - framework: net46, >= net46, dnxcore50, >= netstandard10, >= netstandard13, >= netstandard15
+      Microsoft.NETCore.Platforms (>= 1.0.1) - framework: >= net46, dnxcore50, >= netstandard10, >= netstandard13
+      Microsoft.NETCore.Targets (>= 1.0.1) - framework: >= net46, dnxcore50, >= netstandard10, >= netstandard13
+      System.Runtime (>= 4.1) - framework: >= net46, dnxcore50, >= netstandard10, >= netstandard13
     System.Diagnostics.FileVersionInfo (4.0) - framework: >= net46
+      Microsoft.NETCore.Platforms (>= 1.0.1) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Globalization (>= 4.0.11) - framework: >= net46, >= netstandard13
+      System.IO (>= 4.1) - framework: >= net46, dnxcore50, >= netstandard13
+      System.IO.FileSystem (>= 4.0.1) - framework: >= net46, dnxcore50, >= netstandard13
+      System.IO.FileSystem.Primitives (>= 4.0.1) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Reflection.Metadata (>= 1.3) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Runtime (>= 4.1) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Runtime.Extensions (>= 4.1) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Runtime.InteropServices (>= 4.1) - framework: >= net46, >= netstandard13
     System.Diagnostics.Process (4.1) - framework: >= netstandard15
-      Microsoft.NETCore.Platforms (>= 1.0.1) - framework: >= netstandard14
-      Microsoft.Win32.Primitives (>= 4.0.1) - framework: >= netstandard14
-      Microsoft.Win32.Registry (>= 4.0) - framework: >= netstandard14
-      runtime.native.System (>= 4.0) - framework: >= netstandard14
-      System.Collections (>= 4.0.11) - framework: >= netstandard14
-      System.Diagnostics.Debug (>= 4.0.11) - framework: >= netstandard14
-      System.Globalization (>= 4.0.11) - framework: >= netstandard14
-      System.IO (>= 4.1) - framework: >= netstandard13
-      System.IO.FileSystem (>= 4.0.1) - framework: >= netstandard14
-      System.IO.FileSystem.Primitives (>= 4.0.1) - framework: >= netstandard14
-      System.Resources.ResourceManager (>= 4.0.1) - framework: >= netstandard14
-      System.Runtime (>= 4.1) - framework: >= netstandard13
-      System.Runtime.Extensions (>= 4.1) - framework: >= netstandard14
-      System.Runtime.Handles (>= 4.0.1) - framework: >= netstandard13
-      System.Runtime.InteropServices (>= 4.1) - framework: >= netstandard14
-      System.Text.Encoding (>= 4.0.11) - framework: >= netstandard13
-      System.Text.Encoding.Extensions (>= 4.0.11) - framework: >= netstandard14
-      System.Threading (>= 4.0.11) - framework: >= netstandard14
-      System.Threading.Tasks (>= 4.0.11) - framework: >= netstandard14
-      System.Threading.Thread (>= 4.0) - framework: >= netstandard14
-      System.Threading.ThreadPool (>= 4.0.10) - framework: >= netstandard14
+      Microsoft.NETCore.Platforms (>= 1.0.1) - framework: >= net461, >= netstandard14
+      Microsoft.Win32.Primitives (>= 4.0.1) - framework: >= net461, >= netstandard14
+      Microsoft.Win32.Registry (>= 4.0) - framework: >= net461, >= netstandard14
+      runtime.native.System (>= 4.0) - framework: >= net461, >= netstandard14
+      System.Collections (>= 4.0.11) - framework: >= net461, >= netstandard14
+      System.Diagnostics.Debug (>= 4.0.11) - framework: >= net461, >= netstandard14
+      System.Globalization (>= 4.0.11) - framework: >= net461, >= netstandard14
+      System.IO (>= 4.1) - framework: >= net46, >= netstandard13
+      System.IO.FileSystem (>= 4.0.1) - framework: >= net461, >= netstandard14
+      System.IO.FileSystem.Primitives (>= 4.0.1) - framework: >= net461, >= netstandard14
+      System.Resources.ResourceManager (>= 4.0.1) - framework: >= net461, >= netstandard14
+      System.Runtime (>= 4.1) - framework: >= net46, >= netstandard13
+      System.Runtime.Extensions (>= 4.1) - framework: >= net461, >= netstandard14
+      System.Runtime.Handles (>= 4.0.1) - framework: >= net46, >= netstandard13
+      System.Runtime.InteropServices (>= 4.1) - framework: >= net461, >= netstandard14
+      System.Text.Encoding (>= 4.0.11) - framework: >= net46, >= netstandard13
+      System.Text.Encoding.Extensions (>= 4.0.11) - framework: >= net461, >= netstandard14
+      System.Threading (>= 4.0.11) - framework: >= net461, >= netstandard14
+      System.Threading.Tasks (>= 4.0.11) - framework: >= net461, >= netstandard14
+      System.Threading.Thread (>= 4.0) - framework: >= net461, >= netstandard14
+      System.Threading.ThreadPool (>= 4.0.10) - framework: >= net461, >= netstandard14
     System.Diagnostics.StackTrace (4.0.1) - framework: >= net46
+      System.Collections.Immutable (>= 1.2) - framework: >= net46, >= netstandard13
+      System.IO.FileSystem (>= 4.0.1) - framework: >= net46, >= netstandard13
+      System.Reflection (>= 4.1) - framework: >= net46, >= netstandard13
+      System.Reflection.Metadata (>= 1.3) - framework: >= net46, >= netstandard13
+      System.Runtime (>= 4.1) - framework: >= net46, >= netstandard13
+      System.Runtime.Extensions (>= 4.1) - framework: >= net46, >= netstandard13
     System.Diagnostics.Tools (4.0.1) - framework: >= net46, >= netstandard13
       Microsoft.NETCore.Platforms (>= 1.0.1) - framework: dnxcore50, >= netstandard10
       Microsoft.NETCore.Targets (>= 1.0.1) - framework: dnxcore50, >= netstandard10
       System.Runtime (>= 4.1) - framework: dnxcore50, >= netstandard10
+    System.Diagnostics.Tracing (4.1) - framework: >= net46
+      Microsoft.NETCore.Platforms (>= 1.0.1) - framework: net45, net451, net452, net453, net46, >= net462, dnxcore50, >= netstandard11, >= netstandard12, >= netstandard13, >= netstandard15
+      Microsoft.NETCore.Targets (>= 1.0.1) - framework: net45, net451, net452, net453, net46, >= net462, dnxcore50, >= netstandard11, >= netstandard12, >= netstandard13, >= netstandard15
+      System.Runtime (>= 4.1) - framework: net45, net451, net452, net453, net46, >= net462, dnxcore50, >= netstandard11, >= netstandard12, >= netstandard13, >= netstandard15
     System.Dynamic.Runtime (4.0.11) - framework: >= net46, >= netstandard10
-      System.Collections (>= 4.0.11) - framework: dnxcore50, >= netstandard13
-      System.Diagnostics.Debug (>= 4.0.11) - framework: dnxcore50, >= netstandard13
-      System.Globalization (>= 4.0.11) - framework: dnxcore50, >= netstandard13
-      System.Linq (>= 4.1) - framework: dnxcore50, >= netstandard13
-      System.Linq.Expressions (>= 4.1) - framework: dnxcore50, netstandard10, >= netstandard13
-      System.ObjectModel (>= 4.0.12) - framework: dnxcore50, netstandard10, >= netstandard13
-      System.Reflection (>= 4.1) - framework: dnxcore50, netstandard10, >= netstandard13
-      System.Reflection.Emit (>= 4.0.1) - framework: >= netstandard13
-      System.Reflection.Emit.ILGeneration (>= 4.0.1) - framework: >= netstandard13
-      System.Reflection.Primitives (>= 4.0.1) - framework: >= netstandard13
-      System.Reflection.TypeExtensions (>= 4.1) - framework: dnxcore50, >= netstandard13
-      System.Resources.ResourceManager (>= 4.0.1) - framework: dnxcore50, >= netstandard13
-      System.Runtime (>= 4.1) - framework: dnxcore50, netstandard10, >= netstandard13
-      System.Runtime.Extensions (>= 4.1) - framework: dnxcore50, >= netstandard13
-      System.Threading (>= 4.0.11) - framework: dnxcore50, >= netstandard13
-    System.Globalization (4.0.11) - framework: >= net46, dnxcore50, >= netstandard10
-      Microsoft.NETCore.Platforms (>= 1.0.1) - framework: dnxcore50, netstandard10, >= netstandard13
-      Microsoft.NETCore.Targets (>= 1.0.1) - framework: dnxcore50, netstandard10, >= netstandard13
-      System.Runtime (>= 4.1) - framework: dnxcore50, netstandard10, >= netstandard13
-    System.IO (4.1) - framework: >= net463, dnxcore50
-      Microsoft.NETCore.Platforms (>= 1.0.1) - framework: dnxcore50, netstandard10, netstandard13, >= netstandard15
-      Microsoft.NETCore.Targets (>= 1.0.1) - framework: dnxcore50, netstandard10, netstandard13, >= netstandard15
-      System.Runtime (>= 4.1) - framework: dnxcore50, netstandard10, netstandard13, >= netstandard15
-      System.Text.Encoding (>= 4.0.11) - framework: dnxcore50, netstandard10, netstandard13, >= netstandard15
-      System.Threading.Tasks (>= 4.0.11) - framework: dnxcore50, netstandard10, netstandard13, >= netstandard15
-    System.IO.FileSystem (4.0.1) - framework: >= net46, >= netstandard13
+      System.Collections (>= 4.0.11) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Diagnostics.Debug (>= 4.0.11) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Globalization (>= 4.0.11) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Linq (>= 4.1) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Linq.Expressions (>= 4.1) - framework: >= net46, dnxcore50, >= netstandard10, >= netstandard13
+      System.ObjectModel (>= 4.0.12) - framework: >= net46, dnxcore50, >= netstandard10, >= netstandard13
+      System.Reflection (>= 4.1) - framework: >= net46, dnxcore50, >= netstandard10, >= netstandard13
+      System.Reflection.Emit (>= 4.0.1) - framework: >= net46, >= netstandard13
+      System.Reflection.Emit.ILGeneration (>= 4.0.1) - framework: >= net46, >= netstandard13
+      System.Reflection.Primitives (>= 4.0.1) - framework: >= net46, >= netstandard13
+      System.Reflection.TypeExtensions (>= 4.1) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Resources.ResourceManager (>= 4.0.1) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Runtime (>= 4.1) - framework: >= net46, dnxcore50, >= netstandard10, >= netstandard13
+      System.Runtime.Extensions (>= 4.1) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Threading (>= 4.0.11) - framework: >= net46, dnxcore50, >= netstandard13
+    System.Globalization (4.0.11) - framework: net46, >= net46, dnxcore50, >= netstandard10, >= netstandard13, >= netstandard15
+      Microsoft.NETCore.Platforms (>= 1.0.1) - framework: >= net46, dnxcore50, >= netstandard10, >= netstandard13
+      Microsoft.NETCore.Targets (>= 1.0.1) - framework: >= net46, dnxcore50, >= netstandard10, >= netstandard13
+      System.Runtime (>= 4.1) - framework: >= net46, dnxcore50, >= netstandard10, >= netstandard13
+    System.IO (4.1) - framework: net46, >= net46, dnxcore50, >= netstandard10, netstandard13, >= netstandard13, >= netstandard15
+      Microsoft.NETCore.Platforms (>= 1.0.1) - framework: net46, >= net462, dnxcore50, >= netstandard10, >= netstandard13, >= netstandard15
+      Microsoft.NETCore.Targets (>= 1.0.1) - framework: net46, >= net462, dnxcore50, >= netstandard10, >= netstandard13, >= netstandard15
+      System.Runtime (>= 4.1) - framework: net46, >= net462, dnxcore50, >= netstandard10, >= netstandard13, >= netstandard15
+      System.Text.Encoding (>= 4.0.11) - framework: net46, >= net462, dnxcore50, >= netstandard10, >= netstandard13, >= netstandard15
+      System.Threading.Tasks (>= 4.0.11) - framework: net46, >= net462, dnxcore50, >= netstandard10, >= netstandard13, >= netstandard15
+    System.IO.FileSystem (4.0.1) - framework: >= net46, >= netstandard13, >= netstandard15
       Microsoft.NETCore.Platforms (>= 1.0.1) - framework: >= netstandard13
       Microsoft.NETCore.Targets (>= 1.0.1) - framework: >= netstandard13
       System.IO (>= 4.1) - framework: >= netstandard13
@@ -247,60 +279,60 @@ NUGET
       System.Runtime.Handles (>= 4.0.1) - framework: >= netstandard13
       System.Text.Encoding (>= 4.0.11) - framework: >= netstandard13
       System.Threading.Tasks (>= 4.0.11) - framework: >= netstandard13
-    System.IO.FileSystem.Primitives (4.0.1) - framework: >= net46, >= netstandard13
-      System.Runtime (>= 4.1) - framework: >= netstandard13
-    System.Linq (4.1) - framework: >= net46, dnxcore50, >= netstandard10
-      System.Collections (>= 4.0.11) - framework: dnxcore50, netstandard10, >= netstandard16
-      System.Diagnostics.Debug (>= 4.0.11) - framework: dnxcore50, >= netstandard16
-      System.Resources.ResourceManager (>= 4.0.1) - framework: dnxcore50, >= netstandard16
-      System.Runtime (>= 4.1) - framework: dnxcore50, netstandard10, >= netstandard16
-      System.Runtime.Extensions (>= 4.1) - framework: dnxcore50, >= netstandard16
-    System.Linq.Expressions (4.1) - framework: >= net46, dnxcore50, >= netstandard10
-      System.Collections (>= 4.0.11) - framework: dnxcore50, >= netstandard16
-      System.Diagnostics.Debug (>= 4.0.11) - framework: dnxcore50, >= netstandard16
-      System.Globalization (>= 4.0.11) - framework: dnxcore50, >= netstandard16
-      System.IO (>= 4.1) - framework: dnxcore50, >= netstandard16
-      System.Linq (>= 4.1) - framework: dnxcore50, >= netstandard16
-      System.ObjectModel (>= 4.0.12) - framework: >= netstandard16
-      System.Reflection (>= 4.1) - framework: dnxcore50, netstandard10, netstandard13, >= netstandard16
-      System.Reflection.Emit (>= 4.0.1) - framework: >= netstandard16
-      System.Reflection.Emit.ILGeneration (>= 4.0.1) - framework: dnxcore50, >= netstandard16
-      System.Reflection.Emit.Lightweight (>= 4.0.1) - framework: dnxcore50, >= netstandard16
-      System.Reflection.Extensions (>= 4.0.1) - framework: dnxcore50, >= netstandard16
-      System.Reflection.Primitives (>= 4.0.1) - framework: dnxcore50, >= netstandard16
-      System.Reflection.TypeExtensions (>= 4.1) - framework: dnxcore50, >= netstandard16
-      System.Resources.ResourceManager (>= 4.0.1) - framework: dnxcore50, >= netstandard16
-      System.Runtime (>= 4.1) - framework: dnxcore50, netstandard10, netstandard13, >= netstandard16
-      System.Runtime.Extensions (>= 4.1) - framework: dnxcore50, >= netstandard16
-      System.Threading (>= 4.0.11) - framework: dnxcore50, >= netstandard16
-    System.ObjectModel (4.0.12) - framework: dnxcore50, >= netstandard10
-      System.Collections (>= 4.0.11) - framework: dnxcore50, >= netstandard13
-      System.Diagnostics.Debug (>= 4.0.11) - framework: dnxcore50, >= netstandard13
-      System.Resources.ResourceManager (>= 4.0.1) - framework: dnxcore50, >= netstandard13
-      System.Runtime (>= 4.1) - framework: dnxcore50, netstandard10, >= netstandard13
-      System.Threading (>= 4.0.11) - framework: dnxcore50, >= netstandard13
-    System.Reflection (4.1) - framework: >= net46, dnxcore50, >= netstandard10, netstandard13, >= netstandard15
-      Microsoft.NETCore.Platforms (>= 1.0.1) - framework: dnxcore50, netstandard10, netstandard13, >= netstandard15
-      Microsoft.NETCore.Targets (>= 1.0.1) - framework: dnxcore50, netstandard10, netstandard13, >= netstandard15
-      System.IO (>= 4.1) - framework: dnxcore50, netstandard10, netstandard13, >= netstandard15
-      System.Reflection.Primitives (>= 4.0.1) - framework: dnxcore50, netstandard10, netstandard13, >= netstandard15
-      System.Runtime (>= 4.1) - framework: dnxcore50, netstandard10, netstandard13, >= netstandard15
-    System.Reflection.Emit (4.0.1) - framework: >= netstandard13
-      System.IO (>= 4.1) - framework: >= netstandard11
-      System.Reflection (>= 4.1) - framework: >= netstandard11
-      System.Reflection.Emit.ILGeneration (>= 4.0.1) - framework: >= netstandard11, monotouch, xamarinios
-      System.Reflection.Primitives (>= 4.0.1) - framework: >= netstandard11
-      System.Runtime (>= 4.1) - framework: >= netstandard11
-    System.Reflection.Emit.ILGeneration (4.0.1) - framework: dnxcore50, >= netstandard13
+    System.IO.FileSystem.Primitives (4.0.1) - framework: >= net46, >= netstandard13, >= netstandard15
+      System.Runtime (>= 4.1) - framework: >= net46, >= netstandard13
+    System.Linq (4.1) - framework: >= net46, dnxcore50, >= netstandard10, >= netstandard13, >= netstandard16
+      System.Collections (>= 4.0.11) - framework: >= net463, dnxcore50, >= netstandard10, >= netstandard16
+      System.Diagnostics.Debug (>= 4.0.11) - framework: >= net463, dnxcore50, >= netstandard16
+      System.Resources.ResourceManager (>= 4.0.1) - framework: >= net463, dnxcore50, >= netstandard16
+      System.Runtime (>= 4.1) - framework: >= net463, dnxcore50, >= netstandard10, >= netstandard16
+      System.Runtime.Extensions (>= 4.1) - framework: >= net463, dnxcore50, >= netstandard16
+    System.Linq.Expressions (4.1) - framework: >= net46, dnxcore50, >= netstandard10, >= netstandard13
+      System.Collections (>= 4.0.11) - framework: >= net463, dnxcore50, >= netstandard16
+      System.Diagnostics.Debug (>= 4.0.11) - framework: >= net463, dnxcore50, >= netstandard16
+      System.Globalization (>= 4.0.11) - framework: >= net463, dnxcore50, >= netstandard16
+      System.IO (>= 4.1) - framework: >= net463, dnxcore50, >= netstandard16
+      System.Linq (>= 4.1) - framework: >= net463, dnxcore50, >= netstandard16
+      System.ObjectModel (>= 4.0.12) - framework: >= net463, >= netstandard16
+      System.Reflection (>= 4.1) - framework: net46, >= net463, dnxcore50, >= netstandard10, >= netstandard13, >= netstandard16
+      System.Reflection.Emit (>= 4.0.1) - framework: >= net463, >= netstandard16
+      System.Reflection.Emit.ILGeneration (>= 4.0.1) - framework: >= net463, dnxcore50, >= netstandard16
+      System.Reflection.Emit.Lightweight (>= 4.0.1) - framework: >= net463, dnxcore50, >= netstandard16
+      System.Reflection.Extensions (>= 4.0.1) - framework: >= net463, dnxcore50, >= netstandard16
+      System.Reflection.Primitives (>= 4.0.1) - framework: >= net463, dnxcore50, >= netstandard16
+      System.Reflection.TypeExtensions (>= 4.1) - framework: >= net463, dnxcore50, >= netstandard16
+      System.Resources.ResourceManager (>= 4.0.1) - framework: >= net463, dnxcore50, >= netstandard16
+      System.Runtime (>= 4.1) - framework: net46, >= net463, dnxcore50, >= netstandard10, >= netstandard13, >= netstandard16
+      System.Runtime.Extensions (>= 4.1) - framework: >= net463, dnxcore50, >= netstandard16
+      System.Threading (>= 4.0.11) - framework: >= net463, dnxcore50, >= netstandard16
+    System.ObjectModel (4.0.12) - framework: >= net46, dnxcore50, >= netstandard10, >= netstandard13, >= netstandard16
+      System.Collections (>= 4.0.11) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Diagnostics.Debug (>= 4.0.11) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Resources.ResourceManager (>= 4.0.1) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Runtime (>= 4.1) - framework: >= net46, dnxcore50, >= netstandard10, >= netstandard13
+      System.Threading (>= 4.0.11) - framework: >= net46, dnxcore50, >= netstandard13
+    System.Reflection (4.1) - framework: net46, >= net46, dnxcore50, >= netstandard10, netstandard13, >= netstandard13, >= netstandard15
+      Microsoft.NETCore.Platforms (>= 1.0.1) - framework: net46, >= net462, dnxcore50, >= netstandard10, >= netstandard13, >= netstandard15
+      Microsoft.NETCore.Targets (>= 1.0.1) - framework: net46, >= net462, dnxcore50, >= netstandard10, >= netstandard13, >= netstandard15
+      System.IO (>= 4.1) - framework: net46, >= net462, dnxcore50, >= netstandard10, >= netstandard13, >= netstandard15
+      System.Reflection.Primitives (>= 4.0.1) - framework: net46, >= net462, dnxcore50, >= netstandard10, >= netstandard13, >= netstandard15
+      System.Runtime (>= 4.1) - framework: net46, >= net462, dnxcore50, >= netstandard10, >= netstandard13, >= netstandard15
+    System.Reflection.Emit (4.0.1) - framework: >= net46, >= netstandard13, >= netstandard16
+      System.IO (>= 4.1) - framework: >= net45, >= netstandard11
+      System.Reflection (>= 4.1) - framework: >= net45, >= netstandard11
+      System.Reflection.Emit.ILGeneration (>= 4.0.1) - framework: >= net45, >= netstandard11, monotouch, xamarinios
+      System.Reflection.Primitives (>= 4.0.1) - framework: >= net45, >= netstandard11
+      System.Runtime (>= 4.1) - framework: >= net45, >= netstandard11
+    System.Reflection.Emit.ILGeneration (4.0.1) - framework: >= net46, dnxcore50, >= netstandard13, >= netstandard16
       System.Reflection (>= 4.1) - framework: >= netstandard10
       System.Reflection.Primitives (>= 4.0.1) - framework: >= netstandard10
       System.Runtime (>= 4.1) - framework: >= netstandard10
-    System.Reflection.Emit.Lightweight (4.0.1) - framework: dnxcore50, >= netstandard16
+    System.Reflection.Emit.Lightweight (4.0.1) - framework: >= net463, dnxcore50, >= netstandard16
       System.Reflection (>= 4.1) - framework: >= netstandard10
       System.Reflection.Emit.ILGeneration (>= 4.0.1) - framework: >= netstandard10, monoandroid, monotouch, xamarinios, xamarinmac
       System.Reflection.Primitives (>= 4.0.1) - framework: >= netstandard10
       System.Runtime (>= 4.1) - framework: >= netstandard10
-    System.Reflection.Extensions (4.0.1) - framework: dnxcore50, >= netstandard10
+    System.Reflection.Extensions (4.0.1) - framework: >= net463, dnxcore50, >= netstandard10, >= netstandard16
       Microsoft.NETCore.Platforms (>= 1.0.1) - framework: dnxcore50, >= netstandard10
       Microsoft.NETCore.Targets (>= 1.0.1) - framework: dnxcore50, >= netstandard10
       System.Reflection (>= 4.1) - framework: dnxcore50, >= netstandard10
@@ -322,31 +354,31 @@ NUGET
       System.Text.Encoding (>= 4.0.11) - framework: >= netstandard11
       System.Text.Encoding.Extensions (>= 4.0.11) - framework: >= netstandard11
       System.Threading (>= 4.0.11) - framework: >= netstandard11
-    System.Reflection.Primitives (4.0.1) - framework: >= net46, dnxcore50, >= netstandard10
+    System.Reflection.Primitives (4.0.1) - framework: net46, >= net46, dnxcore50, >= netstandard10, netstandard13, >= netstandard13, >= netstandard15
       Microsoft.NETCore.Platforms (>= 1.0.1) - framework: dnxcore50, >= netstandard10
       Microsoft.NETCore.Targets (>= 1.0.1) - framework: dnxcore50, >= netstandard10
       System.Runtime (>= 4.1) - framework: dnxcore50, >= netstandard10
-    System.Reflection.TypeExtensions (4.1) - framework: dnxcore50, >= netstandard13
+    System.Reflection.TypeExtensions (4.1) - framework: >= net46, dnxcore50, >= netstandard13, >= netstandard16
       System.Reflection (>= 4.1) - framework: >= net462, dnxcore50, netstandard13, >= netstandard15
       System.Runtime (>= 4.1) - framework: dnxcore50, netstandard13, >= netstandard15
-    System.Resources.ResourceManager (4.0.1) - framework: >= net46, dnxcore50, >= netstandard10
+    System.Resources.ResourceManager (4.0.1) - framework: net46, >= net46, dnxcore50, >= netstandard10, >= netstandard13, >= netstandard15
       Microsoft.NETCore.Platforms (>= 1.0.1) - framework: dnxcore50, >= netstandard10
       Microsoft.NETCore.Targets (>= 1.0.1) - framework: dnxcore50, >= netstandard10
       System.Globalization (>= 4.0.11) - framework: dnxcore50, >= netstandard10
       System.Reflection (>= 4.1) - framework: dnxcore50, >= netstandard10
       System.Runtime (>= 4.1) - framework: dnxcore50, >= netstandard10
     System.Runtime (4.1)
-      Microsoft.NETCore.Platforms (>= 1.0.1) - framework: dnxcore50, netstandard10, netstandard12, netstandard13, >= netstandard15
-      Microsoft.NETCore.Targets (>= 1.0.1) - framework: dnxcore50, netstandard10, netstandard12, netstandard13, >= netstandard15
-    System.Runtime.Extensions (4.1) - framework: >= net46, dnxcore50, >= netstandard10
-      Microsoft.NETCore.Platforms (>= 1.0.1) - framework: dnxcore50, netstandard10, netstandard13, >= netstandard15
-      Microsoft.NETCore.Targets (>= 1.0.1) - framework: dnxcore50, netstandard10, netstandard13, >= netstandard15
-      System.Runtime (>= 4.1) - framework: dnxcore50, netstandard10, netstandard13, >= netstandard15
+      Microsoft.NETCore.Platforms (>= 1.0.1) - framework: net451, net452, net453, net46, >= net462, dnxcore50, >= netstandard10, >= netstandard12, >= netstandard13, >= netstandard15
+      Microsoft.NETCore.Targets (>= 1.0.1) - framework: net451, net452, net453, net46, >= net462, dnxcore50, >= netstandard10, >= netstandard12, >= netstandard13, >= netstandard15
+    System.Runtime.Extensions (4.1) - framework: >= net46, dnxcore50, >= netstandard10, >= netstandard13, >= netstandard15
+      Microsoft.NETCore.Platforms (>= 1.0.1) - framework: net46, >= net462, dnxcore50, >= netstandard10, >= netstandard13, >= netstandard15
+      Microsoft.NETCore.Targets (>= 1.0.1) - framework: net46, >= net462, dnxcore50, >= netstandard10, >= netstandard13, >= netstandard15
+      System.Runtime (>= 4.1) - framework: net46, >= net462, dnxcore50, >= netstandard10, >= netstandard13, >= netstandard15
     System.Runtime.Handles (4.0.1) - framework: >= net46, >= netstandard13, >= netstandard15
-      Microsoft.NETCore.Platforms (>= 1.0.1) - framework: >= netstandard13
-      Microsoft.NETCore.Targets (>= 1.0.1) - framework: >= netstandard13
-      System.Runtime (>= 4.1) - framework: >= netstandard13
-    System.Runtime.InteropServices (4.1) - framework: >= net46, >= netstandard11
+      Microsoft.NETCore.Platforms (>= 1.0.1) - framework: >= net46, >= netstandard13
+      Microsoft.NETCore.Targets (>= 1.0.1) - framework: >= net46, >= netstandard13
+      System.Runtime (>= 4.1) - framework: >= net46, >= netstandard13
+    System.Runtime.InteropServices (4.1) - framework: >= net46, >= netstandard11, >= netstandard13, >= netstandard15
       Microsoft.NETCore.Platforms (>= 1.0.1) - framework: dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15
       Microsoft.NETCore.Targets (>= 1.0.1) - framework: dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15
       System.Reflection (>= 4.1) - framework: dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15
@@ -354,111 +386,154 @@ NUGET
       System.Runtime (>= 4.1) - framework: >= net462, dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15
       System.Runtime.Handles (>= 4.0.1) - framework: dnxcore50, netstandard13, >= netstandard15
     System.Runtime.InteropServices.RuntimeInformation (4.0) - framework: >= netstandard15
-      Microsoft.NETCore.Platforms (>= 1.0.1) - framework: dnxcore50, >= netstandard11
-      runtime.native.System (>= 4.0) - framework: >= netstandard11
-      System.Reflection (>= 4.1) - framework: dnxcore50, >= netstandard11
-      System.Resources.ResourceManager (>= 4.0.1) - framework: dnxcore50, >= netstandard11
-      System.Runtime (>= 4.1) - framework: dnxcore50, >= netstandard11
-      System.Runtime.InteropServices (>= 4.1) - framework: >= netstandard11
-      System.Threading (>= 4.0.11) - framework: dnxcore50, >= netstandard11
+      Microsoft.NETCore.Platforms (>= 1.0.1) - framework: >= net45, dnxcore50, >= netstandard11
+      runtime.native.System (>= 4.0) - framework: >= net45, >= netstandard11
+      System.Reflection (>= 4.1) - framework: >= net45, dnxcore50, >= netstandard11
+      System.Resources.ResourceManager (>= 4.0.1) - framework: >= net45, dnxcore50, >= netstandard11
+      System.Runtime (>= 4.1) - framework: >= net45, dnxcore50, >= netstandard11
+      System.Runtime.InteropServices (>= 4.1) - framework: >= net45, >= netstandard11
+      System.Threading (>= 4.0.11) - framework: >= net45, dnxcore50, >= netstandard11
     System.Runtime.Numerics (4.0.1) - framework: >= net46
+      System.Globalization (>= 4.0.11) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Resources.ResourceManager (>= 4.0.1) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Runtime (>= 4.1) - framework: net45, >= net46, dnxcore50, >= netstandard11, >= netstandard13
+      System.Runtime.Extensions (>= 4.1) - framework: >= net46, dnxcore50, >= netstandard13
     System.Runtime.Serialization.Primitives (4.1.1) - framework: >= netstandard10
-      System.Resources.ResourceManager (>= 4.0.1) - framework: dnxcore50, >= netstandard13
-      System.Runtime (>= 4.1) - framework: dnxcore50, netstandard10, >= netstandard13
+      System.Resources.ResourceManager (>= 4.0.1) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Runtime (>= 4.1) - framework: >= net46, dnxcore50, >= netstandard10, >= netstandard13
     System.Security.Cryptography.Algorithms (4.2) - framework: >= net46
       System.IO (>= 4.1) - framework: >= net463, dnxcore50, netstandard13, netstandard14, >= netstandard16
       System.Runtime (>= 4.1) - framework: >= net463, dnxcore50, netstandard13, netstandard14, >= netstandard16
       System.Security.Cryptography.Encoding (>= 4.0) - framework: >= net463, dnxcore50, >= netstandard16
       System.Security.Cryptography.Primitives (>= 4.0) - framework: net46, net461, >= net463, dnxcore50, netstandard13, netstandard14, >= netstandard16
     System.Security.Cryptography.Encoding (4.0) - framework: >= net46
-    System.Security.Cryptography.Primitives (4.0) - framework: net46, net461, >= net463
+      Microsoft.NETCore.Platforms (>= 1.0.1) - framework: >= net46, >= netstandard13
+      runtime.native.System.Security.Cryptography (>= 4.0) - framework: >= net46, >= netstandard13
+      System.Collections (>= 4.0.11) - framework: >= net46, >= netstandard13
+      System.Collections.Concurrent (>= 4.0.12) - framework: >= net46, >= netstandard13
+      System.Linq (>= 4.1) - framework: >= net46, >= netstandard13
+      System.Resources.ResourceManager (>= 4.0.1) - framework: >= net46, >= netstandard13
+      System.Runtime (>= 4.1) - framework: >= net46, >= netstandard13
+      System.Runtime.Extensions (>= 4.1) - framework: >= net46, >= netstandard13
+      System.Runtime.Handles (>= 4.0.1) - framework: >= net46, >= netstandard13
+      System.Runtime.InteropServices (>= 4.1) - framework: >= net46, >= netstandard13
+      System.Security.Cryptography.Primitives (>= 4.0) - framework: >= net46, >= netstandard13
+      System.Text.Encoding (>= 4.0.11) - framework: >= net46, >= netstandard13
+    System.Security.Cryptography.Primitives (4.0) - framework: >= net46
+      System.Diagnostics.Debug (>= 4.0.11) - framework: >= net46, >= netstandard13
+      System.Globalization (>= 4.0.11) - framework: >= net46, >= netstandard13
+      System.IO (>= 4.1) - framework: >= net46, >= netstandard13
+      System.Resources.ResourceManager (>= 4.0.1) - framework: >= net46, >= netstandard13
+      System.Runtime (>= 4.1) - framework: >= net46, >= netstandard13
+      System.Threading (>= 4.0.11) - framework: >= net46, >= netstandard13
+      System.Threading.Tasks (>= 4.0.11) - framework: >= net46, >= netstandard13
     System.Security.Cryptography.X509Certificates (4.1) - framework: >= net46
       System.Security.Cryptography.Algorithms (>= 4.2) - framework: net46, >= net461, dnxcore50, netstandard13, netstandard14, >= netstandard16
       System.Security.Cryptography.Encoding (>= 4.0) - framework: net46, >= net461, dnxcore50, netstandard13, netstandard14, >= netstandard16
-    System.Text.Encoding (4.0.11) - framework: >= net46, dnxcore50, >= netstandard10
-      Microsoft.NETCore.Platforms (>= 1.0.1) - framework: dnxcore50, netstandard10, >= netstandard13
-      Microsoft.NETCore.Targets (>= 1.0.1) - framework: dnxcore50, netstandard10, >= netstandard13
-      System.Runtime (>= 4.1) - framework: dnxcore50, netstandard10, >= netstandard13
+    System.Text.Encoding (4.0.11) - framework: net46, >= net46, dnxcore50, >= netstandard10, netstandard13, >= netstandard13, >= netstandard15
+      Microsoft.NETCore.Platforms (>= 1.0.1) - framework: >= net46, dnxcore50, >= netstandard10, >= netstandard13
+      Microsoft.NETCore.Targets (>= 1.0.1) - framework: >= net46, dnxcore50, >= netstandard10, >= netstandard13
+      System.Runtime (>= 4.1) - framework: >= net46, dnxcore50, >= netstandard10, >= netstandard13
     System.Text.Encoding.CodePages (4.0.1) - framework: >= net46
-    System.Text.Encoding.Extensions (4.0.11) - framework: >= net46, >= netstandard10
-      Microsoft.NETCore.Platforms (>= 1.0.1) - framework: dnxcore50, netstandard10, >= netstandard13
-      Microsoft.NETCore.Targets (>= 1.0.1) - framework: dnxcore50, netstandard10, >= netstandard13
-      System.Runtime (>= 4.1) - framework: dnxcore50, netstandard10, >= netstandard13
-      System.Text.Encoding (>= 4.0.11) - framework: dnxcore50, netstandard10, >= netstandard13
-    System.Text.RegularExpressions (4.1) - framework: dnxcore50, >= netstandard10
-      System.Collections (>= 4.0.11) - framework: dnxcore50, >= netstandard16
-      System.Globalization (>= 4.0.11) - framework: dnxcore50, >= netstandard16
-      System.Resources.ResourceManager (>= 4.0.1) - framework: dnxcore50, >= netstandard16
-      System.Runtime (>= 4.1) - framework: dnxcore50, netstandard10, netstandard13, >= netstandard16
-      System.Runtime.Extensions (>= 4.1) - framework: dnxcore50, >= netstandard16
-      System.Threading (>= 4.0.11) - framework: dnxcore50, >= netstandard16
-    System.Threading (4.0.11) - framework: >= net46, dnxcore50, >= netstandard10
-      System.Runtime (>= 4.1) - framework: dnxcore50, netstandard10, >= netstandard13
-      System.Threading.Tasks (>= 4.0.11) - framework: dnxcore50, netstandard10, >= netstandard13
-    System.Threading.Tasks (4.0.11) - framework: >= net45, dnxcore50, netstandard10, >= netstandard10, netstandard13, >= netstandard13, >= netstandard15
-      Microsoft.NETCore.Platforms (>= 1.0.1) - framework: dnxcore50, netstandard10, >= netstandard13
-      Microsoft.NETCore.Targets (>= 1.0.1) - framework: dnxcore50, netstandard10, >= netstandard13
-      System.Runtime (>= 4.1) - framework: dnxcore50, netstandard10, >= netstandard13
+      Microsoft.NETCore.Platforms (>= 1.0.1) - framework: >= net46, >= netstandard13
+      System.Collections (>= 4.0.11) - framework: >= net46, >= netstandard13
+      System.Globalization (>= 4.0.11) - framework: >= net46, >= netstandard13
+      System.IO (>= 4.1) - framework: >= net46, >= netstandard13
+      System.Reflection (>= 4.1) - framework: >= net46, >= netstandard13
+      System.Resources.ResourceManager (>= 4.0.1) - framework: >= net46, >= netstandard13
+      System.Runtime (>= 4.1) - framework: >= net46, >= netstandard13
+      System.Runtime.Extensions (>= 4.1) - framework: >= net46, >= netstandard13
+      System.Runtime.Handles (>= 4.0.1) - framework: >= net46, >= netstandard13
+      System.Runtime.InteropServices (>= 4.1) - framework: >= net46, >= netstandard13
+      System.Text.Encoding (>= 4.0.11) - framework: >= net46, >= netstandard13
+      System.Threading (>= 4.0.11) - framework: >= net46, >= netstandard13
+    System.Text.Encoding.Extensions (4.0.11) - framework: >= net46, >= netstandard10, >= netstandard13, >= netstandard15
+      Microsoft.NETCore.Platforms (>= 1.0.1) - framework: >= net46, dnxcore50, >= netstandard10, >= netstandard13
+      Microsoft.NETCore.Targets (>= 1.0.1) - framework: >= net46, dnxcore50, >= netstandard10, >= netstandard13
+      System.Runtime (>= 4.1) - framework: >= net46, dnxcore50, >= netstandard10, >= netstandard13
+      System.Text.Encoding (>= 4.0.11) - framework: >= net46, dnxcore50, >= netstandard10, >= netstandard13
+    System.Text.RegularExpressions (4.1) - framework: >= net46, dnxcore50, >= netstandard10, >= netstandard13, >= netstandard15
+      System.Collections (>= 4.0.11) - framework: >= net463, dnxcore50, >= netstandard16
+      System.Globalization (>= 4.0.11) - framework: >= net463, dnxcore50, >= netstandard16
+      System.Resources.ResourceManager (>= 4.0.1) - framework: >= net463, dnxcore50, >= netstandard16
+      System.Runtime (>= 4.1) - framework: net46, >= net463, dnxcore50, >= netstandard10, >= netstandard13, >= netstandard16
+      System.Runtime.Extensions (>= 4.1) - framework: >= net463, dnxcore50, >= netstandard16
+      System.Threading (>= 4.0.11) - framework: >= net463, dnxcore50, >= netstandard16
+    System.Threading (4.0.11) - framework: net46, >= net46, dnxcore50, >= netstandard10, >= netstandard13, >= netstandard15
+      System.Runtime (>= 4.1) - framework: >= net46, dnxcore50, >= netstandard10, >= netstandard13
+      System.Threading.Tasks (>= 4.0.11) - framework: >= net46, dnxcore50, >= netstandard10, >= netstandard13
+    System.Threading.Tasks (4.0.11) - framework: >= net45, dnxcore50, >= netstandard10, netstandard13, >= netstandard13, >= netstandard15
+      Microsoft.NETCore.Platforms (>= 1.0.1) - framework: >= net46, dnxcore50, >= netstandard10, >= netstandard13
+      Microsoft.NETCore.Targets (>= 1.0.1) - framework: >= net46, dnxcore50, >= netstandard10, >= netstandard13
+      System.Runtime (>= 4.1) - framework: >= net46, dnxcore50, >= netstandard10, >= netstandard13
     System.Threading.Tasks.Extensions (4.0) - framework: >= net45, >= netstandard13, >= netstandard15
       System.Collections (>= 4.0.11) - framework: >= netstandard10
       System.Runtime (>= 4.1) - framework: >= netstandard10
       System.Threading.Tasks (>= 4.0.11) - framework: >= netstandard10
     System.Threading.Tasks.Parallel (4.0.1) - framework: >= net46
+      System.Collections.Concurrent (>= 4.0.12) - framework: net45, >= net46, dnxcore50, >= netstandard11, >= netstandard13
+      System.Diagnostics.Debug (>= 4.0.11) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Diagnostics.Tracing (>= 4.1) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Resources.ResourceManager (>= 4.0.1) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Runtime (>= 4.1) - framework: net45, >= net46, dnxcore50, >= netstandard11, >= netstandard13
+      System.Runtime.Extensions (>= 4.1) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Threading (>= 4.0.11) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Threading.Tasks (>= 4.0.11) - framework: net45, >= net46, dnxcore50, >= netstandard11, >= netstandard13
     System.Threading.Thread (4.0) - framework: >= net46, >= netstandard15
-      System.Runtime (>= 4.1) - framework: >= netstandard13
+      System.Runtime (>= 4.1) - framework: >= net46, >= netstandard13
     System.Threading.ThreadPool (4.0.10) - framework: >= netstandard15
-      System.Runtime (>= 4.1) - framework: >= netstandard13
-      System.Runtime.Handles (>= 4.0.1) - framework: >= netstandard13
-    System.Xml.ReaderWriter (4.0.11) - framework: >= net46, >= netstandard10
-      System.Collections (>= 4.0.11) - framework: dnxcore50, >= netstandard13
-      System.Diagnostics.Debug (>= 4.0.11) - framework: dnxcore50, >= netstandard13
-      System.Globalization (>= 4.0.11) - framework: dnxcore50, >= netstandard13
-      System.IO (>= 4.1) - framework: dnxcore50, netstandard10, >= netstandard13
-      System.IO.FileSystem (>= 4.0.1) - framework: dnxcore50, >= netstandard13
-      System.IO.FileSystem.Primitives (>= 4.0.1) - framework: dnxcore50, >= netstandard13
-      System.Resources.ResourceManager (>= 4.0.1) - framework: dnxcore50, >= netstandard13
-      System.Runtime (>= 4.1) - framework: dnxcore50, netstandard10, >= netstandard13
-      System.Runtime.Extensions (>= 4.1) - framework: dnxcore50, >= netstandard13
-      System.Runtime.InteropServices (>= 4.1) - framework: dnxcore50, >= netstandard13
-      System.Text.Encoding (>= 4.0.11) - framework: dnxcore50, netstandard10, >= netstandard13
-      System.Text.Encoding.Extensions (>= 4.0.11) - framework: dnxcore50, >= netstandard13
-      System.Text.RegularExpressions (>= 4.1) - framework: dnxcore50, >= netstandard13
-      System.Threading.Tasks (>= 4.0.11) - framework: dnxcore50, netstandard10, >= netstandard13
-      System.Threading.Tasks.Extensions (>= 4.0) - framework: dnxcore50, >= netstandard13
+      System.Runtime (>= 4.1) - framework: >= net46, >= netstandard13
+      System.Runtime.Handles (>= 4.0.1) - framework: >= net46, >= netstandard13
+    System.Xml.ReaderWriter (4.0.11) - framework: >= net46, >= netstandard10, >= netstandard13, >= netstandard15
+      System.Collections (>= 4.0.11) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Diagnostics.Debug (>= 4.0.11) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Globalization (>= 4.0.11) - framework: >= net46, dnxcore50, >= netstandard13
+      System.IO (>= 4.1) - framework: >= net46, dnxcore50, >= netstandard10, >= netstandard13
+      System.IO.FileSystem (>= 4.0.1) - framework: >= net46, dnxcore50, >= netstandard13
+      System.IO.FileSystem.Primitives (>= 4.0.1) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Resources.ResourceManager (>= 4.0.1) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Runtime (>= 4.1) - framework: >= net46, dnxcore50, >= netstandard10, >= netstandard13
+      System.Runtime.Extensions (>= 4.1) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Runtime.InteropServices (>= 4.1) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Text.Encoding (>= 4.0.11) - framework: >= net46, dnxcore50, >= netstandard10, >= netstandard13
+      System.Text.Encoding.Extensions (>= 4.0.11) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Text.RegularExpressions (>= 4.1) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Threading.Tasks (>= 4.0.11) - framework: >= net46, dnxcore50, >= netstandard10, >= netstandard13
+      System.Threading.Tasks.Extensions (>= 4.0) - framework: >= net46, dnxcore50, >= netstandard13
     System.Xml.XDocument (4.0.11) - framework: >= net46, >= netstandard10
-      System.Collections (>= 4.0.11) - framework: dnxcore50, >= netstandard13
-      System.Diagnostics.Debug (>= 4.0.11) - framework: dnxcore50, >= netstandard13
-      System.Diagnostics.Tools (>= 4.0.1) - framework: dnxcore50, >= netstandard13
-      System.Globalization (>= 4.0.11) - framework: dnxcore50, >= netstandard13
-      System.IO (>= 4.1) - framework: dnxcore50, netstandard10, >= netstandard13
-      System.Reflection (>= 4.1) - framework: dnxcore50, >= netstandard13
-      System.Resources.ResourceManager (>= 4.0.1) - framework: dnxcore50, >= netstandard13
-      System.Runtime (>= 4.1) - framework: dnxcore50, netstandard10, >= netstandard13
-      System.Runtime.Extensions (>= 4.1) - framework: dnxcore50, >= netstandard13
-      System.Text.Encoding (>= 4.0.11) - framework: dnxcore50, >= netstandard13
-      System.Threading (>= 4.0.11) - framework: dnxcore50, >= netstandard13
-      System.Xml.ReaderWriter (>= 4.0.11) - framework: dnxcore50, netstandard10, >= netstandard13
+      System.Collections (>= 4.0.11) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Diagnostics.Debug (>= 4.0.11) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Diagnostics.Tools (>= 4.0.1) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Globalization (>= 4.0.11) - framework: >= net46, dnxcore50, >= netstandard13
+      System.IO (>= 4.1) - framework: >= net46, dnxcore50, >= netstandard10, >= netstandard13
+      System.Reflection (>= 4.1) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Resources.ResourceManager (>= 4.0.1) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Runtime (>= 4.1) - framework: >= net46, dnxcore50, >= netstandard10, >= netstandard13
+      System.Runtime.Extensions (>= 4.1) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Text.Encoding (>= 4.0.11) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Threading (>= 4.0.11) - framework: >= net46, dnxcore50, >= netstandard13
+      System.Xml.ReaderWriter (>= 4.0.11) - framework: >= net46, dnxcore50, >= netstandard10, >= netstandard13
     System.Xml.XmlDocument (4.0.1) - framework: >= net46, >= netstandard15
-      System.Collections (>= 4.0.11) - framework: >= netstandard13
-      System.Diagnostics.Debug (>= 4.0.11) - framework: >= netstandard13
-      System.Globalization (>= 4.0.11) - framework: >= netstandard13
-      System.IO (>= 4.1) - framework: >= netstandard13
-      System.Resources.ResourceManager (>= 4.0.1) - framework: >= netstandard13
-      System.Runtime (>= 4.1) - framework: >= netstandard13
-      System.Runtime.Extensions (>= 4.1) - framework: >= netstandard13
-      System.Text.Encoding (>= 4.0.11) - framework: >= netstandard13
-      System.Threading (>= 4.0.11) - framework: >= netstandard13
-      System.Xml.ReaderWriter (>= 4.0.11) - framework: >= netstandard13
+      System.Collections (>= 4.0.11) - framework: >= net46, >= netstandard13
+      System.Diagnostics.Debug (>= 4.0.11) - framework: >= net46, >= netstandard13
+      System.Globalization (>= 4.0.11) - framework: >= net46, >= netstandard13
+      System.IO (>= 4.1) - framework: >= net46, >= netstandard13
+      System.Resources.ResourceManager (>= 4.0.1) - framework: >= net46, >= netstandard13
+      System.Runtime (>= 4.1) - framework: >= net46, >= netstandard13
+      System.Runtime.Extensions (>= 4.1) - framework: >= net46, >= netstandard13
+      System.Text.Encoding (>= 4.0.11) - framework: >= net46, >= netstandard13
+      System.Threading (>= 4.0.11) - framework: >= net46, >= netstandard13
+      System.Xml.ReaderWriter (>= 4.0.11) - framework: >= net46, >= netstandard13
     System.Xml.XPath (4.0.1) - framework: >= net46, >= netstandard15
-      System.Collections (>= 4.0.11) - framework: >= netstandard13
-      System.Diagnostics.Debug (>= 4.0.11) - framework: >= netstandard13
-      System.Globalization (>= 4.0.11) - framework: >= netstandard13
-      System.IO (>= 4.1) - framework: >= netstandard13
-      System.Resources.ResourceManager (>= 4.0.1) - framework: >= netstandard13
-      System.Runtime (>= 4.1) - framework: >= netstandard13
-      System.Runtime.Extensions (>= 4.1) - framework: >= netstandard13
-      System.Threading (>= 4.0.11) - framework: >= netstandard13
-      System.Xml.ReaderWriter (>= 4.0.11) - framework: >= netstandard13
+      System.Collections (>= 4.0.11) - framework: >= net46, >= netstandard13
+      System.Diagnostics.Debug (>= 4.0.11) - framework: >= net46, >= netstandard13
+      System.Globalization (>= 4.0.11) - framework: >= net46, >= netstandard13
+      System.IO (>= 4.1) - framework: >= net46, >= netstandard13
+      System.Resources.ResourceManager (>= 4.0.1) - framework: >= net46, >= netstandard13
+      System.Runtime (>= 4.1) - framework: >= net46, >= netstandard13
+      System.Runtime.Extensions (>= 4.1) - framework: >= net46, >= netstandard13
+      System.Threading (>= 4.0.11) - framework: >= net46, >= netstandard13
+      System.Xml.ReaderWriter (>= 4.0.11) - framework: >= net46, >= netstandard13
     System.Xml.XPath.XDocument (4.0.1) - framework: >= net46
       System.Xml.XPath (>= 4.0.1) - framework: >= net46, >= netstandard13
     System.Xml.XPath.XmlDocument (4.0.1) - framework: >= netstandard15

--- a/src/FSharp.Data.GraphQL.Client/FSharp.Data.GraphQL.Client.fsproj
+++ b/src/FSharp.Data.GraphQL.Client/FSharp.Data.GraphQL.Client.fsproj
@@ -259,10 +259,37 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6.3'">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
       <ItemGroup>
         <Reference Include="System.IO">
           <HintPath>..\..\packages\System.IO\ref\net462\System.IO.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v1.2')">
+      <ItemGroup>
+        <Reference Include="System.IO">
+          <HintPath>..\..\packages\System.IO\ref\netstandard1.0\System.IO.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.3' Or $(TargetFrameworkVersion) == 'v1.4')">
+      <ItemGroup>
+        <Reference Include="System.IO">
+          <HintPath>..\..\packages\System.IO\ref\netstandard1.3\System.IO.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.5' Or $(TargetFrameworkVersion) == 'v1.6')">
+      <ItemGroup>
+        <Reference Include="System.IO">
+          <HintPath>..\..\packages\System.IO\ref\netstandard1.5\System.IO.dll</HintPath>
           <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
@@ -490,6 +517,24 @@
     </When>
   </Choose>
   <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1')">
+      <ItemGroup>
+        <Reference Include="System.Reflection.TypeExtensions">
+          <HintPath>..\..\packages\System.Reflection.TypeExtensions\ref\net46\System.Reflection.TypeExtensions.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+      <ItemGroup>
+        <Reference Include="System.Reflection.TypeExtensions">
+          <HintPath>..\..\packages\System.Reflection.TypeExtensions\ref\net462\System.Reflection.TypeExtensions.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.3' Or $(TargetFrameworkVersion) == 'v1.4')">
       <ItemGroup>
         <Reference Include="System.Reflection.TypeExtensions">
@@ -734,6 +779,15 @@
     </When>
   </Choose>
   <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6.3'">
+      <ItemGroup>
+        <Reference Include="System.Text.RegularExpressions">
+          <HintPath>..\..\packages\System.Text.RegularExpressions\ref\net463\System.Text.RegularExpressions.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v1.2')">
       <ItemGroup>
         <Reference Include="System.Text.RegularExpressions">
@@ -783,7 +837,7 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v1.2')) Or ($(TargetFrameworkIdentifier) == 'WindowsPhone' And $(TargetFrameworkVersion) == 'v8.1')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v1.2')">
       <ItemGroup>
         <Reference Include="System.Threading.Tasks">
           <HintPath>..\..\packages\System.Threading.Tasks\ref\netstandard1.0\System.Threading.Tasks.dll</HintPath>

--- a/src/FSharp.Data.GraphQL.Server/Planning.fs
+++ b/src/FSharp.Data.GraphQL.Server/Planning.fs
@@ -245,7 +245,7 @@ and private planAbstraction (ctx:PlanningContext) (info) (selectionSet: Selectio
         ) Map.empty
     { info with Kind = ResolveAbstraction plannedTypeFields }
 
-let internal planOperation (ctx: PlanningContext) (operation: OperationDefinition) : ExecutionPlan =
+let internal planOperation documentId (ctx: PlanningContext) (operation: OperationDefinition) : ExecutionPlan =
     // create artificial plan info to start with
     let rootInfo = { 
         Identifier = null
@@ -260,14 +260,16 @@ let internal planOperation (ctx: PlanningContext) (operation: OperationDefinitio
     let (SelectFields(topFields)) = resolvedInfo.Kind
     match operation.OperationType with
     | Query ->
-        { Operation = operation 
+        { DocumentId = documentId
+          Operation = operation 
           Fields = topFields
           RootDef = ctx.Schema.Query
           Strategy = Parallel }
     | Mutation ->
         match ctx.Schema.Mutation with
         | Some mutationDef ->
-            { Operation = operation
+            { DocumentId = documentId
+              Operation = operation
               Fields = topFields
               RootDef = mutationDef
               Strategy = Sequential }

--- a/src/FSharp.Data.GraphQL.Server/Schema.fs
+++ b/src/FSharp.Data.GraphQL.Server/Schema.fs
@@ -241,8 +241,8 @@ type Schema<'Root> (query: ObjectDef<'Root>, ?mutation: ObjectDef<'Root>, ?confi
     member private this.Eval(executionPlan: ExecutionPlan, data: 'Root option, variables: Map<string, obj>): Async<IDictionary<string,obj>> =
         let inline prepareOutput (errors: System.Collections.Concurrent.ConcurrentBag<exn>) (result: NameValueLookup) =
             if errors.IsEmpty 
-            then [ "data", box result ] 
-            else [ "data", box result ; "errors", upcast (errors.ToArray() |> Array.map (fun e -> e.Message)) ]
+            then [ "documentId", box executionPlan.DocumentId ; "data", upcast result ] 
+            else [ "documentId", box executionPlan.DocumentId ; "data", box result ; "errors", upcast (errors.ToArray() |> Array.map (fun e -> e.Message)) ]
         async {
             try
                 let errors = System.Collections.Concurrent.ConcurrentBag<exn>()
@@ -304,7 +304,7 @@ type Schema<'Root> (query: ObjectDef<'Root>, ?mutation: ObjectDef<'Root>, ?confi
                     | Some m -> m
                     | None -> raise (GraphQLException "Operation to be executed is of type mutation, but no mutation root object was defined in current schema")
             let planningCtx = { Schema = this; RootDef = rootDef; Document = ast }
-            planOperation planningCtx operation
+            planOperation (ast.GetHashCode()) planningCtx operation
         | None -> raise (GraphQLException "No operation with specified name has been found for provided document")
         
     /// Creates an execution plan for provided GraphQL query string without 

--- a/src/FSharp.Data.GraphQL.Shared/FSharp.Data.GraphQL.Shared.fsproj
+++ b/src/FSharp.Data.GraphQL.Shared/FSharp.Data.GraphQL.Shared.fsproj
@@ -46,6 +46,18 @@
   <Target Name="AfterBuild">
   </Target>
   -->
+  <ItemGroup>
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="Extensions.fs" />
+    <Compile Include="Prolog.fs" />
+    <Compile Include="Ast.fs" />
+    <Compile Include="AsyncVal.fs" />
+    <Compile Include="TypeSystem.fs" />
+    <Compile Include="Validation.fs" />
+    <Compile Include="Introspection.fs" />
+    <Compile Include="Parser.fs" />
+    <None Include="paket.references" />
+  </ItemGroup>
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
       <ItemGroup>
@@ -141,16 +153,4 @@
       </ItemGroup>
     </When>
   </Choose>
-  <ItemGroup>
-    <Compile Include="AssemblyInfo.fs" />
-    <Compile Include="Extensions.fs" />
-    <Compile Include="Prolog.fs" />
-    <Compile Include="Ast.fs" />
-    <Compile Include="AsyncVal.fs" />
-    <Compile Include="TypeSystem.fs" />
-    <Compile Include="Validation.fs" />
-    <Compile Include="Introspection.fs" />
-    <Compile Include="Parser.fs" />
-    <None Include="paket.references" />
-  </ItemGroup>
 </Project>

--- a/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
+++ b/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
@@ -416,7 +416,9 @@ and ExecutionStrategy =
 /// Execution plan of the current GraphQL operation. It describes, which
 /// fiels will be resolved and how to do so.
 and ExecutionPlan = 
-    { /// AST defintion of current operation.
+    { /// Unique identifier of the current execution plan.
+      DocumentId : int
+      /// AST defintion of current operation.
       Operation : OperationDefinition
       /// Definition of the root type (either query or mutation) used by the
       /// current operation.

--- a/tests/FSharp.Data.GraphQL.Benchmarks/FSharp.Data.GraphQL.Benchmarks.fsproj
+++ b/tests/FSharp.Data.GraphQL.Benchmarks/FSharp.Data.GraphQL.Benchmarks.fsproj
@@ -429,6 +429,17 @@
     </When>
   </Choose>
   <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+      <ItemGroup>
+        <Reference Include="System.Diagnostics.Tracing">
+          <HintPath>..\..\packages\System.Diagnostics.Tracing\ref\net462\System.Diagnostics.Tracing.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v1.2')">
       <ItemGroup>
         <Reference Include="System.Dynamic.Runtime">
@@ -469,10 +480,37 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6.3'">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
       <ItemGroup>
         <Reference Include="System.IO">
           <HintPath>..\..\packages\System.IO\ref\net462\System.IO.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v1.2')">
+      <ItemGroup>
+        <Reference Include="System.IO">
+          <HintPath>..\..\packages\System.IO\ref\netstandard1.0\System.IO.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.3' Or $(TargetFrameworkVersion) == 'v1.4')">
+      <ItemGroup>
+        <Reference Include="System.IO">
+          <HintPath>..\..\packages\System.IO\ref\netstandard1.3\System.IO.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.5' Or $(TargetFrameworkVersion) == 'v1.6')">
+      <ItemGroup>
+        <Reference Include="System.IO">
+          <HintPath>..\..\packages\System.IO\ref\netstandard1.5\System.IO.dll</HintPath>
           <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
@@ -720,6 +758,24 @@
     </When>
   </Choose>
   <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1')">
+      <ItemGroup>
+        <Reference Include="System.Reflection.TypeExtensions">
+          <HintPath>..\..\packages\System.Reflection.TypeExtensions\ref\net46\System.Reflection.TypeExtensions.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+      <ItemGroup>
+        <Reference Include="System.Reflection.TypeExtensions">
+          <HintPath>..\..\packages\System.Reflection.TypeExtensions\ref\net462\System.Reflection.TypeExtensions.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.3' Or $(TargetFrameworkVersion) == 'v1.4')">
       <ItemGroup>
         <Reference Include="System.Reflection.TypeExtensions">
@@ -975,7 +1031,7 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
       <ItemGroup>
         <Reference Include="System.Security.Cryptography.Primitives">
           <HintPath>..\..\packages\System.Security.Cryptography.Primitives\ref\net46\System.Security.Cryptography.Primitives.dll</HintPath>
@@ -1057,6 +1113,15 @@
     </When>
   </Choose>
   <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6.3'">
+      <ItemGroup>
+        <Reference Include="System.Text.RegularExpressions">
+          <HintPath>..\..\packages\System.Text.RegularExpressions\ref\net463\System.Text.RegularExpressions.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v1.2')">
       <ItemGroup>
         <Reference Include="System.Text.RegularExpressions">
@@ -1106,7 +1171,7 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v1.2')) Or ($(TargetFrameworkIdentifier) == 'WindowsPhone' And $(TargetFrameworkVersion) == 'v8.1')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v1.2')">
       <ItemGroup>
         <Reference Include="System.Threading.Tasks">
           <HintPath>..\..\packages\System.Threading.Tasks\ref\netstandard1.0\System.Threading.Tasks.dll</HintPath>

--- a/tests/FSharp.Data.GraphQL.Tests.Sql/FSharp.Data.GraphQL.Tests.Sql.fsproj
+++ b/tests/FSharp.Data.GraphQL.Tests.Sql/FSharp.Data.GraphQL.Tests.Sql.fsproj
@@ -273,10 +273,37 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6.3'">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
       <ItemGroup>
         <Reference Include="System.IO">
           <HintPath>..\..\packages\System.IO\ref\net462\System.IO.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v1.2')">
+      <ItemGroup>
+        <Reference Include="System.IO">
+          <HintPath>..\..\packages\System.IO\ref\netstandard1.0\System.IO.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.3' Or $(TargetFrameworkVersion) == 'v1.4')">
+      <ItemGroup>
+        <Reference Include="System.IO">
+          <HintPath>..\..\packages\System.IO\ref\netstandard1.3\System.IO.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.5' Or $(TargetFrameworkVersion) == 'v1.6')">
+      <ItemGroup>
+        <Reference Include="System.IO">
+          <HintPath>..\..\packages\System.IO\ref\netstandard1.5\System.IO.dll</HintPath>
           <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
@@ -464,6 +491,24 @@
     </When>
   </Choose>
   <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1')">
+      <ItemGroup>
+        <Reference Include="System.Reflection.TypeExtensions">
+          <HintPath>..\..\packages\System.Reflection.TypeExtensions\ref\net46\System.Reflection.TypeExtensions.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+      <ItemGroup>
+        <Reference Include="System.Reflection.TypeExtensions">
+          <HintPath>..\..\packages\System.Reflection.TypeExtensions\ref\net462\System.Reflection.TypeExtensions.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.3' Or $(TargetFrameworkVersion) == 'v1.4')">
       <ItemGroup>
         <Reference Include="System.Reflection.TypeExtensions">
@@ -610,6 +655,15 @@
     </When>
   </Choose>
   <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6.3'">
+      <ItemGroup>
+        <Reference Include="System.Text.RegularExpressions">
+          <HintPath>..\..\packages\System.Text.RegularExpressions\ref\net463\System.Text.RegularExpressions.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v1.2')">
       <ItemGroup>
         <Reference Include="System.Text.RegularExpressions">
@@ -659,7 +713,7 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v1.2')) Or ($(TargetFrameworkIdentifier) == 'WindowsPhone' And $(TargetFrameworkVersion) == 'v8.1')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v1.2')">
       <ItemGroup>
         <Reference Include="System.Threading.Tasks">
           <HintPath>..\..\packages\System.Threading.Tasks\ref\netstandard1.0\System.Threading.Tasks.dll</HintPath>

--- a/tests/FSharp.Data.GraphQL.Tests/ExecutionTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/ExecutionTests.fs
@@ -252,3 +252,18 @@ let ``Execution when querying the same field twice will return it`` () =
         "b", upcast 2]
     noErrors result
     result.["data"] |> equals (upcast expected)
+    
+[<Fact>]
+let ``Execution when querying returns unique document id with response`` () =
+    let schema =
+      Schema(Define.Object<TwiceTest>(
+                "Type", [
+                    Define.Field("a", String, fun _ x -> x.A)
+                    Define.Field("b", Int, fun _ x -> x.B)
+                ]))
+    let result1 = sync <| schema.AsyncExecute("query Example { a, b, a }", { A = "aa"; B = 2 })
+    result1.["documentId"] |> notEquals (null)
+    result1.["documentId"] |> notEquals (upcast Unchecked.defaultof<int>)
+    let result2 = sync <| schema.AsyncExecute("query Example { a, b, a }", { A = "aa"; B = 2 })
+    result1.["documentId"] |> equals (result2.["documentId"])
+    

--- a/tests/FSharp.Data.GraphQL.Tests/FSharp.Data.GraphQL.Tests.fsproj
+++ b/tests/FSharp.Data.GraphQL.Tests/FSharp.Data.GraphQL.Tests.fsproj
@@ -279,10 +279,37 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6.3'">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
       <ItemGroup>
         <Reference Include="System.IO">
           <HintPath>..\..\packages\System.IO\ref\net462\System.IO.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v1.2')">
+      <ItemGroup>
+        <Reference Include="System.IO">
+          <HintPath>..\..\packages\System.IO\ref\netstandard1.0\System.IO.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.3' Or $(TargetFrameworkVersion) == 'v1.4')">
+      <ItemGroup>
+        <Reference Include="System.IO">
+          <HintPath>..\..\packages\System.IO\ref\netstandard1.3\System.IO.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.5' Or $(TargetFrameworkVersion) == 'v1.6')">
+      <ItemGroup>
+        <Reference Include="System.IO">
+          <HintPath>..\..\packages\System.IO\ref\netstandard1.5\System.IO.dll</HintPath>
           <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
@@ -510,6 +537,24 @@
     </When>
   </Choose>
   <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1')">
+      <ItemGroup>
+        <Reference Include="System.Reflection.TypeExtensions">
+          <HintPath>..\..\packages\System.Reflection.TypeExtensions\ref\net46\System.Reflection.TypeExtensions.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+      <ItemGroup>
+        <Reference Include="System.Reflection.TypeExtensions">
+          <HintPath>..\..\packages\System.Reflection.TypeExtensions\ref\net462\System.Reflection.TypeExtensions.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.3' Or $(TargetFrameworkVersion) == 'v1.4')">
       <ItemGroup>
         <Reference Include="System.Reflection.TypeExtensions">
@@ -754,6 +799,15 @@
     </When>
   </Choose>
   <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6.3'">
+      <ItemGroup>
+        <Reference Include="System.Text.RegularExpressions">
+          <HintPath>..\..\packages\System.Text.RegularExpressions\ref\net463\System.Text.RegularExpressions.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v1.2')">
       <ItemGroup>
         <Reference Include="System.Text.RegularExpressions">
@@ -803,7 +857,7 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v1.2')) Or ($(TargetFrameworkIdentifier) == 'WindowsPhone' And $(TargetFrameworkVersion) == 'v8.1')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v1.2')">
       <ItemGroup>
         <Reference Include="System.Threading.Tasks">
           <HintPath>..\..\packages\System.Threading.Tasks\ref\netstandard1.0\System.Threading.Tasks.dll</HintPath>

--- a/tests/FSharp.Data.GraphQL.Tests/Helpers.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/Helpers.fs
@@ -13,6 +13,8 @@ open FSharp.Data.GraphQL.Execution
 
 let equals (expected : 'x) (actual : 'x) = 
     Assert.True((actual = expected), sprintf "expected %+A\nbut got %+A" expected actual)
+let notEquals (expected : 'x) (actual : 'x) = 
+    Assert.True((actual <> expected), sprintf "unexpected %+A" expected)
 let noErrors (result: IDictionary<string, obj>) =
     match result.TryGetValue("errors") with
     | true, errors -> failwithf "expected ExecutionResult to have no errors but got %+A" errors


### PR DESCRIPTION
This PR introduces `documentId` field to result set of executed query and `DocumentId` field to ExecutionPlan itself. It's a unique identifier (computed as hash code of the executed AST document), that can be potentially used to build persistent queries - queries that can be cached and requested by using documentId instead of providing a whole GraphQL query in each request.

This fits perfectly in line with what ExecutionPlan is for, as it can be produced from GraphQL query and i.e. cached using it's DocumentId as a key, to be invoked later with different set of variables.
