### PR TITLE
Changing context input for subscriptions

### DIFF
--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -72,6 +72,9 @@
       <PaketRestoreRequired Condition=" '$(PaketRestoreLockFileHash)' == '' ">true</PaketRestoreRequired>
     </PropertyGroup>
 
+    <PropertyGroup Condition="'$(PaketPropsVersion)' != '5.174.2' ">
+      <PaketRestoreRequired>true</PaketRestoreRequired>
+    </PropertyGroup>
 
     <!-- Do a global restore if required -->
     <Exec Command='$(PaketBootStrapperCommand)' Condition="Exists('$(PaketBootStrapperExePath)') AND !(Exists('$(PaketExePath)'))" ContinueOnError="false" />
@@ -93,7 +96,7 @@
       <PaketOriginalReferencesFilePath Condition=" !Exists('$(PaketOriginalReferencesFilePath)')">$(MSBuildProjectDirectory)\$(MSBuildProjectName).paket.references</PaketOriginalReferencesFilePath>
       <!-- paket.references -->
       <PaketOriginalReferencesFilePath Condition=" !Exists('$(PaketOriginalReferencesFilePath)')">$(MSBuildProjectDirectory)\paket.references</PaketOriginalReferencesFilePath>
-      
+
       <DoAllResolvedFilesExist>false</DoAllResolvedFilesExist>
       <DoAllResolvedFilesExist Condition="Exists(%(PaketResolvedFilePaths.Identity))">true</DoAllResolvedFilesExist>
       <PaketRestoreRequired>true</PaketRestoreRequired>
@@ -132,11 +135,11 @@
     <Error Condition=" '$(DoAllResolvedFilesExist)' != 'true' AND '$(ResolveNuGetPackages)' != 'False' " Text="One Paket file '@(PaketResolvedFilePaths)' is missing while restoring $(MSBuildProjectFile). Please delete 'paket-files/paket.restore.cached' and call 'paket restore'." />
 
     <!-- Step 4 forward all msbuild properties (PackageReference, DotNetCliToolReference) to msbuild -->
-    <ReadLinesFromFile Condition="'@(PaketResolvedFilePaths)' != ''" File="%(PaketResolvedFilePaths.Identity)" ><!--Condition="Exists('%(PaketResolvedFilePaths.Identity)')"-->
+    <ReadLinesFromFile Condition="($(DesignTimeBuild) != true OR '$(PaketPropsLoaded)' != 'true') AND '@(PaketResolvedFilePaths)' != ''" File="%(PaketResolvedFilePaths.Identity)" >
       <Output TaskParameter="Lines" ItemName="PaketReferencesFileLines"/>
     </ReadLinesFromFile>
 
-    <ItemGroup Condition=" '@(PaketReferencesFileLines)' != '' " >
+    <ItemGroup Condition="($(DesignTimeBuild) != true OR '$(PaketPropsLoaded)' != 'true') AND '@(PaketReferencesFileLines)' != '' " >
       <PaketReferencesFileLinesInfo Include="@(PaketReferencesFileLines)" >
         <PackageName>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[0])</PackageName>
         <PackageVersion>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[1])</PackageVersion>

--- a/src/FSharp.Data.GraphQL.Samples.GiraffeServer/Schema.fs
+++ b/src/FSharp.Data.GraphQL.Samples.GiraffeServer/Schema.fs
@@ -195,6 +195,20 @@ module Schema =
                 Define.Field("hero", Nullable HumanType, "Gets human hero", [ Define.Input("id", String) ], fun ctx _ -> getHuman (ctx.Arg("id")))
                 Define.Field("droid", Nullable DroidType, "Gets droid", [ Define.Input("id", String) ], fun ctx _ -> getDroid (ctx.Arg("id"))) ])
 
+    let SubscriptionField =
+        Define.SubscriptionField(
+                    "watchMoon",
+                    RootType,
+                    PlanetType,
+                    "Watches to see if a planet is a moon",
+                    [ Define.Input("id", String) ],
+                    (fun ctx _ p -> if ctx.Arg("id") = p.Id then Some p else None))
+
+    let Subscription =
+        Define.SubscriptionObject<Root>(
+            name = "Subscription",
+            fields = [ SubscriptionField ])
+
     let Mutation =
         Define.Object<Root>(
             name = "Mutation",
@@ -208,20 +222,8 @@ module Schema =
                         getPlanet(ctx.Arg("id"))
                         |> Option.map (fun x ->
                             x.SetMoon(Some(ctx.Arg("ismoon"))) |> ignore
-                            schemaConfig.SubscriptionProvider.Publish<Planet> "watchMoon" x
+                            schemaConfig.SubscriptionProvider.Publish SubscriptionField x
                             x))])
-
-    let Subscription =
-        Define.SubscriptionObject<Root>(
-            name = "Subscription",
-            fields = [
-                Define.SubscriptionField(
-                    "watchMoon",
-                    RootType,
-                    PlanetType,
-                    "Watches to see if a planet is a moon",
-                    [ Define.Input("id", String) ],
-                    (fun ctx _ p -> ctx.Arg("id") = p.Id))])
 
     let schema = Schema(Query, Mutation, Subscription, schemaConfig)
 

--- a/src/FSharp.Data.GraphQL.Server/Execution.fs
+++ b/src/FSharp.Data.GraphQL.Server/Execution.fs
@@ -712,7 +712,6 @@ let private executeSubscription (resultSet: (string * ExecutionInfo) []) (ctx: E
             match err with
             | [] -> NameValueLookup.ofList["data", data.Value] :> Output
             | _ -> NameValueLookup.ofList["data", data.Value; "errors", upcast (formatErrors err)] :> Output)
-        |> AsyncVal.map(fun d -> printfn "Async dict %A" d;d)
         |> AsyncVal.toAsync
         |> Observable.ofAsync)
 

--- a/src/FSharp.Data.GraphQL.Server/Execution.fs
+++ b/src/FSharp.Data.GraphQL.Server/Execution.fs
@@ -692,7 +692,7 @@ let private executeSubscription (resultSet: (string * ExecutionInfo) []) (ctx: E
     let name, info = Array.head resultSet
     let subdef = info.Definition :?> SubscriptionFieldDef
     let args = getArgumentValues subdef.Args info.Ast.Arguments ctx.Variables
-    let returnType = subdef.InputTypeDef
+    let returnType = subdef.OutputTypeDef
     let fieldCtx = 
         { ExecutionInfo = info
           Context = ctx

--- a/src/FSharp.Data.GraphQL.Server/Execution.fs
+++ b/src/FSharp.Data.GraphQL.Server/Execution.fs
@@ -462,6 +462,7 @@ and buildObjectFields (fields: ExecutionInfo list) (objdef: ObjectDef) (ctx: Res
 let internal compileSubscriptionField (subfield: SubscriptionFieldDef) = 
     match subfield.Resolve with
     | Resolve.BoxedFilterExpr(_, _, _, filter) -> filter
+    | Resolve.BoxedAsyncFilterExpr(_, _, _, filter) -> fun ctx a b -> filter ctx a b |> Async.RunSynchronously
     | _ -> raise <| GraphQLException ("Invalid filter expression for subscription field!")
 
 let internal compileField (fieldDef: FieldDef) : ExecuteField =

--- a/src/FSharp.Data.GraphQL.Server/Execution.fs
+++ b/src/FSharp.Data.GraphQL.Server/Execution.fs
@@ -460,7 +460,7 @@ and buildObjectFields (fields: ExecutionInfo list) (objdef: ObjectDef) (ctx: Res
 
 let internal compileSubscriptionField (subfield: SubscriptionFieldDef) = 
     match subfield.Resolve with
-    | Resolve.BoxedFilterExpr(_, _, filter) -> filter
+    | Resolve.BoxedFilterExpr(_, _, _, filter) -> filter
     | _ -> raise <| GraphQLException ("Invalid filter expression for subscription field!")
 
 let internal compileField (fieldDef: FieldDef) : ExecuteField =
@@ -701,7 +701,7 @@ let private executeSubscription (resultSet: (string * ExecutionInfo) []) (ctx: E
           Schema = ctx.Schema
           Args = args
           Variables = ctx.Variables } 
-    subscriptionProvider.Add fieldCtx value name 
+    subscriptionProvider.Add fieldCtx value subdef 
     |> Observable.bind(fun v -> 
         buildResolverTree returnType fieldCtx fieldExecuteMap (Some v) 
         |> AsyncVal.map(treeToDict)

--- a/src/FSharp.Data.GraphQL.Server/Executor.fs
+++ b/src/FSharp.Data.GraphQL.Server/Executor.fs
@@ -150,7 +150,7 @@ type Executor<'Root>(schema: ISchema<'Root>, middlewares : IExecutorMiddleware s
                 | Subscription ->
                     match schema.Subscription with
                     | Some s -> upcast s
-                    | None -> raise (GraphQLException "Operations to be executed is of type subscription, but no subscription root object was defined in the current schema") 
+                    | None -> raise (GraphQLException "Operation to be executed is of type subscription, but no subscription root object was defined in the current schema") 
             let planningCtx = 
                 { Schema = schema
                   RootDef = rootDef

--- a/src/FSharp.Data.GraphQL.Server/ObservableExtensions.fs
+++ b/src/FSharp.Data.GraphQL.Server/ObservableExtensions.fs
@@ -20,6 +20,9 @@ module internal Observable =
     let catch<'Item, 'Exception> (fx : Exception -> IObservable<'Item>) (obs : IObservable<'Item>) =
         obs.Catch(fx)
 
+    let choose (f: 'T -> 'U option) (o: IObservable<'T>): IObservable<'U> =
+        o.Select(f).Where(function Some x -> true | None -> false).Select(Option.get)
+
 open System.Collections.Concurrent
 
 // /// Wrapper type for IObservable that exposes event triggering

--- a/src/FSharp.Data.GraphQL.Server/Planning.fs
+++ b/src/FSharp.Data.GraphQL.Server/Planning.fs
@@ -59,7 +59,7 @@ let private objectInfo(ctx: PlanningContext, parentDef: ObjectDef, field: Field,
           ParentDef = parentDef
           ReturnDef = 
             match parentDef with
-            | SubscriptionObject _ -> (fdef :?> SubscriptionFieldDef).InputTypeDef
+            | SubscriptionObject _ -> (fdef :?> SubscriptionFieldDef).OutputTypeDef
             | Object _ -> fdef.TypeDef
             | _ -> raise (GraphQLException (sprintf "Unexpected parentdef type!"))
           Definition = fdef

--- a/src/FSharp.Data.GraphQL.Server/Schema.fs
+++ b/src/FSharp.Data.GraphQL.Server/Schema.fs
@@ -31,17 +31,18 @@ type SchemaConfig =
         { new ISubscriptionProvider with
             member __.Register (subscription: Subscription) =
                 registeredSubscriptions.Add(subscription.Name, (subscription, new Subject<obj>()))
-            member __.Add (ctx: ResolveFieldContext) (root: obj) (name: string)  =
-                match registeredSubscriptions.TryGetValue(name) with
+            member __.Add (ctx: ResolveFieldContext) (root: obj) (subdef: SubscriptionFieldDef)  =
+                match registeredSubscriptions.TryGetValue(subdef.Name) with
                 | true, (sub, channel) -> 
                     channel
-                    |> Observable.filter(fun o -> sub.Filter ctx root o)
+                    |> Observable.map(fun o -> sub.Filter ctx root o)
+                    |> Observable.choose(id)
                 | false, _ -> Observable.Empty()
-            member __.Publish<'T> (subIdent: string) (value: 'T) =
-                match registeredSubscriptions.TryGetValue(subIdent) with
+            member __.Publish (def: SubscriptionFieldDef<'Root, 'Input, 'Output>) (value: 'Input) =
+                match registeredSubscriptions.TryGetValue(def.Name) with
                 | true, (_, channel) ->
                     channel.OnNext(box value)
-                | false, _ -> printfn "Error: Tried to publish on non-existent channel `%s`" subIdent }
+                | false, _ -> printfn "Error: Tried to publish on non-existent channel `%s`" def.Name }
     /// Default SchemaConfig value for Schemas.
     static member Default = 
         { Types = []

--- a/src/FSharp.Data.GraphQL.Server/Schema.fs
+++ b/src/FSharp.Data.GraphQL.Server/Schema.fs
@@ -124,7 +124,7 @@ type Schema<'Root> (query: ObjectDef<'Root>, ?mutation: ObjectDef<'Root>, ?subsc
         { Name = subdef.Name
           Description = subdef.Description
           Args = subdef.Args |> Array.map (introspectInput namedTypes) 
-          Type = introspectTypeRef false namedTypes subdef.InputTypeDef
+          Type = introspectTypeRef false namedTypes subdef.OutputTypeDef
           IsDeprecated = Option.isSome subdef.DeprecationReason
           DeprecationReason = subdef.DeprecationReason }
 

--- a/src/FSharp.Data.GraphQL.Server/Schema.fs
+++ b/src/FSharp.Data.GraphQL.Server/Schema.fs
@@ -40,8 +40,7 @@ type SchemaConfig =
                 | false, _ -> Observable.Empty()
             member __.Publish (def: SubscriptionFieldDef<'Root, 'Input, 'Output>) (value: 'Input) =
                 match registeredSubscriptions.TryGetValue(def.Name) with
-                | true, (_, channel) ->
-                    channel.OnNext(box value)
+                | true, (_, channel) -> channel.OnNext(box value)
                 | false, _ -> printfn "Error: Tried to publish on non-existent channel `%s`" def.Name }
     /// Default SchemaConfig value for Schemas.
     static member Default = 

--- a/src/FSharp.Data.GraphQL.Shared/Parser.fs
+++ b/src/FSharp.Data.GraphQL.Shared/Parser.fs
@@ -264,8 +264,6 @@ module internal Internal =
   //    OperationDefinition List
   let definitions =
     let operationType = 
-      // leaving out subscriptions for now.
-      // (stoken_ws "subscription" >>% Subscription) 
       (stoken_ws "query" >>% Query) <|> (stoken_ws "mutation" >>% Mutation) <|> (stoken_ws "subscription" >>% Subscription)
       
     let namedOperationDefinition = 

--- a/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
+++ b/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
@@ -2868,43 +2868,63 @@ module SchemaDefinitions =
         static member SubscriptionField(name: string, rootdef: #OutputDef<'Root>, outputdef: #OutputDef<'Output>,
                                         description: string,
                                         [<ReflectedDefinition(true)>] filter: Expr<ResolveFieldContext -> 'Root -> 'Input -> 'Output option>): SubscriptionFieldDef<'Root, 'Input, 'Output> =
-            { Name = name
-              Description = Some description
-              RootTypeDef = rootdef
-              OutputTypeDef = outputdef
-              DeprecationReason = None
-              Args = [||]
-              Filter = Resolve.Filter(typeof<'Root>, typeof<'Input>, typeof<'Output>, filter)
-              Metadata = Metadata.Empty
-            } :> SubscriptionFieldDef<'Root, 'Input, 'Output>
+            upcast { Name = name
+                     Description = Some description
+                     RootTypeDef = rootdef
+                     OutputTypeDef = outputdef
+                     DeprecationReason = None
+                     Args = [||]
+                     Filter = Resolve.Filter(typeof<'Root>, typeof<'Input>, typeof<'Output>, filter)
+                     Metadata = Metadata.Empty }
 
         static member SubscriptionField(name: string, rootdef: #OutputDef<'Root>, outputdef: #OutputDef<'Output>,
                                         description: string,
                                         args: InputFieldDef list,
                                         [<ReflectedDefinition(true)>] filter: Expr<ResolveFieldContext -> 'Root -> 'Input -> 'Output option>): SubscriptionFieldDef<'Root, 'Input, 'Output> =
-            { Name = name
-              Description = Some description
-              RootTypeDef = rootdef
-              OutputTypeDef = outputdef
-              DeprecationReason = None
-              Args = args |> List.toArray
-              Filter = Resolve.Filter(typeof<'Root>, typeof<'Input>, typeof<'Output>, filter)
-              Metadata = Metadata.Empty
-            } :> SubscriptionFieldDef<'Root, 'Input, 'Output>
+            upcast { Name = name
+                     Description = Some description
+                     RootTypeDef = rootdef
+                     OutputTypeDef = outputdef
+                     DeprecationReason = None
+                     Args = args |> List.toArray
+                     Filter = Resolve.Filter(typeof<'Root>, typeof<'Input>, typeof<'Output>, filter)
+                     Metadata = Metadata.Empty }
 
         static member SubscriptionAsyncField(name: string, rootdef: #OutputDef<'Root>, outputdef: #OutputDef<'Output>,
-                                        description: string,
-                                        args: InputFieldDef list,
-                                        [<ReflectedDefinition(true)>] filter: Expr<ResolveFieldContext -> 'Root -> 'Input -> Async<'Output option>>): SubscriptionFieldDef<'Root, 'Input, 'Output> =
-            { Name = name
-              Description = Some description
-              RootTypeDef = rootdef
-              OutputTypeDef = outputdef
-              DeprecationReason = None
-              Args = args |> List.toArray
-              Filter = Resolve.AsyncFilter(typeof<'Root>, typeof<'Input>, typeof<'Output>, filter)
-              Metadata = Metadata.Empty
-            } :> SubscriptionFieldDef<'Root, 'Input, 'Output>
+                                             [<ReflectedDefinition(true)>] filter: Expr<ResolveFieldContext -> 'Root -> 'Input -> Async<'Output option>>): SubscriptionFieldDef<'Root, 'Input, 'Output> =
+            upcast { Name = name
+                     Description = None
+                     RootTypeDef = rootdef
+                     OutputTypeDef = outputdef
+                     DeprecationReason = None
+                     Args = [||]
+                     Filter = Resolve.AsyncFilter(typeof<'Root>, typeof<'Input>, typeof<'Output>, filter)
+                     Metadata = Metadata.Empty }
+
+        static member SubscriptionAsyncField(name: string, rootdef: #OutputDef<'Root>, outputdef: #OutputDef<'Output>,
+                                             description: string,
+                                             [<ReflectedDefinition(true)>] filter: Expr<ResolveFieldContext -> 'Root -> 'Input -> Async<'Output option>>): SubscriptionFieldDef<'Root, 'Input, 'Output> =
+            upcast { Name = name
+                     Description = Some description
+                     RootTypeDef = rootdef
+                     OutputTypeDef = outputdef
+                     DeprecationReason = None
+                     Args = [||]
+                     Filter = Resolve.AsyncFilter(typeof<'Root>, typeof<'Input>, typeof<'Output>, filter)
+                     Metadata = Metadata.Empty }
+
+        static member SubscriptionAsyncField(name: string, rootdef: #OutputDef<'Root>, outputdef: #OutputDef<'Output>,
+                                             description: string,
+                                             args: InputFieldDef list,
+                                             [<ReflectedDefinition(true)>] filter: Expr<ResolveFieldContext -> 'Root -> 'Input -> Async<'Output option>>): SubscriptionFieldDef<'Root, 'Input, 'Output> =
+            upcast { Name = name
+                     Description = Some description
+                     RootTypeDef = rootdef
+                     OutputTypeDef = outputdef
+                     DeprecationReason = None
+                     Args = args |> List.toArray
+                     Filter = Resolve.AsyncFilter(typeof<'Root>, typeof<'Input>, typeof<'Output>, filter)
+                     Metadata = Metadata.Empty }
         
         /// <summary>
         /// Creates an input field. Input fields are used like ordinary fileds in case of <see cref="InputObject"/>s,

--- a/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
+++ b/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
@@ -2914,7 +2914,7 @@ module SchemaDefinitions =
         /// <param name="rootdef">GraphQL type definition of the root field's type.</param>
         /// <param name="outputdef">GraphQL type definition of the current field's type.</param>
         /// <param name="filter">A filter function which decides if the field should be published to clients or not, by returning it as Some or None.</param>
-        static member SubscriptionAsyncField(name: string, rootdef: #OutputDef<'Root>, outputdef: #OutputDef<'Output>,
+        static member AsyncSubscriptionField(name: string, rootdef: #OutputDef<'Root>, outputdef: #OutputDef<'Output>,
                                              [<ReflectedDefinition(true)>] filter: Expr<ResolveFieldContext -> 'Root -> 'Input -> Async<'Output option>>): SubscriptionFieldDef<'Root, 'Input, 'Output> =
             upcast { Name = name
                      Description = None
@@ -2933,7 +2933,7 @@ module SchemaDefinitions =
         /// <param name="outputdef">GraphQL type definition of the current field's type.</param>
         /// <param name="description">Optional field description. Usefull for generating documentation.</param>
         /// <param name="filter">A filter function which decides if the field should be published to clients or not, by returning it as Some or None.</param>
-        static member SubscriptionAsyncField(name: string, rootdef: #OutputDef<'Root>, outputdef: #OutputDef<'Output>,
+        static member AsyncSubscriptionField(name: string, rootdef: #OutputDef<'Root>, outputdef: #OutputDef<'Output>,
                                              description: string,
                                              [<ReflectedDefinition(true)>] filter: Expr<ResolveFieldContext -> 'Root -> 'Input -> Async<'Output option>>): SubscriptionFieldDef<'Root, 'Input, 'Output> =
             upcast { Name = name
@@ -2954,7 +2954,7 @@ module SchemaDefinitions =
         /// <param name="description">Optional field description. Usefull for generating documentation.</param>
         /// <param name="args">List of field arguments used to parametrize resolve expression output.</param>
         /// <param name="filter">A filter function which decides if the field should be published to clients or not, by returning it as Some or None.</param>
-        static member SubscriptionAsyncField(name: string, rootdef: #OutputDef<'Root>, outputdef: #OutputDef<'Output>,
+        static member AsyncSubscriptionField(name: string, rootdef: #OutputDef<'Root>, outputdef: #OutputDef<'Output>,
                                              description: string,
                                              args: InputFieldDef list,
                                              [<ReflectedDefinition(true)>] filter: Expr<ResolveFieldContext -> 'Root -> 'Input -> Async<'Output option>>): SubscriptionFieldDef<'Root, 'Input, 'Output> =
@@ -2977,7 +2977,7 @@ module SchemaDefinitions =
         /// <param name="args">List of field arguments used to parametrize resolve expression output.</param>
         /// <param name="filter">A filter function which decides if the field should be published to clients or not, by returning it as Some or None.</param>
         /// <param name="deprecationReason">Deprecation reason.</param>
-        static member SubscriptionAsyncField(name: string, rootdef: #OutputDef<'Root>, outputdef: #OutputDef<'Output>,
+        static member AsyncSubscriptionField(name: string, rootdef: #OutputDef<'Root>, outputdef: #OutputDef<'Output>,
                                              description: string,
                                              args: InputFieldDef list,
                                              [<ReflectedDefinition(true)>] filter: Expr<ResolveFieldContext -> 'Root -> 'Input -> Async<'Output option>>,

--- a/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
+++ b/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
@@ -2654,10 +2654,6 @@ module SchemaDefinitions =
         /// </summary>
         /// <param name="name">Field name. Must be unique in scope of the defining object.</param>
         /// <param name="typedef">GraphQL type definition of the current field's type.</param>
-        /// <param name="weight">
-        /// Field weight when calculating max degree of nested fields of a query. The higher the value, 
-        /// the higher the cost of the field on a query, and less is the capability of nesting it.
-        /// </param>
         static member Field(name : string, typedef : #OutputDef<'Res>) : FieldDef<'Val> = 
             upcast { FieldDefinition.Name = name
                      Description = None
@@ -2674,10 +2670,6 @@ module SchemaDefinitions =
         /// <param name="name">Field name. Must be unique in scope of the defining object.</param>
         /// <param name="typedef">GraphQL type definition of the current field's type.</param>
         /// <param name="resolve">Expression used to resolve value from defining object.</param>
-        /// <param name="weight">
-        /// Field weight when calculating max degree of nested fields of a query. The higher the value, 
-        /// the higher the cost of the field on a query, and less is the capability of nesting it.
-        /// </param>
         static member Field(name : string, typedef : #OutputDef<'Res>, 
                             [<ReflectedDefinition(true)>] resolve : Expr<ResolveFieldContext -> 'Val -> 'Res>) : FieldDef<'Val> = 
             upcast { FieldDefinition.Name = name
@@ -2695,10 +2687,6 @@ module SchemaDefinitions =
         /// <param name="typedef">GraphQL type definition of the current field's type.</param>
         /// <param name="description">Optional field description. Usefull for generating documentation.</param>
         /// <param name="resolve">Expression used to resolve value from defining object.</param>
-        /// <param name="weight">
-        /// Field weight when calculating max degree of nested fields of a query. The higher the value, 
-        /// the higher the cost of the field on a query, and less is the capability of nesting it.
-        /// </param>
         static member Field(name : string, typedef : #OutputDef<'Res>, description : string, 
                             [<ReflectedDefinition(true)>] resolve : Expr<ResolveFieldContext -> 'Val -> 'Res>) : FieldDef<'Val> = 
             upcast { FieldDefinition.Name = name
@@ -2717,10 +2705,6 @@ module SchemaDefinitions =
         /// <param name="description">Optional field description. Usefull for generating documentation.</param>
         /// <param name="args">List of field arguments used to parametrize resolve expression output.</param>
         /// <param name="resolve">Expression used to resolve value from defining object.</param>
-        /// <param name="weight">
-        /// Field weight when calculating max degree of nested fields of a query. The higher the value, 
-        /// the higher the cost of the field on a query, and less is the capability of nesting it.
-        /// </param>
         static member Field(name : string, typedef : #OutputDef<'Res>, description : string, args : InputFieldDef list, 
                             [<ReflectedDefinition(true)>] resolve : Expr<ResolveFieldContext -> 'Val -> 'Res>) : FieldDef<'Val> = 
             upcast { FieldDefinition.Name = name
@@ -2740,10 +2724,6 @@ module SchemaDefinitions =
         /// <param name="args">List of field arguments used to parametrize resolve expression output.</param>
         /// <param name="resolve">Expression used to resolve value from defining object.</param>
         /// <param name="deprecationReason">Deprecation reason.</param>
-        /// <param name="weight">
-        /// Field weight when calculating max degree of nested fields of a query. The higher the value, 
-        /// the higher the cost of the field on a query, and less is the capability of nesting it.
-        /// </param>
         static member Field(name : string, typedef : #OutputDef<'Res>, description : string, args : InputFieldDef list, 
                             [<ReflectedDefinition(true)>] resolve : Expr<ResolveFieldContext -> 'Val -> 'Res>, 
                             deprecationReason : string) : FieldDef<'Val> = 
@@ -2761,10 +2741,6 @@ module SchemaDefinitions =
         /// <param name="name">Field name. Must be unique in scope of the defining object.</param>
         /// <param name="typedef">GraphQL type definition of the current field's type.</param>
         /// <param name="resolve">Expression used to resolve value from defining object.</param>
-        /// <param name="weight">
-        /// Field weight when calculating max degree of nested fields of a query. The higher the value, 
-        /// the higher the cost of the field on a query, and less is the capability of nesting it.
-        /// </param>
         static member AsyncField(name : string, typedef : #OutputDef<'Res>, 
                                  [<ReflectedDefinition(true)>] resolve : Expr<ResolveFieldContext -> 'Val -> Async<'Res>>) : FieldDef<'Val> = 
             upcast { FieldDefinition.Name = name
@@ -2782,10 +2758,6 @@ module SchemaDefinitions =
         /// <param name="typedef">GraphQL type definition of the current field's type.</param>
         /// <param name="description">Optional field description. Usefull for generating documentation.</param>
         /// <param name="resolve">Expression used to resolve value from defining object.</param>
-        /// <param name="weight">
-        /// Field weight when calculating max degree of nested fields of a query. The higher the value, 
-        /// the higher the cost of the field on a query, and less is the capability of nesting it.
-        /// </param>
         static member AsyncField(name : string, typedef : #OutputDef<'Res>, description : string, 
                                  [<ReflectedDefinition(true)>] resolve : Expr<ResolveFieldContext -> 'Val -> Async<'Res>>) : FieldDef<'Val> = 
             upcast { FieldDefinition.Name = name
@@ -2804,10 +2776,6 @@ module SchemaDefinitions =
         /// <param name="description">Optional field description. Usefull for generating documentation.</param>
         /// <param name="args">List of field arguments used to parametrize resolve expression output.</param>
         /// <param name="resolve">Expression used to resolve value from defining object.</param>
-        /// <param name="weight">
-        /// Field weight when calculating max degree of nested fields of a query. The higher the value, 
-        /// the higher the cost of the field on a query, and less is the capability of nesting it.
-        /// </param>
         static member AsyncField(name : string, typedef : #OutputDef<'Res>, description : string, 
                                  args : InputFieldDef list, 
                                  [<ReflectedDefinition(true)>] resolve : Expr<ResolveFieldContext -> 'Val -> Async<'Res>>) : FieldDef<'Val> = 
@@ -2828,10 +2796,6 @@ module SchemaDefinitions =
         /// <param name="args">List of field arguments used to parametrize resolve expression output.</param>
         /// <param name="resolve">Expression used to resolve value from defining object.</param>
         /// <param name="deprecationReason">Deprecation reason.</param>
-        /// <param name="weight">
-        /// Field weight when calculating max degree of nested fields of a query. The higher the value, 
-        /// the higher the cost of the field on a query, and less is the capability of nesting it.
-        /// </param>
         static member AsyncField(name : string, typedef : #OutputDef<'Res>, description : string, 
                                  args : InputFieldDef list, 
                                  [<ReflectedDefinition(true)>] resolve : Expr<ResolveFieldContext -> 'Val -> Async<'Res>>, 
@@ -2844,6 +2808,11 @@ module SchemaDefinitions =
                      DeprecationReason = Some deprecationReason
                      Metadata = Metadata.Empty }
 
+        /// <summary>
+        /// Creates a custom defined field using a custom field execution function.
+        /// </summary>
+        /// <param name="name">Field name. Must be unique in scope of the defining object.</param>
+        /// <param name="execField">Expression used to execute the field.</param>
         static member CustomField(name : string, [<ReflectedDefinition(true)>] execField : Expr<ExecuteField>) : FieldDef<'Val> = 
             upcast { FieldDefinition.Name = name
                      Description = None
@@ -2853,6 +2822,13 @@ module SchemaDefinitions =
                      DeprecationReason = None
                      Metadata = Metadata.Empty }
 
+        /// <summary>
+        /// Creates a subscription field inside object type.
+        /// </summary>
+        /// <param name="name">Field name. Must be unique in scope of the defining object.</param>
+        /// <param name="rootdef">GraphQL type definition of the root field's type.</param>
+        /// <param name="outputdef">GraphQL type definition of the current field's type.</param>
+        /// <param name="filter">A filter function which decides if the field should be published to clients or not, by returning it as Some or None.</param>
         static member SubscriptionField(name: string, rootdef: #OutputDef<'Root>, outputdef: #OutputDef<'Output>,
                                         [<ReflectedDefinition(true)>] filter: Expr<ResolveFieldContext -> 'Root -> 'Input -> 'Output option>): SubscriptionFieldDef<'Root, 'Input, 'Output> =
             { Name = name
@@ -2865,6 +2841,14 @@ module SchemaDefinitions =
               Metadata = Metadata.Empty
             } :> SubscriptionFieldDef<'Root, 'Input, 'Output>
 
+        /// <summary>
+        /// Creates a subscription field inside object type.
+        /// </summary>
+        /// <param name="name">Field name. Must be unique in scope of the defining object.</param>
+        /// <param name="rootdef">GraphQL type definition of the root field's type.</param>
+        /// <param name="outputdef">GraphQL type definition of the current field's type.</param>
+        /// <param name="description">Optional field description. Usefull for generating documentation.</param>
+        /// <param name="filter">A filter function which decides if the field should be published to clients or not, by returning it as Some or None.</param>
         static member SubscriptionField(name: string, rootdef: #OutputDef<'Root>, outputdef: #OutputDef<'Output>,
                                         description: string,
                                         [<ReflectedDefinition(true)>] filter: Expr<ResolveFieldContext -> 'Root -> 'Input -> 'Output option>): SubscriptionFieldDef<'Root, 'Input, 'Output> =
@@ -2877,6 +2861,15 @@ module SchemaDefinitions =
                      Filter = Resolve.Filter(typeof<'Root>, typeof<'Input>, typeof<'Output>, filter)
                      Metadata = Metadata.Empty }
 
+        /// <summary>
+        /// Creates a subscription field inside object type.
+        /// </summary>
+        /// <param name="name">Field name. Must be unique in scope of the defining object.</param>
+        /// <param name="rootdef">GraphQL type definition of the root field's type.</param>
+        /// <param name="outputdef">GraphQL type definition of the current field's type.</param>
+        /// <param name="description">Optional field description. Usefull for generating documentation.</param>
+        /// <param name="args">List of field arguments used to parametrize resolve expression output.</param>
+        /// <param name="filter">A filter function which decides if the field should be published to clients or not, by returning it as Some or None.</param>
         static member SubscriptionField(name: string, rootdef: #OutputDef<'Root>, outputdef: #OutputDef<'Output>,
                                         description: string,
                                         args: InputFieldDef list,
@@ -2890,6 +2883,37 @@ module SchemaDefinitions =
                      Filter = Resolve.Filter(typeof<'Root>, typeof<'Input>, typeof<'Output>, filter)
                      Metadata = Metadata.Empty }
 
+        /// <summary>
+        /// Creates a subscription field inside object type. Field is marked as deprecated.
+        /// </summary>
+        /// <param name="name">Field name. Must be unique in scope of the defining object.</param>
+        /// <param name="rootdef">GraphQL type definition of the root field's type.</param>
+        /// <param name="outputdef">GraphQL type definition of the current field's type.</param>
+        /// <param name="description">Optional field description. Usefull for generating documentation.</param>
+        /// <param name="args">List of field arguments used to parametrize resolve expression output.</param>
+        /// <param name="filter">A filter function which decides if the field should be published to clients or not, by returning it as Some or None.</param>
+        /// <param name="deprecationReason">Deprecation reason.</param>
+        static member SubscriptionField(name: string, rootdef: #OutputDef<'Root>, outputdef: #OutputDef<'Output>,
+                                        description: string,
+                                        args: InputFieldDef list,
+                                        [<ReflectedDefinition(true)>] filter: Expr<ResolveFieldContext -> 'Root -> 'Input -> 'Output option>,
+                                        deprecationReason : string): SubscriptionFieldDef<'Root, 'Input, 'Output> =
+            upcast { Name = name
+                     Description = Some description
+                     RootTypeDef = rootdef
+                     OutputTypeDef = outputdef
+                     DeprecationReason = Some deprecationReason
+                     Args = args |> List.toArray
+                     Filter = Resolve.Filter(typeof<'Root>, typeof<'Input>, typeof<'Output>, filter)
+                     Metadata = Metadata.Empty }
+
+        /// <summary>
+        /// Creates a subscription field inside object type, with asynchronously resolved value.
+        /// </summary>
+        /// <param name="name">Field name. Must be unique in scope of the defining object.</param>
+        /// <param name="rootdef">GraphQL type definition of the root field's type.</param>
+        /// <param name="outputdef">GraphQL type definition of the current field's type.</param>
+        /// <param name="filter">A filter function which decides if the field should be published to clients or not, by returning it as Some or None.</param>
         static member SubscriptionAsyncField(name: string, rootdef: #OutputDef<'Root>, outputdef: #OutputDef<'Output>,
                                              [<ReflectedDefinition(true)>] filter: Expr<ResolveFieldContext -> 'Root -> 'Input -> Async<'Output option>>): SubscriptionFieldDef<'Root, 'Input, 'Output> =
             upcast { Name = name
@@ -2901,6 +2925,14 @@ module SchemaDefinitions =
                      Filter = Resolve.AsyncFilter(typeof<'Root>, typeof<'Input>, typeof<'Output>, filter)
                      Metadata = Metadata.Empty }
 
+        /// <summary>
+        /// Creates a subscription field inside object type, with asynchronously resolved value.
+        /// </summary>
+        /// <param name="name">Field name. Must be unique in scope of the defining object.</param>
+        /// <param name="rootdef">GraphQL type definition of the root field's type.</param>
+        /// <param name="outputdef">GraphQL type definition of the current field's type.</param>
+        /// <param name="description">Optional field description. Usefull for generating documentation.</param>
+        /// <param name="filter">A filter function which decides if the field should be published to clients or not, by returning it as Some or None.</param>
         static member SubscriptionAsyncField(name: string, rootdef: #OutputDef<'Root>, outputdef: #OutputDef<'Output>,
                                              description: string,
                                              [<ReflectedDefinition(true)>] filter: Expr<ResolveFieldContext -> 'Root -> 'Input -> Async<'Output option>>): SubscriptionFieldDef<'Root, 'Input, 'Output> =
@@ -2913,6 +2945,15 @@ module SchemaDefinitions =
                      Filter = Resolve.AsyncFilter(typeof<'Root>, typeof<'Input>, typeof<'Output>, filter)
                      Metadata = Metadata.Empty }
 
+        /// <summary>
+        /// Creates a subscription field inside object type, with asynchronously resolved value.
+        /// </summary>
+        /// <param name="name">Field name. Must be unique in scope of the defining object.</param>
+        /// <param name="rootdef">GraphQL type definition of the root field's type.</param>
+        /// <param name="outputdef">GraphQL type definition of the current field's type.</param>
+        /// <param name="description">Optional field description. Usefull for generating documentation.</param>
+        /// <param name="args">List of field arguments used to parametrize resolve expression output.</param>
+        /// <param name="filter">A filter function which decides if the field should be published to clients or not, by returning it as Some or None.</param>
         static member SubscriptionAsyncField(name: string, rootdef: #OutputDef<'Root>, outputdef: #OutputDef<'Output>,
                                              description: string,
                                              args: InputFieldDef list,
@@ -2922,6 +2963,30 @@ module SchemaDefinitions =
                      RootTypeDef = rootdef
                      OutputTypeDef = outputdef
                      DeprecationReason = None
+                     Args = args |> List.toArray
+                     Filter = Resolve.AsyncFilter(typeof<'Root>, typeof<'Input>, typeof<'Output>, filter)
+                     Metadata = Metadata.Empty }
+
+        /// <summary>
+        /// Creates a subscription field inside object type, with asynchronously resolved value. Field is marked as deprecated.
+        /// </summary>
+        /// <param name="name">Field name. Must be unique in scope of the defining object.</param>
+        /// <param name="rootdef">GraphQL type definition of the root field's type.</param>
+        /// <param name="outputdef">GraphQL type definition of the current field's type.</param>
+        /// <param name="description">Optional field description. Usefull for generating documentation.</param>
+        /// <param name="args">List of field arguments used to parametrize resolve expression output.</param>
+        /// <param name="filter">A filter function which decides if the field should be published to clients or not, by returning it as Some or None.</param>
+        /// <param name="deprecationReason">Deprecation reason.</param>
+        static member SubscriptionAsyncField(name: string, rootdef: #OutputDef<'Root>, outputdef: #OutputDef<'Output>,
+                                             description: string,
+                                             args: InputFieldDef list,
+                                             [<ReflectedDefinition(true)>] filter: Expr<ResolveFieldContext -> 'Root -> 'Input -> Async<'Output option>>,
+                                             deprecationReason : string): SubscriptionFieldDef<'Root, 'Input, 'Output> =
+            upcast { Name = name
+                     Description = Some description
+                     RootTypeDef = rootdef
+                     OutputTypeDef = outputdef
+                     DeprecationReason = Some deprecationReason
                      Args = args |> List.toArray
                      Filter = Resolve.AsyncFilter(typeof<'Root>, typeof<'Input>, typeof<'Output>, filter)
                      Metadata = Metadata.Empty }

--- a/tests/FSharp.Data.GraphQL.Tests/FSharp.Data.GraphQL.Tests.fsproj
+++ b/tests/FSharp.Data.GraphQL.Tests/FSharp.Data.GraphQL.Tests.fsproj
@@ -39,6 +39,7 @@
     <Compile Include="LinqTests.fs" />
     <Compile Include="DeferredTests.fs" />
     <Compile Include="MiddlewaresTests.fs" />
+    <Compile Include="SubscriptionTests.fs" />
     <Compile Include="Program.fs" Condition=" '$(TargetFramework)' == 'netcoreapp2.0' " />
   </ItemGroup>
   <ItemGroup>

--- a/tests/FSharp.Data.GraphQL.Tests/SubscriptionTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/SubscriptionTests.fs
@@ -1,0 +1,135 @@
+module FSharp.Data.GraphQL.Tests.SubscriptionTests
+
+open System
+open Xunit
+open FSharp.Control
+open FSharp.Data.GraphQL
+open FSharp.Data.GraphQL.Parser
+open FSharp.Data.GraphQL.Execution
+open System.Threading
+open System.Collections.Concurrent
+open FSharp.Data.GraphQL.Types
+open FSharp.Data.GraphQL.Tests
+open FSharp.Data.GraphQL.Tests
+
+type Value =
+    { Id : int
+      mutable Data : string }
+
+type Root =
+    { ClientId : string }
+
+let ValueType =
+    Define.Object<Value>(
+        name = "Value", 
+        fieldsFn = fun () -> 
+        [
+            Define.Field("id", Int, (fun _ d -> d.Id))
+            Define.Field("data", String, (fun _ d -> d.Data)) 
+        ])
+
+let RootType =
+    Define.Object<Root>(
+        name = "Query",
+        description = "Root object",
+        isTypeOf = (fun o -> o :? Root),
+        fieldsFn = fun () -> [ Define.Field("clientId", String, (fun _ r -> r.ClientId)) ]
+    )
+
+let root = { ClientId = "5" }
+
+let values = [ { Id = 1; Data = "Value 1" }; { Id = 2; Data = "Value 2" } ]
+
+let Query = 
+    Define.Object<Root>(
+        name = "Query",
+        fieldsFn = fun () -> [ Define.Field("values", ListOf ValueType, (fun _ _ -> values)) ] )
+
+let SubscriptionField =
+    Define.SubscriptionField(
+        "updatedData", 
+        RootType, 
+        ValueType, 
+        "Get's updated data", 
+        [ Define.Input("id", String) ], 
+        fun ctx _ v -> if ctx.Arg("id") = v.Id then Some v else None)
+
+let AsyncSubscriptionField =
+    Define.SubscriptionAsyncField(
+        "updatedDataAsync", 
+        RootType, 
+        ValueType, 
+        "Get's updated data asynchronously on the server", 
+        [ Define.Input("id", String) ], 
+        fun ctx _ v -> async { return (if ctx.Arg("id") = v.Id then Some v else None) })
+
+let Subscription =
+    Define.SubscriptionObject<Root>(
+        name = "Subscription",
+            fields = [ SubscriptionField; AsyncSubscriptionField ])
+
+let schemaConfig = SchemaConfig.Default
+
+let updateValue id data =
+    let value = values |> List.find (fun x -> x.Id = id)
+    value.Data <- data
+    schemaConfig.SubscriptionProvider.Publish SubscriptionField value
+    schemaConfig.SubscriptionProvider.Publish AsyncSubscriptionField value
+
+let schema = Schema(Query, subscription = Subscription, config = schemaConfig)
+
+let executor = Executor(schema)
+
+[<Fact>]
+let ``Should be able to perform normal query in a schema with Subscriptions``() =
+    let expected =
+        NameValueLookup.ofList [
+            "values", upcast [ 
+                box <| NameValueLookup.ofList [
+                    "id", upcast 1
+                    "data", upcast "Value 1" 
+                ]
+                upcast NameValueLookup.ofList [
+                    "id", upcast 2
+                    "data", upcast "Value 2"
+                ]
+            ]
+        ]
+    let query = parse """{
+        values {
+            id
+            data
+        }
+    }"""
+    let result = executor.AsyncExecute(query) |> sync
+    match result with
+    | Direct (data, errors) ->
+        empty errors
+        data.["data"] |> equals (upcast expected)
+    | _ -> failwith "Expected Direct GQLResponse"
+
+[<Fact>]
+let ``Should be able to subscribe to sync field and get results``() =
+    let expected = NameValueLookup.ofList [
+        "id", upcast 1
+        "data", upcast "Value 1"
+    ]
+    let query = parse """"{
+            updatedData (id : 1) {
+                id
+                data
+            }
+        }"""
+    use mre = new ManualResetEvent(false)
+    let actual = ConcurrentBag<Output>()
+    let plan = executor.CreateExecutionPlan(query)
+    let result = executor.AsyncExecute(plan, data = root) |> sync
+    match result with
+    | Stream data ->
+        data |> Observable.add (fun x -> actual.Add(x); set mre)
+        wait mre "Timeout while waiting for Deferred GQLResponse"
+        actual
+        |> Seq.cast<NameValueLookup>
+        |> contains expected
+        |> ignore
+    | _ -> failwith "Expected Stream GQLResponse"

--- a/tests/FSharp.Data.GraphQL.Tests/SubscriptionTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/SubscriptionTests.fs
@@ -53,7 +53,7 @@ let SubscriptionField =
         fun ctx _ v -> if ctx.Arg("id") = v.Id then Some v else None)
 
 let AsyncSubscriptionField =
-    Define.SubscriptionAsyncField(
+    Define.AsyncSubscriptionField(
         "watchDataAsync", 
         RootType, 
         ValueType, 


### PR DESCRIPTION
With this PR, I am changing the `SubscriptionFieldDefinition` object to be able to have a generic typed output, making it not required to be a GraphQL type. This will be a breaking change on the filter function and the provider implementations as well, since the filter function now returns the output as an option instead of a boolean value.

Also, implementations for asynchronous subscriptions fields were made.