### PR TITLE
Fix pack vol. 1

### DIFF
--- a/src/FSharp.Data.GraphQL.Client/AssemblyInfo.fs
+++ b/src/FSharp.Data.GraphQL.Client/AssemblyInfo.fs
@@ -1,41 +1,13 @@
-﻿namespace FSharp.Data.GraphQL.Client.AssemblyInfo
-
+﻿namespace System
 open System.Reflection
-open System.Runtime.CompilerServices
-open System.Runtime.InteropServices
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[<assembly: AssemblyTitle("FSharp.Data.GraphQL.Client")>]
-[<assembly: AssemblyDescription("")>]
-[<assembly: AssemblyConfiguration("")>]
-[<assembly: AssemblyCompany("")>]
-[<assembly: AssemblyProduct("FSharp.Data.GraphQL.Client")>]
-[<assembly: AssemblyCopyright("Copyright ©  2016")>]
-[<assembly: AssemblyTrademark("")>]
-[<assembly: AssemblyCulture("")>]
+[<assembly: AssemblyTitleAttribute("FSharp.Data.GraphQL.Client")>]
+[<assembly: AssemblyProductAttribute("FSharp.Data.GraphQL")>]
+[<assembly: AssemblyDescriptionAttribute("FSharp implementation of Facebook GraphQL query language")>]
+[<assembly: AssemblyVersionAttribute("0.0.2")>]
+[<assembly: AssemblyFileVersionAttribute("0.0.2")>]
+do ()
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[<assembly: ComVisible(false)>]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[<assembly: Guid("7c9cc625-fb4e-4215-9f7c-494aa6043821")>]
-
-// Version information for an assembly consists of the following four values:
-// 
-//       Major Version
-//       Minor Version 
-//       Build Number
-//       Revision
-// 
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [<assembly: AssemblyVersion("1.0.*")>]
-[<assembly: AssemblyVersion("1.0.0.0")>]
-[<assembly: AssemblyFileVersion("1.0.0.0")>]
-
-do
-    ()
+module internal AssemblyVersionInformation =
+    let [<Literal>] Version = "0.0.2"
+    let [<Literal>] InformationalVersion = "0.0.2"

--- a/src/FSharp.Data.GraphQL.Server/AssemblyInfo.fs
+++ b/src/FSharp.Data.GraphQL.Server/AssemblyInfo.fs
@@ -2,15 +2,15 @@
 open System.Reflection
 open System.Runtime.CompilerServices
 
-[<assembly: AssemblyTitleAttribute("FSharp.Data.GraphQL")>]
+[<assembly: AssemblyTitleAttribute("FSharp.Data.GraphQL.Server")>]
 [<assembly: AssemblyProductAttribute("FSharp.Data.GraphQL")>]
 [<assembly: AssemblyDescriptionAttribute("FSharp implementation of Facebook GraphQL query language")>]
-[<assembly: AssemblyVersionAttribute("0.0.1")>]
-[<assembly: AssemblyFileVersionAttribute("0.0.1")>]
-[<assembly: InternalsVisibleTo("FSharp.Data.GraphQL.Tests")>]
-[<assembly: InternalsVisibleTo("FSharp.Data.GraphQL.Benchmarks")>]
+[<assembly: AssemblyVersionAttribute("0.0.2")>]
+[<assembly: AssemblyFileVersionAttribute("0.0.2")>]
+[<assembly: InternalsVisibleToAttribute("FSharp.Data.GraphQL.Benchmarks")>]
+[<assembly: InternalsVisibleToAttribute("FSharp.Data.GraphQL.Tests")>]
 do ()
 
 module internal AssemblyVersionInformation =
-    let [<Literal>] Version = "0.0.1"
-    let [<Literal>] InformationalVersion = "0.0.1"
+    let [<Literal>] Version = "0.0.2"
+    let [<Literal>] InformationalVersion = "0.0.2"

--- a/src/FSharp.Data.GraphQL.Server/Linq.fs
+++ b/src/FSharp.Data.GraphQL.Server/Linq.fs
@@ -399,7 +399,7 @@ let rec private getTracks alreadyFound info =
             |> Seq.map (List.map (getTracks found))
             |> Seq.collect id
             |> Seq.toList
-        IR(info, tracks, children) 
+        IR(info, found, children) 
 
 let rec private assignableChildren (parentType: Type) (childTracks: Set<Tracker>) = 
     let assignable, unassignable =

--- a/src/FSharp.Data.GraphQL.Server/Values.fs
+++ b/src/FSharp.Data.GraphQL.Server/Values.fs
@@ -42,7 +42,11 @@ let rec internal compileByType (errMsg: string) (inputDef: InputDef): ExecuteInp
         let ctor = ReflectionHelper.matchConstructor objtype (objdef.Fields |> Array.map (fun x -> x.Name))
         let mapper =
             ctor.GetParameters()
-            |> Array.map(fun param -> objdef.Fields |> Array.find(fun field -> field.Name = param.Name))
+            |> Array.map(fun param -> 
+                match objdef.Fields |> Array.tryFind(fun field -> field.Name = param.Name) with
+                | Some x -> x
+                | None -> 
+                    failwithf "Input object '%s' refers to type '%O', but constructor parameter '%s' doesn't match any of the defined input fields" objdef.Name objtype param.Name)
 
         fun variables value ->
             match value with

--- a/src/FSharp.Data.GraphQL.Shared/AssemblyInfo.fs
+++ b/src/FSharp.Data.GraphQL.Shared/AssemblyInfo.fs
@@ -5,13 +5,13 @@ open System.Runtime.CompilerServices
 [<assembly: AssemblyTitleAttribute("FSharp.Data.GraphQL.Shared")>]
 [<assembly: AssemblyProductAttribute("FSharp.Data.GraphQL")>]
 [<assembly: AssemblyDescriptionAttribute("FSharp implementation of Facebook GraphQL query language")>]
-[<assembly: AssemblyVersionAttribute("0.0.1")>]
-[<assembly: AssemblyFileVersionAttribute("0.0.1")>]
-[<assembly: InternalsVisibleTo("FSharp.Data.GraphQL.Server")>]
-[<assembly: InternalsVisibleTo("FSharp.Data.GraphQL.Client")>]
-[<assembly: InternalsVisibleTo("FSharp.Data.GraphQL.Tests")>]
+[<assembly: AssemblyVersionAttribute("0.0.2")>]
+[<assembly: AssemblyFileVersionAttribute("0.0.2")>]
+[<assembly: InternalsVisibleToAttribute("FSharp.Data.GraphQL.Server")>]
+[<assembly: InternalsVisibleToAttribute("FSharp.Data.GraphQL.Client")>]
+[<assembly: InternalsVisibleToAttribute("FSharp.Data.GraphQL.Tests")>]
 do ()
 
 module internal AssemblyVersionInformation =
-    let [<Literal>] Version = "0.0.1"
-    let [<Literal>] InformationalVersion = "0.0.1"
+    let [<Literal>] Version = "0.0.2"
+    let [<Literal>] InformationalVersion = "0.0.2"

--- a/src/FSharp.Data.GraphQL.Shared/AssemblyInfo.fs
+++ b/src/FSharp.Data.GraphQL.Shared/AssemblyInfo.fs
@@ -1,11 +1,15 @@
 ﻿namespace System
 open System.Reflection
+open System.Runtime.CompilerServices
 
 [<assembly: AssemblyTitleAttribute("FSharp.Data.GraphQL.Shared")>]
 [<assembly: AssemblyProductAttribute("FSharp.Data.GraphQL")>]
 [<assembly: AssemblyDescriptionAttribute("FSharp implementation of Facebook GraphQL query language")>]
 [<assembly: AssemblyVersionAttribute("0.0.1")>]
 [<assembly: AssemblyFileVersionAttribute("0.0.1")>]
+[<assembly: InternalsVisibleTo("FSharp.Data.GraphQL.Server")>]
+[<assembly: InternalsVisibleTo("FSharp.Data.GraphQL.Client")>]
+[<assembly: InternalsVisibleTo("FSharp.Data.GraphQL.Tests")>]
 do ()
 
 module internal AssemblyVersionInformation =

--- a/src/FSharp.Data.GraphQL.Shared/Ast.fs
+++ b/src/FSharp.Data.GraphQL.Shared/Ast.fs
@@ -180,7 +180,4 @@ and TypeDefinition =
     | EnumTypeDefinition of EnumTypeDefinition
     | InputObjectTypeDefinition of InputObjectTypeDefinition
 
-module Visitor =
-    
-    let visit enter leave ast = failwith "Not implemented"
         

--- a/src/FSharp.Data.GraphQL.Shared/Extensions.fs
+++ b/src/FSharp.Data.GraphQL.Shared/Extensions.fs
@@ -1,7 +1,7 @@
 ﻿/// The MIT License (MIT)
 /// Copyright (c) 2016 Bazinga Technologies Inc
 
-module FSharp.Data.GraphQL.Extensions
+module internal FSharp.Data.GraphQL.Extensions
 
 open System.Reflection
 

--- a/src/FSharp.Data.GraphQL.Shared/Prolog.fs
+++ b/src/FSharp.Data.GraphQL.Shared/Prolog.fs
@@ -10,7 +10,10 @@ open System.Collections.Generic
 type GraphQLException(msg) = 
     inherit Exception(msg)
 
-module Array =
+type MalformedQueryException(msg) =
+    inherit GraphQLException(msg)
+
+module internal Array =
 
     /// <summary>
     /// Returns a new array with unique elements. Uniqueness is determined by
@@ -28,7 +31,7 @@ module Array =
                     i <- i + 1
             Array.sub temp 0 i
 
-module List =
+module internal List =
     
     /// <summary>
     /// Merges elements of two lists, returning a new list without duplicates.
@@ -42,7 +45,7 @@ module List =
             |> List.filter (fun x -> not <| List.exists(fun y -> f(x) = f(y)) listy)
         uniqx @ listy
 
-module Set =
+module internal Set =
 
     /// <summary>
     /// Maps over each of the <paramref name="set"/> elements, applying function
@@ -53,7 +56,7 @@ module Set =
     /// <param name="set">Input set.</param>
     let collect f set = set |> Set.fold (fun acc e -> acc + f e) Set.empty
     
-module Map =
+module internal Map =
 
     /// <summary>
     /// Merges the entries of two maps by their key, returning new map in result.
@@ -71,7 +74,7 @@ module Map =
             | Some vx -> Map.add ky (mergeFn ky vx vy) acc
             | None -> Map.add ky vy acc) mapx
 
-module ReflectionHelper =
+module internal ReflectionHelper =
     
     /// <summary>
     /// Returns pair of function constructors for `cons(head,tail)` and `nil` 

--- a/src/FSharp.Data.GraphQL.Shared/Validation.fs
+++ b/src/FSharp.Data.GraphQL.Shared/Validation.fs
@@ -1,7 +1,7 @@
 ﻿/// The MIT License (MIT)
 /// Copyright (c) 2016 Bazinga Technologies Inc
 
-module FSharp.Data.GraphQL.Validation
+module internal FSharp.Data.GraphQL.Validation
 
 open FSharp.Data.GraphQL.Types
 open FSharp.Data.GraphQL.Types.Patterns

--- a/tests/FSharp.Data.GraphQL.Tests/CoercionTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/CoercionTests.fs
@@ -27,15 +27,7 @@ let ``Int coerces input`` () =
     testCoercion Int 123 (StringValue "123")
     testCoercion Int 1 (BooleanValue true)
     testCoercion Int 0 (BooleanValue false)
-
-[<Fact>]
-let ``Long coerces input`` () = 
-    testCoercion Long 123L (IntValue 123L)
-    testCoercion Long 123L (FloatValue 123.4)
-    testCoercion Long 123L (StringValue "123")
-    testCoercion Long 1L (BooleanValue true)
-    testCoercion Long 0L (BooleanValue false)
-    
+        
 [<Fact>]
 let ``Float coerces input`` () = 
     testCoercion Float 123. (IntValue 123L)


### PR DESCRIPTION
- When compiling a schema, if there is an InputObject over type T and it doesn't cover that type constructor params, there will be a more human-readable error message explaining why schema compilation failed.
- Added `SchemaConfig.ParseErrors` hook, it will allow to apply custom logic for errors thrown during execution GraphQL query. Example use cases: 
  1. Error logging.
  2. Converting backend error messages into more human friendly ones to be returned to frontend.
  3. Attaching stack traces returned to the browser (for debugging).
- Modified a way of working with variables. Now variables defined by query will be type validated when execution plan will be created (in case of schema conflicts a `MalformedQueryException` will be thrown). Also variables with schema types will be included in execution plan.
