### PR TITLE
Add type safety to Executor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ samples/client-provider/js/*.*
 *.suo
 *.user
 *.sln.docstates
+.vscode
 
 # Xamarin Studio / monodevelop user-specific
 *.userprefs

--- a/docs/content/linq.md
+++ b/docs/content/linq.md
@@ -76,7 +76,7 @@ What it also does is free interpretation of field parameters into their LINQ "eq
 
 - `skip`, `take`, `orderBy` and `orderByDesc` will be translated into corresponding LINQ equivalent methods.
 - `id` will be translated into `.Where(x => x.Id == <id>)`. This requires returned type to provide an Id member used as entity identifier.
-- `first`/`after` and `last`/`before` combinations known to the [RelayJS](https://facebook.github.io/relay/) users will be translated into `.OrderBy(x => x.Id).Where(x => x.Id > <after>).Take(<first>)` and `.OrderByDescending(x => x.Id).Wherex(x => x.Id < <before>).Take(<last>)` equivalents. This also requires from queried elements to provide Id member used as entity identifier.
+- `first`/`after` and `last`/`before` combinations known to the [RelayJS](https://facebook.github.io/relay/) users will be translated into `.OrderBy(x => x.Id).Where(x => x.Id > <after>).Take(<first>)` and `.OrderByDescending(x => x.Id).Where(x => x.Id < <before>).Take(<last>)` equivalents. This also requires from queried elements to provide Id member used as entity identifier.
 
 This list can be extended and overriden by custom user implementation.
 

--- a/samples/graphiql-client/graphiql-client.fsproj
+++ b/samples/graphiql-client/graphiql-client.fsproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <PackageTargetFallback>$(PackageTargetFallback);portable-net45+win8+wp8+wpa81;</PackageTargetFallback>
+    <DefineConstants>$(DefineConstants);NETSTANDARD1_6</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="server.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FSharp.Core" Version="4.1.*" />
+    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
+    <PackageReference Include="Suave" Version="2.1.0" />
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.*" />
+
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\netcore\FSharp.Data.GraphQL.Shared\FSharp.Data.GraphQL.Shared.fsproj" />
+    <ProjectReference Include="..\..\src\netcore\FSharp.Data.GraphQL.Server\FSharp.Data.GraphQL.Server.fsproj" />
+  </ItemGroup>
+</Project>

--- a/src/FSharp.Data.GraphQL.Server/Executor.fs
+++ b/src/FSharp.Data.GraphQL.Server/Executor.fs
@@ -8,7 +8,7 @@ open FSharp.Data.GraphQL.Parser
 open FSharp.Data.GraphQL.Types.Patterns
 open FSharp.Data.GraphQL.Planning
 
-type Executor (schema: ISchema) = 
+type Executor<'Root> (schema: ISchema<'Root>) = 
     let fieldExecuteMap = FieldExecuteMap()
 
     //FIXME: for some reason static do or do invocation in module doesn't work
@@ -115,6 +115,10 @@ type Executor (schema: ISchema) =
                     match schema.Mutation with
                     | Some m -> m
                     | None -> raise (GraphQLException "Operation to be executed is of type mutation, but no mutation root object was defined in current schema")
+                | Subscription ->
+                    match schema.Subscription with
+                    | Some s -> s
+                    | None -> raise (GraphQLException "Operations to be executed is of type subscription, but no subscription root object was defined in the current schema") 
             let planningCtx = { Schema = schema; RootDef = rootDef; Document = ast }
             planOperation (ast.GetHashCode()) planningCtx operation
         | None -> raise (GraphQLException "No operation with specified name has been found for provided document")

--- a/src/FSharp.Data.GraphQL.Server/Planning.fs
+++ b/src/FSharp.Data.GraphQL.Server/Planning.fs
@@ -276,3 +276,14 @@ let internal planOperation documentId (ctx: PlanningContext) (operation: Operati
               Variables = variables }
         | None -> 
             raise (GraphQLException "Tried to execute a GraphQL mutation on schema with no mutation type defined")
+    | Subscription ->
+        match ctx.Schema.Subscription with
+        | Some subscriptionDef ->
+            { DocumentId = documentId
+              Operation = operation
+              Fields = topFields
+              RootDef = subscriptionDef
+              Strategy = Sequential 
+              Variables = variables }
+        | None -> 
+            raise (GraphQLException "Tried to execute a GraphQL subscription on schema with no mutation type defined")

--- a/src/FSharp.Data.GraphQL.Shared/Ast.fs
+++ b/src/FSharp.Data.GraphQL.Shared/Ast.fs
@@ -30,6 +30,7 @@ and OperationDefinition = {
 and OperationType = 
     | Query
     | Mutation
+    | Subscription
 
 /// 2.2.2 Selection Sets
 and Selection = 

--- a/src/FSharp.Data.GraphQL.Shared/Parser.fs
+++ b/src/FSharp.Data.GraphQL.Shared/Parser.fs
@@ -266,7 +266,7 @@ module internal Internal =
     let operationType = 
       // leaving out subscriptions for now.
       // (stoken_ws "subscription" >>% Subscription) 
-      (stoken_ws "query" >>% Query) <|> (stoken_ws "mutation" >>% Mutation) 
+      (stoken_ws "query" >>% Query) <|> (stoken_ws "mutation" >>% Mutation) <|> (stoken_ws "subscription" >>% Subscription)
       
     let namedOperationDefinition = 
       let variableDefinition =

--- a/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
+++ b/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
@@ -290,8 +290,12 @@ type ISchema =
         abstract Query : ObjectDef
 
         /// A mutation root object. Defines all top level operations,
-        /// that can be performend from GraphQL mutations.
+        /// that can be performed from GraphQL mutations.
         abstract Mutation : ObjectDef option
+
+        // A subscription root object. Defines all top level operations,
+        // that can be performed from GraphQL subscriptions. 
+        abstract Subscription : ObjectDef option
 
         /// List of all directives supported by the current schema.
         abstract Directives : DirectiveDef []
@@ -315,6 +319,14 @@ type ISchema =
         abstract Introspected : Introspection.IntrospectionSchema
 
         abstract ParseErrors : exn[] -> string[]
+    end
+
+and ISchema<'Root> = 
+    interface
+        inherit ISchema
+        abstract Query : ObjectDef<'Root>
+        abstract Mutation : ObjectDef<'Root> option
+        abstract Subscription : ObjectDef<'Root> option
     end
 
 and FieldExecuteMap () = 

--- a/src/netcore/FSharp.Data.GraphQL.Server/FSharp.Data.GraphQL.Server.fsproj
+++ b/src/netcore/FSharp.Data.GraphQL.Server/FSharp.Data.GraphQL.Server.fsproj
@@ -13,6 +13,7 @@
     <Compile Include="../../FSharp.Data.GraphQL.Server/Values.fs" />
     <Compile Include="../../FSharp.Data.GraphQL.Server/Planning.fs" />
     <Compile Include="../../FSharp.Data.GraphQL.Server/Execution.fs" />
+    <Compile Include="../../FSharp.Data.GraphQL.Server/Executor.fs" />
     <Compile Include="../../FSharp.Data.GraphQL.Server/Schema.fs" />
     <Compile Include="../../FSharp.Data.GraphQL.Server/Linq.fs" />
     <Compile Include="../../FSharp.Data.GraphQL.Server/Relay/Node.fs" />

--- a/tests/FSharp.Data.GraphQL.Benchmarks/ExecutionBenchmark.fs
+++ b/tests/FSharp.Data.GraphQL.Benchmarks/ExecutionBenchmark.fs
@@ -94,7 +94,7 @@ type SimpleExecutionBenchmark() =
     }"""
 
     let mutable schema : Schema<unit> = Unchecked.defaultof<Schema<unit>>
-    let mutable schemaProcessor : Executor = Unchecked.defaultof<Executor>
+    let mutable schemaProcessor : Executor<unit> = Unchecked.defaultof<Executor<unit>>
     let mutable simpleAst : Ast.Document = Unchecked.defaultof<Ast.Document>
     let mutable flatAst : Ast.Document = Unchecked.defaultof<Ast.Document>
     let mutable nestedAst : Ast.Document = Unchecked.defaultof<Ast.Document>

--- a/tests/netcore/FSharp.Data.GraphQL.Tests/FSharp.Data.GraphQL.Tests.fsproj
+++ b/tests/netcore/FSharp.Data.GraphQL.Tests/FSharp.Data.GraphQL.Tests.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
    <OutputType>Exe</OutputType>
-   <TargetFramework>netcoreapp1.0</TargetFramework>
+   <TargetFramework>netcoreapp1.1</TargetFramework>
    <PackageTargetFallback>$(PackageTargetFallback);portable-net45+win8+wp8+wpa81;</PackageTargetFallback>
    <DefineConstants>$(DefineConstants);NETSTANDARD1_6</DefineConstants>
   </PropertyGroup>
@@ -18,8 +18,8 @@
     <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />
     <PackageReference Include="FSharp.Core" Version="4.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170123-02" />
-    <PackageReference Include="xunit" Version="2.2.0-beta5-build3474" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-beta5-build1225" />
+    <PackageReference Include="xunit" Version="2.3.0-beta1-build3642" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta1-build3642" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.*" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.*" />
     <ProjectReference Include="../../../src/netcore/FSharp.Data.GraphQL.Shared/FSharp.Data.GraphQL.Shared.fsproj" />


### PR DESCRIPTION
In FSharp.Data.GraphQL.Executor, all of the AsyncExecute functions took in an optional parameter data of type 'Root, but 'Root was never constrained and any type could be passed in. This PR changes the schema definition to be of type ISchema<'Root>, making the root parameter type safe.

There are also a few additions making matches on operation types complete, and improvements to the GraphiQL sample (variable support)