### PR TITLE
Int64 support, fixes in reflection

### DIFF
--- a/src/FSharp.Data.GraphQL.Shared/Ast.fs
+++ b/src/FSharp.Data.GraphQL.Shared/Ast.fs
@@ -81,7 +81,7 @@ and FragmentDefinition = {
 /// 2.2.7 Input Values
 and Value = 
     /// 2.2.7.1 Int Value
-    | IntValue of int
+    | IntValue of int64
     /// 2.2.7.2 Float Value
     | FloatValue of double
     /// 2.2.7.3 Boolean Value

--- a/src/FSharp.Data.GraphQL.Shared/Parser.fs
+++ b/src/FSharp.Data.GraphQL.Shared/Parser.fs
@@ -115,7 +115,7 @@ module internal Internal =
 
   // 2.9.1 IntValue 
   //   IntegerPart
-  let integerValue = integerPart |>> int
+  let integerValue = integerPart |>> int64
 
 
   // 2.9.2 FloatValue

--- a/tests/FSharp.Data.GraphQL.Tests/CoercionTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/CoercionTests.fs
@@ -22,15 +22,23 @@ let private testCoercion graphQLType (expected: 't) actual =
 
 [<Fact>]
 let ``Int coerces input`` () = 
-    testCoercion Int 123 (IntValue 123)
+    testCoercion Int 123 (IntValue 123L)
     testCoercion Int 123 (FloatValue 123.4)
     testCoercion Int 123 (StringValue "123")
     testCoercion Int 1 (BooleanValue true)
     testCoercion Int 0 (BooleanValue false)
+
+[<Fact>]
+let ``Long coerces input`` () = 
+    testCoercion Long 123L (IntValue 123L)
+    testCoercion Long 123L (FloatValue 123.4)
+    testCoercion Long 123L (StringValue "123")
+    testCoercion Long 1L (BooleanValue true)
+    testCoercion Long 0L (BooleanValue false)
     
 [<Fact>]
 let ``Float coerces input`` () = 
-    testCoercion Float 123. (IntValue 123)
+    testCoercion Float 123. (IntValue 123L)
     testCoercion Float 123.4 (FloatValue 123.4)
     testCoercion Float 123.4 (StringValue "123.4")
     testCoercion Float 1. (BooleanValue true)
@@ -38,15 +46,15 @@ let ``Float coerces input`` () =
 
 [<Fact>]
 let ``Boolean coerces input`` () = 
-    testCoercion Boolean true (IntValue 123)
-    testCoercion Boolean false (IntValue 0)
+    testCoercion Boolean true (IntValue 123L)
+    testCoercion Boolean false (IntValue 0L)
     testCoercion Boolean true (FloatValue 123.4)
     testCoercion Boolean true (BooleanValue true)
     testCoercion Boolean false (BooleanValue false)
 
 [<Fact>]
 let ``String coerces input`` () = 
-    testCoercion String "123" (IntValue 123)
+    testCoercion String "123" (IntValue 123L)
     testCoercion String "123.4" (FloatValue 123.4)
     testCoercion String "acb123.4" (StringValue "acb123.4")
     testCoercion String "true" (BooleanValue true)

--- a/tests/FSharp.Data.GraphQL.Tests/IntrospectionTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/IntrospectionTests.fs
@@ -52,6 +52,24 @@ let ``Core type definitions are considered nullable`` () =
             "ofType", null]]
     noErrors result
     result.["data"] |> equals (upcast expected)
+
+type User = { FirstName: string; LastName: string }
+type UserInput = { Name: string }
+
+[<Fact>]
+let ``Introspection works with query and mutation sharing same generic param`` =
+    let User = Define.Object<User>("User", [
+        Define.AutoField("firstName", String)
+        Define.AutoField("lastName", String) ])
+    let UserInput = Define.InputObject<UserInput>("UserInput", [
+        Define.Input("name", String) ])
+    let Query = Define.Object<User list>("Query", [
+        Define.Field("users", ListOf User, fun _ u -> u) ])
+    let Mutation = Define.Object<User list>("Mutation", [
+        Define.Field("addUser", User, fun _ u -> u |> List.head)])
+    let schema = Schema(Query, Mutation)
+    let introResult = schema.AsyncExecute(Introspection.introspectionQuery) |> sync
+    ()
     
 [<Fact>]
 let ``Default field type definitions are considered non-null`` () =

--- a/tests/FSharp.Data.GraphQL.Tests/ParserTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/ParserTests.fs
@@ -36,7 +36,7 @@ let queryWithSelections selections =
 let queryWithSelection selection = queryWithSelections [ selection ]
 
 let arg name value = { Argument.Name = name; Value = value }
-let argInt name value = arg name (IntValue value)
+let argInt name value = arg name (IntValue (int64 value))
 let fieldWithNameAndArgsAndSelections name arguments selections =
     Field { Name = name
             Alias = None


### PR DESCRIPTION
- New type def `Long` with support for Int64. Parser has been adjusted to support Int64 in GraphQL query string.
- New type def `Guid` with GUID support.
- Property tracker fix for repetition of the same track across different execution infos.
- Fix for reflection helper to be able to construct inputs from internal/private types.
