### PR TITLE
Adding a scalar definition of Long  

### DIFF
--- a/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
+++ b/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
@@ -2443,6 +2443,15 @@ module SchemaDefinitions =
           CoerceInput = coerceIntInput
           CoerceValue = coerceIntValue }
 
+    /// GraphQL type of int
+    let Long : ScalarDefinition<int64> =
+        { Name = "Int64"
+          Description =
+              Some
+                  "The `Long` scalar type represents non-fractional signed whole numeric values. Long can represent values between -(2^63) and 2^63 - 1."
+          CoerceInput = coerceLongInput
+          CoerceValue = coerceLongValue }
+
     /// GraphQL type of boolean
     let Boolean : ScalarDefinition<bool> =
         { Name = "Boolean"

--- a/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
+++ b/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
@@ -2443,9 +2443,9 @@ module SchemaDefinitions =
           CoerceInput = coerceIntInput
           CoerceValue = coerceIntValue }
 
-    /// GraphQL type of int
+    /// GraphQL type of long
     let Long : ScalarDefinition<int64> =
-        { Name = "Int64"
+        { Name = "Long"
           Description =
               Some
                   "The `Long` scalar type represents non-fractional signed whole numeric values. Long can represent values between -(2^63) and 2^63 - 1."

--- a/tests/FSharp.Data.GraphQL.Tests/CoercionTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/CoercionTests.fs
@@ -36,6 +36,14 @@ let ``Float coerces input`` () =
     testCoercion Float 0. (BooleanValue false)
 
 [<Fact>]
+let ``Long coerces input`` () = 
+    testCoercion Long 123. (IntValue 123L)
+    testCoercion Long 123.4 (FloatValue 123.4)
+    testCoercion Long 123.4 (StringValue "123.4")
+    testCoercion Long 1. (BooleanValue true)
+    testCoercion Long 0. (BooleanValue false)
+
+[<Fact>]
 let ``Boolean coerces input`` () = 
     testCoercion Boolean true (IntValue 123L)
     testCoercion Boolean false (IntValue 0L)

--- a/tests/FSharp.Data.GraphQL.Tests/CoercionTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/CoercionTests.fs
@@ -17,6 +17,7 @@ let private testCoercion graphQLType (expected: 't) actual =
     let result = (scalar.CoerceInput actual) |> Option.map (fun x -> downcast x)
     match result with
     | Some x -> equals expected x
+    | None -> raise (Exception(sprintf "Expected %A to be able to be coerced to %A" actual expected))
     
 
 [<Fact>]
@@ -37,11 +38,11 @@ let ``Float coerces input`` () =
 
 [<Fact>]
 let ``Long coerces input`` () = 
-    testCoercion Long 123. (IntValue 123L)
-    testCoercion Long 123.4 (FloatValue 123.4)
-    testCoercion Long 123.4 (StringValue "123.4")
-    testCoercion Long 1. (BooleanValue true)
-    testCoercion Long 0. (BooleanValue false)
+    testCoercion Long 123L (IntValue 123L)
+    testCoercion Long 123L (FloatValue 123.4)
+    testCoercion Long 123L (StringValue "123")
+    testCoercion Long 1L (BooleanValue true)
+    testCoercion Long 0L (BooleanValue false)
 
 [<Fact>]
 let ``Boolean coerces input`` () = 


### PR DESCRIPTION
While reading the code I noticed there was existing long coercion functions. I've simply added a scalar definition of `Long` to expose these functions. 