### PR TITLE
Changing subscription to delay async field evaluation to the last moment

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -27,3 +27,10 @@
 
 ### 0.0.4-beta01 - May 31 2018
 * Fix package dependency versions
+
+### 0.0.5-beta - August 10 2018
+* Upgraded dependencies on Newtonsoft.Json to the latest version.
+* Changing subscription field definitions to have a generic output type - the output is not required to be a GraphQL type anymore.
+* Implemented experimental support for @live directive, through a subscription system.
+* Fixed a bug that caused an exception when ToString function is called on an empty NameValueLookup.
+* Added support for asynchronous subscription field definitions.

--- a/src/FSharp.Data.GraphQL.Server/Execution.fs
+++ b/src/FSharp.Data.GraphQL.Server/Execution.fs
@@ -435,10 +435,10 @@ and buildObjectFields (fields: ExecutionInfo list) (objdef: ObjectDef) (ctx: Res
         | [] -> asyncVal { return ResolverObjectNode{ Name = name; Value = Some value; Children = acc |> List.rev |> List.toArray } }
     build [] fields
 
-let internal compileSubscriptionField (subfield: SubscriptionFieldDef) =
+let internal compileSubscriptionField (subfield: SubscriptionFieldDef) = 
     match subfield.Resolve with
-    | Resolve.BoxedFilterExpr(_, _, _, filter) -> filter
-    | Resolve.BoxedAsyncFilterExpr(_, _, _, filter) -> fun ctx a b -> filter ctx a b |> Async.RunSynchronously
+    | Resolve.BoxedFilterExpr(_, _, _, filter) -> fun ctx a b -> filter ctx a b |> AsyncVal.wrap
+    | Resolve.BoxedAsyncFilterExpr(_, _, _, filter) -> fun ctx a b -> filter ctx a b |> AsyncVal.ofAsync
     | _ -> raise <| GraphQLException ("Invalid filter expression for subscription field!")
 
 let internal compileField (fieldDef: FieldDef) : ExecuteField =

--- a/src/FSharp.Data.GraphQL.Server/Execution.fs
+++ b/src/FSharp.Data.GraphQL.Server/Execution.fs
@@ -437,8 +437,8 @@ and buildObjectFields (fields: ExecutionInfo list) (objdef: ObjectDef) (ctx: Res
 
 let internal compileSubscriptionField (subfield: SubscriptionFieldDef) = 
     match subfield.Resolve with
-    | Resolve.BoxedFilterExpr(_, _, _, filter) -> fun ctx a b -> filter ctx a b |> AsyncVal.wrap
-    | Resolve.BoxedAsyncFilterExpr(_, _, _, filter) -> fun ctx a b -> filter ctx a b |> AsyncVal.ofAsync
+    | Resolve.BoxedFilterExpr(_, _, _, filter) -> fun ctx a b -> filter ctx a b |> AsyncVal.wrap |> AsyncVal.toAsync
+    | Resolve.BoxedAsyncFilterExpr(_, _, _, filter) -> filter
     | _ -> raise <| GraphQLException ("Invalid filter expression for subscription field!")
 
 let internal compileField (fieldDef: FieldDef) : ExecuteField =

--- a/src/FSharp.Data.GraphQL.Server/ObservableExtensions.fs
+++ b/src/FSharp.Data.GraphQL.Server/ObservableExtensions.fs
@@ -26,4 +26,6 @@ module internal Observable =
     let choose (f: 'T -> 'U option) (o: IObservable<'T>): IObservable<'U> =
         o.Select(f).Where(Option.isSome).Select(Option.get)
 
-    let concat (os : IObservable<'T> seq) = Observable.Concat(os)
+    let concat (sources : IObservable<IObservable<'T>>) = Observable.Concat(sources)
+
+    let mapAsync f = Observable.map (fun x -> (ofAsync (f x))) >> concat

--- a/src/FSharp.Data.GraphQL.Server/Schema.fs
+++ b/src/FSharp.Data.GraphQL.Server/Schema.fs
@@ -38,7 +38,7 @@ type SchemaConfig =
                 match registeredSubscriptions.TryGetValue(subdef.Name) with
                 | true, (sub, channel) -> 
                     channel
-                    |> Observable.map(fun o -> sub.Filter ctx root o |> AsyncVal.get)
+                    |> Observable.mapAsync(fun o -> sub.Filter ctx root o)
                     |> Observable.choose(id)
                 | false, _ -> Observable.Empty()
 

--- a/src/FSharp.Data.GraphQL.Server/Schema.fs
+++ b/src/FSharp.Data.GraphQL.Server/Schema.fs
@@ -38,7 +38,7 @@ type SchemaConfig =
                 match registeredSubscriptions.TryGetValue(subdef.Name) with
                 | true, (sub, channel) -> 
                     channel
-                    |> Observable.map(fun o -> sub.Filter ctx root o)
+                    |> Observable.map(fun o -> sub.Filter ctx root o |> AsyncVal.get)
                     |> Observable.choose(id)
                 | false, _ -> Observable.Empty()
 

--- a/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
+++ b/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
@@ -283,7 +283,7 @@ type Subscription = {
     Name: string
     /// Filter function, used to determine what events we will propagate
     /// The 1st obj is the boxed root value, the second is the boxed value of the input object
-    Filter: (ResolveFieldContext -> obj -> obj -> AsyncVal<obj option>)
+    Filter: (ResolveFieldContext -> obj -> obj -> Async<obj option>)
 }
 
 /// Describes the backing implementation for a subscription system.

--- a/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
+++ b/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
@@ -283,7 +283,7 @@ type Subscription = {
     Name: string
     /// Filter function, used to determine what events we will propagate
     /// The 1st obj is the boxed root value, the second is the boxed value of the input object
-    Filter: (ResolveFieldContext -> obj -> obj -> obj option)
+    Filter: (ResolveFieldContext -> obj -> obj -> AsyncVal<obj option>)
 }
 
 /// Describes the backing implementation for a subscription system.


### PR DESCRIPTION
With this PR, I am fixing the subscription for asynchronous fields to be evaluated on the last moment.
Also, adding the release notes for 0.0.5-beta.