### PR TITLE
Fix handling of enum arguments

### DIFF
--- a/src/FSharp.Data.GraphQL.Server/ReflectionHelper.fs
+++ b/src/FSharp.Data.GraphQL.Server/ReflectionHelper.fs
@@ -5,6 +5,7 @@ namespace FSharp.Data.GraphQL
 
 open System
 open System.Reflection
+open FSharp.Reflection
 open System.Collections
 open System.Collections.Generic
 open System.Linq
@@ -162,3 +163,17 @@ module internal ReflectionHelper =
                 // at last, default constructor should be used if defined
                 |> Array.find (fun (_, paramNames) -> Set.isSubset (Set.ofArray paramNames) fieldNames)    
             ctor
+            
+    let parseUnion (t: Type) (u: string) =
+    #if NETSTANDARD1_6        
+        if t.GetTypeInfo().IsEnum then Enum.Parse(t, u, ignoreCase = true)
+    #else
+        if t.IsEnum then Enum.Parse(t, u, ignoreCase = true)
+    #endif
+        else
+            try
+                match FSharpType.GetUnionCases(t, bindingFlags = (BindingFlags.NonPublic ||| BindingFlags.Public))|> Array.filter(fun case -> case.Name.ToLower() = u.ToLower()) with
+                | [|case|] -> FSharpValue.MakeUnion(case, [||])
+                | _ -> null
+            with _ -> null
+

--- a/src/FSharp.Data.GraphQL.Server/ReflectionHelper.fs
+++ b/src/FSharp.Data.GraphQL.Server/ReflectionHelper.fs
@@ -167,13 +167,19 @@ module internal ReflectionHelper =
     let parseUnion (t: Type) (u: string) =
     #if NETSTANDARD1_6        
         if t.GetTypeInfo().IsEnum then Enum.Parse(t, u, ignoreCase = true)
-    #else
-        if t.IsEnum then Enum.Parse(t, u, ignoreCase = true)
-    #endif
         else
             try
-                match FSharpType.GetUnionCases(t, bindingFlags = (BindingFlags.NonPublic ||| BindingFlags.Public))|> Array.filter(fun case -> case.Name.ToLower() = u.ToLower()) with
-                | [|case|] -> FSharpValue.MakeUnion(case, [||])
+                match FSharpType.GetUnionCases(t, true)|> Array.filter(fun case -> case.Name.ToLower() = u.ToLower()) with
+                | [|case|] -> FSharpValue.MakeUnion(case, [||], true)
                 | _ -> null
             with _ -> null
+    #else
+        if t.IsEnum then Enum.Parse(t, u, ignoreCase = true)
+        else
+            try
+                match FSharpType.GetUnionCases(t, (BindingFlags.NonPublic ||| BindingFlags.Public))|> Array.filter(fun case -> case.Name.ToLower() = u.ToLower()) with
+                | [|case|] -> FSharpValue.MakeUnion(case, [||], (BindingFlags.NonPublic ||| BindingFlags.Public))
+                | _ -> null
+            with _ -> null
+    #endif
 

--- a/src/FSharp.Data.GraphQL.Server/Values.fs
+++ b/src/FSharp.Data.GraphQL.Server/Values.fs
@@ -95,10 +95,10 @@ let rec internal compileByType (errMsg: string) (inputDef: InputDef): ExecuteInp
             match value with
             | Variable variableName -> variables.[variableName]
             | _ ->
-                let coerced = coerceStringInput value
+                let coerced = coerceEnumInput value
                 match coerced with
                 | None -> null
-                | Some s -> Enum.Parse(enumdef.Type, s, ignoreCase = true)
+                | Some s -> ReflectionHelper.parseUnion enumdef.Type s
     | _ -> failwithf "Unexpected value of inputDef: %O" inputDef
                 
 let rec private coerceVariableValue isNullable typedef (vardef: VarDef) (input: obj) (errMsg: string) : obj = 

--- a/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
+++ b/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
@@ -1938,6 +1938,11 @@ module SchemaDefinitions =
                  else "false")
         | _ -> None
     
+    let coerceEnumInput = 
+        function
+        | EnumValue e -> Some e
+        | _ -> None
+    
     /// Tries to resolve AST query input to bool.
     let coerceBoolInput = 
         function 


### PR DESCRIPTION
As of now, enum arguments are silently discarded. This fixes this bug, and adds tests to ensure that no regressions occur in the future.