### PR TITLE
Pass subscription ident as string instead of subscription field

### DIFF
--- a/src/FSharp.Data.GraphQL.Samples.GiraffeServer/Schema.fs
+++ b/src/FSharp.Data.GraphQL.Samples.GiraffeServer/Schema.fs
@@ -199,19 +199,17 @@ module Schema =
                 Define.Field("droid", Nullable DroidType, "Gets droid", [ Define.Input("id", String) ], fun ctx _ -> getDroid (ctx.Arg("id")))
                 Define.Field("planet", Nullable PlanetType, "Gets planet", [ Define.Input("id", String) ], fun ctx _ -> getPlanet (ctx.Arg("id"))) ])
 
-    let SubscriptionField =
-        Define.SubscriptionField(
+    let Subscription =
+        Define.SubscriptionObject<Root>(
+            name = "Subscription",
+            fields = [
+                Define.SubscriptionField(
                     "watchMoon",
                     RootType,
                     PlanetType,
                     "Watches to see if a planet is a moon",
                     [ Define.Input("id", String) ],
-                    (fun ctx _ p -> if ctx.Arg("id") = p.Id then Some p else None))
-
-    let Subscription =
-        Define.SubscriptionObject<Root>(
-            name = "Subscription",
-            fields = [ SubscriptionField ])
+                    (fun ctx _ p -> if ctx.Arg("id") = p.Id then Some p else None)) ])
 
     let Mutation =
         Define.Object<Root>(
@@ -226,7 +224,7 @@ module Schema =
                         getPlanet (ctx.Arg("id"))
                         |> Option.map (fun x ->
                             x.SetMoon(Some(ctx.Arg("ismoon"))) |> ignore
-                            schemaConfig.SubscriptionProvider.Publish SubscriptionField x
+                            schemaConfig.SubscriptionProvider.Publish<Planet> "watchMoon" x
                             schemaConfig.LiveFieldSubscriptionProvider.Publish<Planet> "Planet" "ismoon" x
                             x))])
 

--- a/src/FSharp.Data.GraphQL.Server/Schema.fs
+++ b/src/FSharp.Data.GraphQL.Server/Schema.fs
@@ -42,8 +42,8 @@ type SchemaConfig =
                     |> Observable.choose(id)
                 | false, _ -> Observable.Empty()
 
-            member __.Publish (def: SubscriptionFieldDef<'Root, 'Input, 'Output>) (value: 'Input) =
-                match registeredSubscriptions.TryGetValue(def.Name) with
+            member __.Publish<'T> (name: string) (value: 'T) =
+                match registeredSubscriptions.TryGetValue(name) with
                 | true, (_, channel) -> channel.OnNext(box value)
                 | false, _ -> () }
 

--- a/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
+++ b/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
@@ -294,7 +294,7 @@ and ISubscriptionProvider =
         /// Creates an active subscription, and returns the IObservable stream of POCO objects that will be projected on
         abstract member Add : ResolveFieldContext -> obj -> SubscriptionFieldDef -> IObservable<obj>
         /// Publishes an event to the subscription system given the identifier of the subscription type
-        abstract member Publish : SubscriptionFieldDef<'Root, 'Input, 'Output> -> 'Input -> unit
+        abstract member Publish<'T> : string -> 'T -> unit
     end
 
 /// Represents a subscription of a field in a live query.

--- a/tests/FSharp.Data.GraphQL.Tests/SubscriptionTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/SubscriptionTests.fs
@@ -67,8 +67,8 @@ let updateValue id data =
     getValue id
     |> Option.map (fun value ->
         value.Data <- data
-        schemaConfig.SubscriptionProvider.Publish SubscriptionField value
-        schemaConfig.SubscriptionProvider.Publish AsyncSubscriptionField value)
+        schemaConfig.SubscriptionProvider.Publish "watchData" value
+        schemaConfig.SubscriptionProvider.Publish "watchDataAsync" value)
     |> ignore
 
 let Subscription =


### PR DESCRIPTION
Reverting changes made in #172 that required the subscription field def be provided as input to the ISubscriptionProvider.Publish method. Instead we favour passing in a string ident of the subscription field. The advantages of the change is it's consistent with the other APIs and does not require the user hold a reference to the subscription field. The one disadvantage is type-safety as the caller can pass the wrong type to the subscription filter. 
