### PR TITLE
[WIP] Creating support for @stream directives

### DIFF
--- a/src/FSharp.Data.GraphQL.Server/Execution.fs
+++ b/src/FSharp.Data.GraphQL.Server/Execution.fs
@@ -535,42 +535,6 @@ let private executeQueryOrMutation (resultSet: (string * ExecutionInfo) []) (ctx
                 | _ ,_ -> raise <| GraphQLException("Path terminated unexpectedly!")
             return res
         }
-    // let deferredResults =
-    //     if ctx.ExecutionPlan.DeferredFields.Length = 0
-    //     then None
-    //     else
-    //         resultTrees
-    //         |> Array.map(AsyncVal.bind(fun tree ->
-    //             ctx.ExecutionPlan.DeferredFields
-    //             |> List.filter (fun d -> (List.head d.Path) = tree.Name)
-    //             |> List.toArray
-    //             |> Array.map(fun d ->
-    //                 let fdef = d.Info.Definition
-    //                 let args = getArgumentValues fdef.Args d.Info.Ast.Arguments ctx.Variables
-    //                 let fieldCtx = { 
-    //                     ExecutionInfo = d.Info
-    //                     Context = ctx
-    //                     ReturnType = fdef.TypeDef
-    //                     ParentType = objdef
-    //                     Schema = ctx.Schema
-    //                     Args = args
-    //                     Variables = ctx.Variables
-    //                 }
-    //                 traversePath d fieldCtx d.Path (AsyncVal.wrap tree) [(List.head d.Path)]
-    //                 |> AsyncVal.bind(Array.map(fun (tree, path) ->
-    //                     asyncVal {
-    //                         // TODO: what to do with deferred errors?
-    //                         let d, _ = treeToDict tree
-    //                         return NameValueLookup.ofList["data", d.Value; "path", upcast path]
-    //                     }) >> AsyncVal.collectParallel))
-    //             |> AsyncVal.collectParallel
-    //             |> AsyncVal.map (Array.fold Array.append Array.empty)))
-    //         |> AsyncVal.collectParallel
-    //         |> AsyncVal.map (Array.fold Array.append Array.empty)
-    //         |> AsyncVal.toAsync
-    //         |> Observable.ofAsync
-    //         |> Observable.bind Observable.ofSeq
-    //         |> Some
     let deferredResults =
         if ctx.ExecutionPlan.DeferredFields.Length = 0
         then None

--- a/src/FSharp.Data.GraphQL.Server/Execution.fs
+++ b/src/FSharp.Data.GraphQL.Server/Execution.fs
@@ -516,11 +516,8 @@ let private executeQueryOrMutation (resultSet: (string * ExecutionInfo) []) (ctx
                         let! res = buildResolverTree d.Info.ReturnDef fieldCtx fieldExecuteMap t.Value
                         return! async { return [|res, List.rev(p::pathAcc)|] }
                     }
-                | [p;"__index";_;"__index"], t ->
-                    asyncVal { 
-                        let! res = buildResolverTree d.Info.ReturnDef fieldCtx fieldExecuteMap t.Value
-                        return! async { return [|res, List.rev(p::pathAcc)|] }
-                    }
+                | [_;"__index";_;"__index"], _ ->
+                    raise <| GraphQLException("Nested defer directives are not supported yet.")
                 | p, ResolverObjectNode n ->
                     asyncVal {
                         let next = n.Children |> Array.tryFind(fun c' -> c'.Name = (List.head p))

--- a/src/FSharp.Data.GraphQL.Server/Execution.fs
+++ b/src/FSharp.Data.GraphQL.Server/Execution.fs
@@ -506,12 +506,7 @@ let private executeQueryOrMutation (resultSet: (string * ExecutionInfo) []) (ctx
                         | SelectFields [f] -> return! async { return [|res, List.rev (f.Identifier :: pathAcc)|] }
                         | _ -> return! async { return [|res, List.rev ((List.head path)::pathAcc)|] }
                     }
-                | [p], t -> 
-                    asyncVal { 
-                        let! res = buildResolverTree d.Info.ReturnDef fieldCtx fieldExecuteMap t.Value
-                        return! async { return [|res, List.rev(p::pathAcc)|] }
-                    }
-                | [p;"__index"], t ->
+                | ([p;"__index"] | [p]), t ->
                     asyncVal { 
                         let! res = buildResolverTree d.Info.ReturnDef fieldCtx fieldExecuteMap t.Value
                         return! async { return [|res, List.rev(p::pathAcc)|] }

--- a/src/FSharp.Data.GraphQL.Server/Execution.fs
+++ b/src/FSharp.Data.GraphQL.Server/Execution.fs
@@ -500,21 +500,36 @@ let private executeQueryOrMutation (resultSet: (string * ExecutionInfo) []) (ctx
             let! res = 
                 match List.tail path, tree' with
                 | [], t -> 
+                    // printfn "%A\n\n%A\n\n%A" d fieldCtx t
+                    // printfn "Done"
                     asyncVal { 
                         let! res = buildResolverTree d.Info.ReturnDef fieldCtx fieldExecuteMap t.Value
                         return! async { return [|res, List.rev ((List.head path)::pathAcc)|] }
                     }
                 | [p], t -> 
+                    // printfn "%A\n\n%A\n\n%A" d fieldCtx t
+                    // printfn "Done"
                     asyncVal { 
                         let! res = buildResolverTree d.Info.ReturnDef fieldCtx fieldExecuteMap t.Value
                         return! async { return [|res, List.rev(p::pathAcc)|] }
                     }
-                | [p;"__index"], t -> 
+                | [p;"__index"], t ->
+                    // printfn "%A\n\n%A\n\n%A" d fieldCtx t
+                    // printfn "Done"
                     asyncVal { 
                         let! res = buildResolverTree d.Info.ReturnDef fieldCtx fieldExecuteMap t.Value
                         return! async { return [|res, List.rev(p::pathAcc)|] }
                     }
-                | p, ResolverObjectNode n -> 
+                | [p;"__index";_;"__index"], t ->
+                    // printfn "%A\n\n%A\n\n%A" d fieldCtx t
+                    // printfn "Done"
+                    asyncVal { 
+                        let! res = buildResolverTree d.Info.ReturnDef fieldCtx fieldExecuteMap t.Value
+                        return! async { return [|res, List.rev(p::pathAcc)|] }
+                    }
+                | p, ResolverObjectNode n ->
+                    // printfn "%A\n\n%A\n\n%A" d fieldCtx n
+                    // printfn "Done"
                     asyncVal {
                         let next = n.Children |> Array.tryFind(fun c' -> c'.Name = (List.head p))
                         let! res =
@@ -524,6 +539,8 @@ let private executeQueryOrMutation (resultSet: (string * ExecutionInfo) []) (ctx
                         return res
                     }
                 | p, ResolverListNode l ->
+                    // printfn "%A\n\n%A\n\n%A" d fieldCtx l
+                    // printfn "Done"
                     asyncVal {
                         let! res =
                             l.Children

--- a/src/FSharp.Data.GraphQL.Server/Execution.fs
+++ b/src/FSharp.Data.GraphQL.Server/Execution.fs
@@ -500,36 +500,36 @@ let private executeQueryOrMutation (resultSet: (string * ExecutionInfo) []) (ctx
             let! res = 
                 match List.tail path, tree' with
                 | [], t -> 
-                    // printfn "%A\n\n%A\n\n%A" d fieldCtx t
-                    // printfn "Done"
+                    printfn "%A\n\n%A\n\n%A" d fieldCtx t
+                    printfn "Done"
                     asyncVal { 
                         let! res = buildResolverTree d.Info.ReturnDef fieldCtx fieldExecuteMap t.Value
                         return! async { return [|res, List.rev ((List.head path)::pathAcc)|] }
                     }
                 | [p], t -> 
-                    // printfn "%A\n\n%A\n\n%A" d fieldCtx t
-                    // printfn "Done"
+                    printfn "%A\n\n%A\n\n%A" d fieldCtx t
+                    printfn "Done"
                     asyncVal { 
                         let! res = buildResolverTree d.Info.ReturnDef fieldCtx fieldExecuteMap t.Value
                         return! async { return [|res, List.rev(p::pathAcc)|] }
                     }
                 | [p;"__index"], t ->
-                    // printfn "%A\n\n%A\n\n%A" d fieldCtx t
-                    // printfn "Done"
+                    printfn "%A\n\n%A\n\n%A" d fieldCtx t
+                    printfn "Done"
                     asyncVal { 
                         let! res = buildResolverTree d.Info.ReturnDef fieldCtx fieldExecuteMap t.Value
                         return! async { return [|res, List.rev(p::pathAcc)|] }
                     }
                 | [p;"__index";_;"__index"], t ->
-                    // printfn "%A\n\n%A\n\n%A" d fieldCtx t
-                    // printfn "Done"
+                    printfn "%A\n\n%A\n\n%A" d fieldCtx t
+                    printfn "Done"
                     asyncVal { 
                         let! res = buildResolverTree d.Info.ReturnDef fieldCtx fieldExecuteMap t.Value
                         return! async { return [|res, List.rev(p::pathAcc)|] }
                     }
                 | p, ResolverObjectNode n ->
-                    // printfn "%A\n\n%A\n\n%A" d fieldCtx n
-                    // printfn "Done"
+                    printfn "%A\n\n%A\n\n%A" d fieldCtx n
+                    printfn "Done"
                     asyncVal {
                         let next = n.Children |> Array.tryFind(fun c' -> c'.Name = (List.head p))
                         let! res =
@@ -539,8 +539,8 @@ let private executeQueryOrMutation (resultSet: (string * ExecutionInfo) []) (ctx
                         return res
                     }
                 | p, ResolverListNode l ->
-                    // printfn "%A\n\n%A\n\n%A" d fieldCtx l
-                    // printfn "Done"
+                    printfn "%A\n\n%A\n\n%A" d fieldCtx l
+                    printfn "Done"
                     asyncVal {
                         let! res =
                             l.Children

--- a/src/FSharp.Data.GraphQL.Server/Executor.fs
+++ b/src/FSharp.Data.GraphQL.Server/Executor.fs
@@ -45,9 +45,9 @@ type Executor<'Root> (schema: ISchema<'Root>) =
                 | [] -> NameValueLookup.ofList [ "documentId", box executionPlan.DocumentId ; "data", upcast data ] :> Output
                 | errors -> NameValueLookup.ofList [ "documentId", box executionPlan.DocumentId ; "data", upcast data ; "errors", upcast errors ] :> Output
             match res with
-            | Direct(data, errors) -> Direct(prepareData data errors, errors)
-            | Deferred(data, errors, deferred) -> Deferred(prepareData data errors, errors, deferred)
-            | Stream(stream) -> Stream(stream)
+            | Direct (data, errors) -> Direct (prepareData data errors, errors)
+            | Deferred (data, errors, deferred) -> Deferred (prepareData data errors, errors, deferred)
+            | Stream (stream) -> Stream(stream)
         async {
             try
                 let errors = System.Collections.Concurrent.ConcurrentBag<exn>()

--- a/src/FSharp.Data.GraphQL.Server/Planning.fs
+++ b/src/FSharp.Data.GraphQL.Server/Planning.fs
@@ -206,7 +206,8 @@ let rec private plan (ctx : PlanningContext) (stage : PlanningStage) : PlanningS
         // We dont yet know the indicies of our elements so we append a dummy value on
         let inner, deferredFields', path' = plan ctx ({ info with ParentDef = info.ReturnDef; ReturnDef = downcast returnDef; Identifier = "__index" }, deferredFields, "__index"::info.Identifier::path)
         { info with Kind = ResolveCollection inner }, deferredFields', path'
-    | Abstract _ -> planAbstraction ctx info.Ast.SelectionSet (info, deferredFields, path) (ref []) None 
+    | Abstract _ -> 
+        planAbstraction ctx info.Ast.SelectionSet (info, deferredFields, path) (ref []) None 
     | _ -> failwith "Invalid Return Type in Planning!"
 
 and private planSelection (ctx: PlanningContext) (selectionSet: Selection list) (stage: PlanningStage) visitedFragments : PlanningStage = 

--- a/src/FSharp.Data.GraphQL.Server/Planning.fs
+++ b/src/FSharp.Data.GraphQL.Server/Planning.fs
@@ -153,7 +153,7 @@ let private isDeferredField (field: Field) : bool =
 let private isStreamedField (field : Field) : bool =
     field.Directives |> List.exists (fun d -> d.Name = "stream")
                 
-type PlanningStage = ExecutionInfo * DeferredExecutionInfo list * StreamedExecutionInfo list * string list
+type PlanningStage = ExecutionInfo * DeferredExecutionInfo list * DeferredExecutionInfo list * string list
 
 let private getSelectionFrag = function
     | SelectFields(fragmentFields) -> fragmentFields
@@ -207,7 +207,7 @@ and private planSelection (ctx: PlanningContext) (selectionSet: Selection list) 
     let parentDef = downcast info.ReturnDef
     let plannedFields, deferredFields', streamedFields' =
         selectionSet
-        |> List.fold(fun (fields : ExecutionInfo list, deferredFields : DeferredExecutionInfo list, streamedFields : StreamedExecutionInfo list) selection ->
+        |> List.fold(fun (fields : ExecutionInfo list, deferredFields : DeferredExecutionInfo list, streamedFields : DeferredExecutionInfo list) selection ->
             //FIXME: includer is not passed along from top level fragments (both inline and spreads)
             let includer = getIncluder selection.Directives info.Include
             let updatedInfo = { info with Include = includer }
@@ -254,7 +254,7 @@ and private planAbstraction (ctx:PlanningContext) (selectionSet: Selection list)
     let info, deferredFields, streamedFields, path = stage
     let plannedTypeFields, deferredFields', streamedFields' =
         selectionSet
-        |> List.fold(fun (fields : Map<string, ExecutionInfo list>, deferredFields : DeferredExecutionInfo list, streamedFields : StreamedExecutionInfo list) selection ->
+        |> List.fold(fun (fields : Map<string, ExecutionInfo list>, deferredFields : DeferredExecutionInfo list, streamedFields : DeferredExecutionInfo list) selection ->
             let includer = getIncluder selection.Directives info.Include
             let innerData = { info with Include = includer }
             match selection with

--- a/src/FSharp.Data.GraphQL.Server/Planning.fs
+++ b/src/FSharp.Data.GraphQL.Server/Planning.fs
@@ -191,7 +191,6 @@ let rec private deepMerge (xs: ExecutionInfo list) (ys: ExecutionInfo list) =
          ys
          |> List.filter(fun y -> not <| List.exists(fun x -> x.Identifier = y.Identifier) xs')
      xs' @ ys'
- 
 
 let rec private plan (ctx : PlanningContext) (stage : PlanningStage) : PlanningStage =
     let info, deferredFields, path = stage

--- a/src/FSharp.Data.GraphQL.Server/Planning.fs
+++ b/src/FSharp.Data.GraphQL.Server/Planning.fs
@@ -147,10 +147,13 @@ let private doesFragmentTypeApply (schema: ISchema) fragment (objectType: Object
         | Some (Abstract conditionalType) -> schema.IsPossibleType conditionalType objectType
         | _ -> false
 
-let private isDeferredField (field: Field): bool =
+let private isDeferredField (field: Field) : bool =
     field.Directives |> List.exists(fun d -> d.Name = "defer")
+
+let private isStreamedField (field : Field) : bool =
+    field.Directives |> List.exists (fun d -> d.Name = "stream")
                 
-type PlanningStage = ExecutionInfo * DeferredExecutionInfo list * string list
+type PlanningStage = ExecutionInfo * DeferredExecutionInfo list * StreamedExecutionInfo list * string list
 
 let private getSelectionFrag = function
     | SelectFields(fragmentFields) -> fragmentFields
@@ -183,28 +186,28 @@ let rec private deepMerge (xs: ExecutionInfo list) (ys: ExecutionInfo list) =
      xs' @ ys'
  
 
-let rec private plan (ctx: PlanningContext) (stage:PlanningStage): PlanningStage =
-    let info, deferredFields, path = stage
+let rec private plan (ctx : PlanningContext) (stage : PlanningStage) : PlanningStage =
+    let info, deferredFields, streamedFields, path = stage
     match info.ReturnDef with
-    | Leaf _ -> info, deferredFields, info.Identifier::path
-    | SubscriptionObject _ -> planSelection ctx info.Ast.SelectionSet (info, deferredFields, info.Identifier::path) (ref [])
-    | Object _ -> planSelection ctx info.Ast.SelectionSet (info, deferredFields, info.Identifier::path) (ref [])
+    | Leaf _ -> info, deferredFields, streamedFields, info.Identifier::path
+    | SubscriptionObject _ -> planSelection ctx info.Ast.SelectionSet (info, deferredFields, streamedFields, info.Identifier::path) (ref [])
+    | Object _ -> planSelection ctx info.Ast.SelectionSet (info, deferredFields, streamedFields, info.Identifier::path) (ref [])
     | Nullable returnDef -> 
-        let inner, deferredFields', path' = plan ctx ({ info with ParentDef = info.ReturnDef; ReturnDef = downcast returnDef }, deferredFields, path)
-        { inner with IsNullable = true}, deferredFields', path'
+        let inner, deferredFields', streamedFields', path' = plan ctx ({ info with ParentDef = info.ReturnDef; ReturnDef = downcast returnDef }, deferredFields, streamedFields, path)
+        { inner with IsNullable = true}, deferredFields', streamedFields', path'
     | List returnDef -> 
         // We dont yet know the indicies of our elements so we append a dummy value on
-        let inner, deferredFields', path' = plan ctx ({ info with ParentDef = info.ReturnDef; ReturnDef = downcast returnDef; Identifier = "__index" }, deferredFields, "__index"::info.Identifier::path)
-        { info with Kind = ResolveCollection inner }, deferredFields', path'
-    | Abstract _ -> planAbstraction ctx info.Ast.SelectionSet (info, deferredFields, path) (ref []) None 
+        let inner, deferredFields', streamedFields', path' = plan ctx ({ info with ParentDef = info.ReturnDef; ReturnDef = downcast returnDef; Identifier = "__index" }, deferredFields, streamedFields, "__index"::info.Identifier::path)
+        { info with Kind = ResolveCollection inner }, deferredFields', streamedFields', path'
+    | Abstract _ -> planAbstraction ctx info.Ast.SelectionSet (info, deferredFields, streamedFields, path) (ref []) None 
     | _ -> failwith "Invalid Return Type in Planning!"
 
 and private planSelection (ctx: PlanningContext) (selectionSet: Selection list) (stage: PlanningStage) visitedFragments : PlanningStage = 
-    let info, deferredFields, path = stage
+    let info, deferredFields, streamedFields, path = stage
     let parentDef = downcast info.ReturnDef
-    let plannedFields, deferredFields' =
+    let plannedFields, deferredFields', streamedFields' =
         selectionSet
-        |> List.fold(fun (fields: ExecutionInfo list, deferredFields: DeferredExecutionInfo list) selection ->
+        |> List.fold(fun (fields : ExecutionInfo list, deferredFields : DeferredExecutionInfo list, streamedFields : StreamedExecutionInfo list) selection ->
             //FIXME: includer is not passed along from top level fragments (both inline and spreads)
             let includer = getIncluder selection.Directives info.Include
             let updatedInfo = { info with Include = includer }
@@ -212,85 +215,89 @@ and private planSelection (ctx: PlanningContext) (selectionSet: Selection list) 
             | Field field ->
                 let identifier = field.AliasOrName
                 if fields |> List.exists (fun f -> f.Identifier = identifier) 
-                then fields, deferredFields
+                then fields, deferredFields, streamedFields
                 else 
                     let innerInfo = objectInfo(ctx, parentDef, field, includer)
-                    let executionPlan, deferredFields', path' = plan ctx (innerInfo, deferredFields, path)
+                    let executionPlan, deferredFields', streamedFields', path' = plan ctx (innerInfo, deferredFields, streamedFields, path)
                     if isDeferredField field
-                    then (fields, {Info = {info with Kind = SelectFields [executionPlan]}; Path = path'}::deferredFields')
-                    else (fields @ [executionPlan], deferredFields')    // unfortunatelly, order matters here
-                    
+                    then (fields, {Info = {info with Kind = SelectFields [executionPlan]}; Path = path'} :: deferredFields', streamedFields')
+                    elif isStreamedField field
+                    then (fields, deferredFields', {Info = {info with Kind = SelectFields [executionPlan]}; Path = path'} :: streamedFields')
+                    else (fields @ [executionPlan], deferredFields', streamedFields') // unfortunatelly, order matters here
             | FragmentSpread spread ->
                 let spreadName = spread.Name
                 if !visitedFragments |> List.exists (fun name -> name = spreadName) 
-                then fields, deferredFields  // fragment already found
+                then fields, deferredFields, streamedFields  // fragment already found
                 else
                     visitedFragments := spreadName::!visitedFragments
                     match ctx.Document.Definitions |> List.tryFind (function FragmentDefinition f -> f.Name.Value = spreadName | _ -> false) with
                     | Some (FragmentDefinition fragment) when doesFragmentTypeApply ctx.Schema fragment parentDef ->
                         // retrieve fragment data just as it was normal selection set
                         // TODO: Check if the path is correctly defined
-                        let fragmentInfo, deferredFields', path' = planSelection ctx fragment.SelectionSet (updatedInfo, deferredFields, path) visitedFragments 
+                        let fragmentInfo, deferredFields', streamedFields', path' = planSelection ctx fragment.SelectionSet (updatedInfo, deferredFields, streamedFields, path) visitedFragments 
                         let fragmentFields = getSelectionFrag fragmentInfo.Kind
                         // filter out already existing fields
-                        deepMerge fields fragmentFields, deferredFields'
+                        deepMerge fields fragmentFields, deferredFields', streamedFields'
                         // List.mergeBy (fun field -> field.Identifier) fields fragmentFields, deferedFields'
-                    | _ -> fields, deferredFields
+                    | _ -> fields, deferredFields, streamedFields
             | InlineFragment fragment when doesFragmentTypeApply ctx.Schema fragment parentDef ->
                  // retrieve fragment data just as it was normal selection set
-                 let fragmentInfo, deferredFields', path' = planSelection ctx fragment.SelectionSet (updatedInfo, deferredFields, path) visitedFragments
+                 let fragmentInfo, deferredFields', streamedFields', path' = planSelection ctx fragment.SelectionSet (updatedInfo, deferredFields, streamedFields, path) visitedFragments
                  let fragmentFields = getSelectionFrag fragmentInfo.Kind
-
                  // filter out already existing fields
-                 deepMerge fields fragmentFields, deferredFields'
-            | _ -> fields, deferredFields
-        ) ([],deferredFields)
-    { info with Kind = SelectFields plannedFields }, deferredFields', path
+                 deepMerge fields fragmentFields, deferredFields', streamedFields'
+            | _ -> fields, deferredFields, streamedFields
+        ) ([],deferredFields, streamedFields)
+    { info with Kind = SelectFields plannedFields }, deferredFields', streamedFields', path
     
 and private planAbstraction (ctx:PlanningContext) (selectionSet: Selection list) (stage:PlanningStage) visitedFragments typeCondition : PlanningStage =
-    let info, deferredFields, path = stage
-    let plannedTypeFields, deferredFields' =
+    let info, deferredFields, streamedFields, path = stage
+    let plannedTypeFields, deferredFields', streamedFields' =
         selectionSet
-        |> List.fold(fun (fields: Map<string, ExecutionInfo list>, deferredFields: DeferredExecutionInfo list) selection ->
+        |> List.fold(fun (fields : Map<string, ExecutionInfo list>, deferredFields : DeferredExecutionInfo list, streamedFields : StreamedExecutionInfo list) selection ->
             let includer = getIncluder selection.Directives info.Include
             let innerData = { info with Include = includer }
             match selection with
             | Field field ->
                 let a = abstractionInfo ctx (info.ReturnDef :?> AbstractDef) field typeCondition includer
-                // Make sure that we properly deal with the deferred fields
-                let foldPlan (f:Map<string, ExecutionInfo list>, d, _) k data =
-                    let f', d', p' = plan ctx (data, d, path)
-                    f.Add(k, [f']), d', p'
-                let infoMap, deferredFields', path' = Map.fold (foldPlan) (Map.empty, deferredFields, []) a  
+                // Make sure that we properly deal with the deferred and streamed fields
+                let foldPlan (f:Map<string, ExecutionInfo list>, d, s, _) k data =
+                    let f', d', s', p' = plan ctx (data, d, s, path)
+                    f.Add(k, [f']), d', s', p'
+                let infoMap, deferredFields', streamedFields', path' = Map.fold (foldPlan) (Map.empty, deferredFields, streamedFields, []) a  
                 if isDeferredField field
                 then 
                     printfn "Abstraction Info Keys: %A" (a |> Map.toSeq |> Seq.map fst)
                     printfn "InfoMap Keys: %A" (infoMap |> Map.toSeq |> Seq.map fst)
-                    fields, {Info = { innerData with Kind = ResolveAbstraction infoMap}; Path = path'}::deferredFields'
-                else Map.merge (fun _ oldVal newVal -> deepMerge oldVal newVal) fields infoMap, deferredFields'
+                    fields, {Info = { innerData with Kind = ResolveAbstraction infoMap}; Path = path'} :: deferredFields', streamedFields'
+                elif isStreamedField field
+                then
+                    printfn "Abstraction Info Keys: %A" (a |> Map.toSeq |> Seq.map fst)
+                    printfn "InfoMap Keys: %A" (infoMap |> Map.toSeq |> Seq.map fst)
+                    fields, deferredFields', {Info = { innerData with Kind = ResolveAbstraction infoMap}; Path = path'} :: streamedFields'
+                else Map.merge (fun _ oldVal newVal -> deepMerge oldVal newVal) fields infoMap, deferredFields', streamedFields'
             | FragmentSpread spread ->
                 let spreadName = spread.Name
                 if !visitedFragments |> List.exists (fun name -> name = spreadName) 
-                then fields, deferredFields  // fragment already found
+                then fields, deferredFields, streamedFields  // fragment already found
                 else
                     visitedFragments := spreadName::!visitedFragments
                     match ctx.Document.Definitions |> List.tryFind (function FragmentDefinition f -> f.Name.Value = spreadName | _ -> false) with
                     | Some (FragmentDefinition fragment) ->
                         // retrieve fragment data just as it was normal selection set
-                        let fragmentInfo, deferredFields', path' = planAbstraction ctx fragment.SelectionSet (innerData, deferredFields, path) visitedFragments fragment.TypeCondition
+                        let fragmentInfo, deferredFields', streamedFields', path' = planAbstraction ctx fragment.SelectionSet (innerData, deferredFields, streamedFields, path) visitedFragments fragment.TypeCondition
                         let fragmentFields = getAbstractionFrag fragmentInfo.Kind
                         // filter out already existing fields
-                        Map.merge (fun _ oldVal newVal -> deepMerge oldVal newVal) fields fragmentFields, deferredFields'
-                    | _ -> fields, deferredFields
+                        Map.merge (fun _ oldVal newVal -> deepMerge oldVal newVal) fields fragmentFields, deferredFields', streamedFields'
+                    | _ -> fields, deferredFields, streamedFields
             | InlineFragment fragment ->
                 // retrieve fragment data just as it was normal selection set
-                let fragmentInfo, deferredFields', path' = planAbstraction ctx fragment.SelectionSet (innerData, deferredFields, path) visitedFragments fragment.TypeCondition
+                let fragmentInfo, deferredFields', streamedFields', path' = planAbstraction ctx fragment.SelectionSet (innerData, deferredFields, streamedFields, path) visitedFragments fragment.TypeCondition
                 let fragmentFields = getAbstractionFrag fragmentInfo.Kind
-
                 // filter out already existing fields
-                Map.merge (fun _ oldVal newVal -> deepMerge oldVal newVal) fields fragmentFields, deferredFields'
-        ) (Map.empty, deferredFields)
-    { info with Kind = ResolveAbstraction plannedTypeFields }, deferredFields', path
+                Map.merge (fun _ oldVal newVal -> deepMerge oldVal newVal) fields fragmentFields, deferredFields', streamedFields'
+        ) (Map.empty, deferredFields, streamedFields)
+    { info with Kind = ResolveAbstraction plannedTypeFields }, deferredFields', streamedFields', path
 
 let private planVariables (schema: ISchema) (operation: OperationDefinition) =
     operation.VariableDefinitions 
@@ -315,9 +322,12 @@ let internal planOperation documentId (ctx: PlanningContext) (operation: Operati
         Definition = Unchecked.defaultof<FieldDef> 
         Include = incl 
         IsNullable = false }
-    let resolvedInfo, deferredFields, _ = planSelection ctx operation.SelectionSet (rootInfo, [], []) (ref [])
+    let resolvedInfo, deferredFields, streamedFields, _ = planSelection ctx operation.SelectionSet (rootInfo, [], [], []) (ref [])
     let deferredFields' = 
         deferredFields
+        |> List.map (fun d -> {d with Path = List.rev d.Path})
+    let streamedFields' =
+        streamedFields
         |> List.map (fun d -> {d with Path = List.rev d.Path})
     let (SelectFields(topFields)) = resolvedInfo.Kind
     let variables = planVariables ctx.Schema operation
@@ -327,6 +337,7 @@ let internal planOperation documentId (ctx: PlanningContext) (operation: Operati
           Operation = operation 
           Fields = topFields
           DeferredFields = deferredFields'
+          StreamedFields = streamedFields'
           RootDef = ctx.Schema.Query
           Strategy = Parallel
           Variables = variables }
@@ -337,6 +348,7 @@ let internal planOperation documentId (ctx: PlanningContext) (operation: Operati
               Operation = operation
               Fields = topFields
               DeferredFields = deferredFields'
+              StreamedFields = streamedFields'
               RootDef = mutationDef
               Strategy = Sequential 
               Variables = variables }
@@ -349,6 +361,7 @@ let internal planOperation documentId (ctx: PlanningContext) (operation: Operati
               Operation = operation
               Fields = topFields
               DeferredFields = deferredFields'
+              StreamedFields = streamedFields'
               RootDef = subscriptionDef
               Strategy = Sequential 
               Variables = variables }

--- a/src/FSharp.Data.GraphQL.Server/Schema.fs
+++ b/src/FSharp.Data.GraphQL.Server/Schema.fs
@@ -56,7 +56,7 @@ type SchemaConfig =
 
     static member Default = 
         { Types = []
-          Directives = [IncludeDirective; SkipDirective; DeferDirective]
+          Directives = [ IncludeDirective; SkipDirective; DeferDirective; StreamDirective ]
           ParseError = fun e -> e.Message
           SubscriptionProvider = SchemaConfig.DefaultSubscriptionProvider() }
 

--- a/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
+++ b/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
@@ -629,7 +629,14 @@ and VarDef =
 and DeferredExecutionInfo = {
     Info : ExecutionInfo
     Path : string list
+    Kind : DeferredExecutionInfoKind
 }
+
+/// Kind of deferred execution.
+and DeferredExecutionInfoKind =
+    | DeferredExecution
+    | StreamedExecution
+
 and ExecutionPlan = 
     { /// Unique identifier of the current execution plan.
       DocumentId : int
@@ -644,8 +651,6 @@ and ExecutionPlan =
       Fields : ExecutionInfo list
       /// A list of all deferred fields in the query
       DeferredFields : DeferredExecutionInfo list
-      /// A list of all streamed fields in the query
-      StreamedFields : DeferredExecutionInfo list
       /// List of variables defined within executed query.
       Variables: VarDef list }
     member x.Item with get(id) = x.Fields |> List.find (fun f -> f.Identifier = id)

--- a/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
+++ b/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
@@ -630,6 +630,10 @@ and DeferredExecutionInfo = {
     Info : ExecutionInfo
     Path : string list
 }
+and StreamedExecutionInfo = {
+    Info : ExecutionInfo
+    Path : string list
+}
 and ExecutionPlan = 
     { /// Unique identifier of the current execution plan.
       DocumentId : int
@@ -644,6 +648,8 @@ and ExecutionPlan =
       Fields : ExecutionInfo list
       /// A list of all deferred fields in the query
       DeferredFields : DeferredExecutionInfo list
+      /// A list of all streamed fields in the query
+      StreamedFields : StreamedExecutionInfo list
       /// List of variables defined within executed query.
       Variables: VarDef list }
     member x.Item with get(id) = x.Fields |> List.find (fun f -> f.Identifier = id)
@@ -2120,10 +2126,19 @@ module SchemaDefinitions =
                                        >> Option.map box
                                        >> Option.toObj) } |] }
 
+    /// GraphQL @defer directive.
     let DeferDirective : DirectiveDef =
         { Name = "defer"
           Description = Some "Defers the resolution of this field or fragment"
           Locations =
+            DirectiveLocation.FIELD ||| DirectiveLocation.FRAGMENT_SPREAD ||| DirectiveLocation.INLINE_FRAGMENT ||| DirectiveLocation.FRAGMENT_DEFINITION
+          Args = [||] }
+
+    /// GraphQL @stream directive.
+    let StreamDirective : DirectiveDef =
+        { Name = "stream"
+          Description = Some "Streams the resolution of this field or fragment"
+          Locations = 
             DirectiveLocation.FIELD ||| DirectiveLocation.FRAGMENT_SPREAD ||| DirectiveLocation.INLINE_FRAGMENT ||| DirectiveLocation.FRAGMENT_DEFINITION
           Args = [||] }
     

--- a/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
+++ b/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
@@ -630,10 +630,6 @@ and DeferredExecutionInfo = {
     Info : ExecutionInfo
     Path : string list
 }
-and StreamedExecutionInfo = {
-    Info : ExecutionInfo
-    Path : string list
-}
 and ExecutionPlan = 
     { /// Unique identifier of the current execution plan.
       DocumentId : int
@@ -649,7 +645,7 @@ and ExecutionPlan =
       /// A list of all deferred fields in the query
       DeferredFields : DeferredExecutionInfo list
       /// A list of all streamed fields in the query
-      StreamedFields : StreamedExecutionInfo list
+      StreamedFields : DeferredExecutionInfo list
       /// List of variables defined within executed query.
       Variables: VarDef list }
     member x.Item with get(id) = x.Fields |> List.find (fun f -> f.Identifier = id)

--- a/tests/FSharp.Data.GraphQL.Tests/DeferredTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/DeferredTests.fs
@@ -7,6 +7,11 @@ open FSharp.Data.GraphQL
 open FSharp.Data.GraphQL.Types
 open FSharp.Data.GraphQL.Parser
 open FSharp.Data.GraphQL.Execution
+open System.Threading
+open FSharp.Data.GraphQL.Tests
+open System.Collections.Generic
+open System.Collections.Concurrent
+open System.Collections.Concurrent
 
 #nowarn "40"
 
@@ -95,11 +100,11 @@ let executor =
     Executor(schema)
 
 let asts query = 
-    ["defer"; "stream" ]
+    ["defer"; "stream"]
     |> Seq.map (query >> parse)
 
 [<Fact>]
-let ``Simple Defer`` () =
+let ``Simple Defer and Stream`` () =
     let expectedDirect =
         NameValueLookup.ofList [
            "testData", upcast NameValueLookup.ofList [
@@ -127,66 +132,35 @@ let ``Simple Defer`` () =
             deferred |> Observable.add(equals (upcast expectedDeferred))
         | _ -> fail "Expected Deferred GQLResponse")
 
-[<Fact(Skip="FIXME: investigate reason of failure")>]
-let ``Partial Union Defer`` () = 
-    let expectedDirect = 
-        NameValueLookup.ofList [
-            "testData", upcast NameValueLookup.ofList [
-                "a", upcast "Apple"
-                "union", upcast NameValueLookup.ofList[
-                    "id", upcast "1"
-                ]
-            ]
-        ]
-    let query = sprintf """{
-        testData {
-            a
-            union {
-                ... on A {
-                    id
-                    a @%s
-                }
-                ... on B {
-                    id
-                    b
-                }
-            }
-        }
-    }"""
-    asts query
-    |> Seq.map (executor.AsyncExecute >> sync)
-    |> Seq.iter (fun result ->
-        match result with
-        | Deferred(data, errors, deferred) ->
-            empty errors
-            data.["data"] |> equals (upcast expectedDirect)
-            // deferred |> Observable.add(printfn "Deferred: %A")
-        | _ -> fail "Expected Deferred GQLRespnse")
-
 [<Fact>]
 let ``List Union Defer``() =
     let expectedDirect =
         NameValueLookup.ofList [
             "testData", upcast NameValueLookup.ofList [
                 "a", upcast "Apple"
-                "list", upcast [
-                    NameValueLookup.ofList [
-                        "id", upcast "2"
-                    ]
-                    NameValueLookup.ofList [
-                        "id", upcast "3"
-                        "b", upcast 4
-                    ]
-                ]
             ]
         ]
-    let query = sprintf """{
+    let expectedDeferred =
+        NameValueLookup.ofList [
+            "data", [
+                NameValueLookup.ofList [
+                    "id", upcast "2"
+                    "a", upcast "Union A"
+                ] :> obj
+                NameValueLookup.ofList [
+                    "id", upcast "3"
+                    "b", upcast 4
+                ] :> obj
+            ] :> obj
+            "path", upcast ["testData"; "list"]
+        ]
+    let query = parse """{
         testData {
             a
-            list {
+            list @defer {
                 ... on A {
                     id
-                    a @%s
+                    a
                 }
                 ... on B {
                     id
@@ -195,48 +169,114 @@ let ``List Union Defer``() =
             }
         }
     }"""
-    asts query
-    |> Seq.map (executor.AsyncExecute >> sync)
-    |> Seq.iter (fun result ->
-        match result with
-        | Deferred(data, errors, deferred) ->
-            empty errors
-            data.["data"] |> equals (upcast expectedDirect)
-            // deferred |> Observable.add(printfn "Deferred: %A")
-        | _ -> fail "Expected Deferred GQLRespnse")
+    use mre = new ManualResetEvent(false)
+    let actualDeferred = ConcurrentBag<Output>()
+    let result = query |> executor.AsyncExecute |> sync
+    match result with
+    | Deferred(data, errors, deferred) ->
+        empty errors
+        data.["data"] |> equals (upcast expectedDirect)
+        deferred |> Observable.add (fun x -> actualDeferred.Add(x); mre.Set() |> ignore)
+        if TimeSpan.FromSeconds(float 30) |> mre.WaitOne |> not
+        then fail "Timeout while waiting for Deferred GQLResponse"
+        actualDeferred |> single |> equals (upcast expectedDeferred)
+    | _ -> fail "Expected Deferred GQLResponse"
 
-[<Fact(Skip="FIXME: investigate reason of failure")>]
-let ``Complex Defer`` () =
+[<Fact>]
+let ``List Stream``() =
+    let expectedDirect =
+        NameValueLookup.ofList [
+            "testData", upcast NameValueLookup.ofList [
+                "a", upcast "Apple"
+            ]
+        ]
+    let expectedDeferred1 =
+        NameValueLookup.ofList [
+            "data", [
+                NameValueLookup.ofList [
+                    "id", upcast "2"
+                    "a", upcast "Union A"
+                ] :> obj
+            ] :> obj
+            "path", upcast ["testData" :> obj; "list" :> obj; 0 :> obj]
+        ]        
+    let expectedDeferred2 =
+        NameValueLookup.ofList [
+            "data", [
+                NameValueLookup.ofList [
+                    "id", upcast "3"
+                    "b", upcast 4
+                ] :> obj
+            ] :> obj
+            "path", upcast ["testData" :> obj; "list" :> obj; 1 :> obj]
+        ]
+    let query = parse """{
+        testData {
+            a
+            list @stream {
+                ... on A {
+                    id
+                    a
+                }
+                ... on B {
+                    id
+                    b
+                }
+            }
+        }
+    }"""
+    use mre = new ManualResetEvent(false)
+    let actualDeferred = ConcurrentBag<Output>()
+    let result = query |> executor.AsyncExecute |> sync
+    match result with
+    | Deferred(data, errors, deferred) ->
+        empty errors
+        data.["data"] |> equals (upcast expectedDirect)
+        deferred 
+        |> Observable.add (fun x -> 
+            actualDeferred.Add(x)
+            if actualDeferred.Count = 2 then mre.Set() |> ignore)
+        if TimeSpan.FromSeconds(float 30) |> mre.WaitOne |> not
+        then fail "Timeout while waiting for Deferred GQLResponse"
+        actualDeferred
+        |> Seq.cast<NameValueLookup>
+        |> contains expectedDeferred1
+        |> contains expectedDeferred2
+        |> ignore
+    | _ -> fail "Expected Deferred GQLResponse"
+
+[<Fact>]
+let ``Union Defer and Stream`` () =
     let expectedDirect =
         NameValueLookup.ofList [
             "testData", upcast NameValueLookup.ofList [
                 "a", upcast "Apple"
                 "b", upcast "Banana"
-                "union", upcast NameValueLookup.ofList [ "id", upcast "1" ]
             ]
         ]
     let expectedDeferred =
         NameValueLookup.ofList [
-            "data", upcast NameValueLookup.ofList [ "a", upcast "Union A" ]
-            "path", upcast ["Data"; "union"; "a"]
+            "data", upcast NameValueLookup.ofList [ "id", upcast "1"; "a", upcast "Union A" ]
+            "path", upcast ["testData"; "union"]
         ]
-    let query d = 
-        sprintf """{
-            testData {
-                a
-                b
-                union {
-                    ... on A {
-                        id
-                        a @%s
-                    }
-                    ... on B {
-                        id
-                        b @%s
-                    }
+    let query = sprintf """{
+        testData {
+            a
+            b
+            union @%s {
+                ... on A {
+                    id
+                    a
+                }
+                ... on B {
+                    id
+                    b
                 }
             }
-        }""" d d
+        }
+    }"""
+    use mre = new ManualResetEvent(false)
+    let actualDeferred = ConcurrentBag<Output>()
     asts query
     |> Seq.map (executor.AsyncExecute >> sync)
     |> Seq.iter (fun result ->
@@ -244,5 +284,8 @@ let ``Complex Defer`` () =
         | Deferred(data, errors, deferred) -> 
             empty errors
             data.["data"] |> equals (upcast expectedDirect)
-            deferred |> Observable.add(equals (upcast expectedDeferred))
+            deferred |> Observable.add (fun x -> actualDeferred.Add(x); mre.Set() |> ignore)
+            if TimeSpan.FromSeconds(float 30) |> mre.WaitOne |> not
+            then fail "Timeout while waiting for Deferred GQLResponse"
+            actualDeferred |> single |> equals (upcast expectedDeferred)
         | _ -> fail "Expected Deferred GQLRespnse")

--- a/tests/FSharp.Data.GraphQL.Tests/FSharp.Data.GraphQL.Tests.fsproj
+++ b/tests/FSharp.Data.GraphQL.Tests/FSharp.Data.GraphQL.Tests.fsproj
@@ -34,6 +34,7 @@
     <Compile Include="PlanningTests.fs" />
     <Compile Include="PropertyTrackerTests.fs" />
     <Compile Include="LinqTests.fs" />
+    <Compile Include="DeferredTests.fs" />
     <Compile Include="Program.fs" Condition=" '$(TargetFramework)' == 'netcoreapp2.0' " />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
With this Pull Request, I am implementing stream directive support for the server component, as described [here](https://dev-blog.apollodata.com/new-features-in-graphql-batch-defer-stream-live-and-subscribe-7585d0c28b07).

- [x] Mapping streamed fields in the executor
- [x] Create the logic for the stream execution
- [x] Unify streamed and deferred results into a single union case
- [x] Check recursive queries (deferred results inside a streamed result, for example)
- [x] Make tests