### PR TITLE
Relay Modern's relay-compiler requires the connection to be optional.

### DIFF
--- a/src/FSharp.Data.GraphQL.Server/Relay/Connections.fs
+++ b/src/FSharp.Data.GraphQL.Server/Relay/Connections.fs
@@ -127,6 +127,7 @@ module Definitions =
                 Define.Field("totalCount", Nullable Int, """A count of the total number of objects in this connection, ignoring pagination. This allows a client to fetch the first five objects by passing \"5\" as the argument to `first`, then fetch the total count so it could display \"5 of 83\", for example. In cases where we employ infinite scrolling or don't have an exact count of entries, this field will return `null`.""", fun _ conn -> conn.TotalCount)
                 Define.Field("pageInfo", PageInfo, "Information to aid in pagination.", fun _ conn -> conn.PageInfo)
                 Define.Field("edges", ListOf(EdgeOf nodeType), "Information to aid in pagination.", fun _ conn -> conn.Edges)])
+        |> Nullable
 
 [<RequireQualifiedAccess>]
 module Connection =
@@ -161,4 +162,5 @@ module Connection =
               StartCursor = first
               EndCursor = last }
           Edges = edges }
+        |> Some
     

--- a/tests/FSharp.Data.GraphQL.Tests/PropertyTrackerTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/PropertyTrackerTests.fs
@@ -57,6 +57,7 @@ let rec Person = Define.Object<Person>(
                   StartCursor = data |> List.tryHead |> Option.map (fun edge -> edge.Cursor)
                   EndCursor = data |> List.tryLast |> Option.map (fun edge -> edge.Cursor) }
               Edges = data }
+            |> Some
         ) ])
 and Droid = Define.Object<Droid>(
     name = "Droid",

--- a/tests/FSharp.Data.GraphQL.Tests/Relay/ConnectionTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/Relay/ConnectionTests.fs
@@ -37,8 +37,9 @@ let inline toConnection cursor slice all =
           StartCursor = Some (cursor all.Head)
           EndCursor = Some (all |> List.last |> cursor) }
       TotalCount = Some (all.Length) }
+    |> Some
 
-let resolveSlice (cursor: 't -> string) (values: 't list) (SliceInfo slice) () : Connection<'t> =
+let resolveSlice (cursor: 't -> string) (values: 't list) (SliceInfo slice) () : Connection<'t> option =
     match slice with
     | Forward(first, after) -> 
         let idx = 


### PR DESCRIPTION
Relay Modern introduces a relay-compiler which yields an error if fields having a Connection type are not nullable. The nullable property will now be enforced by `ConnectionOf`.