### PR TITLE
Async versions of Register and Publish of subscription providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,10 +90,10 @@ and ILiveFieldSubscriptionProvider =
     interface
         abstract member HasSubscribers : string -> string -> bool
         abstract member IsRegistered : string -> string -> bool
-        abstract member Register : ILiveFieldSubscription -> unit
+        abstract member RegisterAsync : ILiveFieldSubscription -> Async<unit>
         abstract member TryFind : string -> string -> ILiveFieldSubscription option
         abstract member Add : obj -> string -> string -> IObservable<obj>
-        abstract member Publish<'T> : string -> string -> 'T -> unit
+        abstract member PublishAsync<'T> : string -> string -> 'T -> Async<unit>
     end
 ```
 

--- a/src/FSharp.Data.GraphQL.Server/Schema.fs
+++ b/src/FSharp.Data.GraphQL.Server/Schema.fs
@@ -60,10 +60,10 @@ type SchemaConfig =
             member __.IsRegistered (typeName : string) (fieldName : string) =
                 let key = typeName, fieldName
                 registeredSubscriptions.ContainsKey(key)
-            member __.Register (subscription : ILiveFieldSubscription) =
+            member __.RegisterAsync (subscription : ILiveFieldSubscription) = async {
                 let key = subscription.TypeName, subscription.FieldName
                 let value = subscription, new Subject<obj>()
-                registeredSubscriptions.Add(key, value)
+                registeredSubscriptions.Add(key, value) }
             member __.TryFind (typeName : string) (fieldName : string) =
                 let key = typeName, fieldName
                 match registeredSubscriptions.TryGetValue(key) with
@@ -74,11 +74,11 @@ type SchemaConfig =
                 match registeredSubscriptions.TryGetValue(key) with
                 | true, (sub, channel) -> channel |> Observable.filter (fun o -> sub.Identity o = identity)
                 | false, _ -> Observable.Empty()
-            member __.Publish<'T> (typeName : string) (fieldName : string) (value : 'T) =
+            member __.PublishAsync<'T> (typeName : string) (fieldName : string) (value : 'T) = async {
                 let key = typeName, fieldName
                 match registeredSubscriptions.TryGetValue(key) with
                 | true, (_, channel) -> channel.OnNext(box value)
-                | false, _ -> () }
+                | false, _ -> () } }
     /// Default SchemaConfig used by Schema when no config is provided.
     static member Default =
         { Types = []

--- a/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
+++ b/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
@@ -352,13 +352,13 @@ and ILiveFieldSubscriptionProvider =
         /// Checks if a type and a field is registered in the provider.
         abstract member IsRegistered : string -> string -> bool
         /// Registers a new live query subscription type, called at schema compilation time.
-        abstract member Register : ILiveFieldSubscription -> unit
+        abstract member RegisterAsync : ILiveFieldSubscription -> Async<unit>
         /// Tries to find a subscription based on the type name and field name.
         abstract member TryFind : string -> string -> ILiveFieldSubscription option
         /// Creates an active subscription, and returns the IObservable stream of POCO objects that will be projected on.
         abstract member Add : obj -> string -> string -> IObservable<obj>
         /// Publishes an event to the subscription system, given the key of the subscription type.
-        abstract member Publish<'T> : string -> string -> 'T -> unit
+        abstract member PublishAsync<'T> : string -> string -> 'T -> Async<unit>
     end
 
 /// Interface used for receiving information about a whole
@@ -1937,10 +1937,17 @@ and TypeMap() =
 module SubscriptionExtensions =
     type ISubscriptionProvider with
         member this.Register subscription =
-            this.RegisterAsync(subscription) |> Async.RunSynchronously
+            this.RegisterAsync subscription |> Async.RunSynchronously
 
         member this.Publish<'T> name subType =
             this.PublishAsync name subType |> Async.RunSynchronously
+
+    type ILiveFieldSubscriptionProvider with
+        member this.Register subscription =
+            this.RegisterAsync subscription |> Async.RunSynchronously
+
+        member this.Publish<'T> typeName fieldName subType =
+            this.PublishAsync typeName fieldName subType |> Async.RunSynchronously
 
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module Resolve =

--- a/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
+++ b/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
@@ -290,11 +290,11 @@ type Subscription = {
 and ISubscriptionProvider =
     interface
         /// Registers a new subscription type, called at schema compilation time.
-        abstract member Register: Subscription -> unit
+        abstract member RegisterAsync : Subscription -> Async<unit>
         /// Creates an active subscription, and returns the IObservable stream of POCO objects that will be projected on
         abstract member Add : ResolveFieldContext -> obj -> SubscriptionFieldDef -> IObservable<obj>
         /// Publishes an event to the subscription system given the identifier of the subscription type
-        abstract member Publish<'T> : string -> 'T -> unit
+        abstract member PublishAsync<'T> : string -> 'T -> Async<unit>
     end
 
 /// Represents a subscription of a field in a live query.
@@ -1572,20 +1572,24 @@ and [<CustomEquality; NoComparison>] InputFieldDefinition<'In> =
         hash
 
     override x.ToString() = x.Name + ": " + x.TypeDef.ToString()
+
 and SubscriptionFieldDef =
     interface
         abstract OutputTypeDef : OutputDef
         inherit FieldDef
     end
+
 and SubscriptionFieldDef<'Val> =
     interface
         inherit SubscriptionFieldDef
         inherit FieldDef<'Val>
     end
+
 and SubscriptionFieldDef<'Root, 'Input, 'Output> =
     interface
         inherit SubscriptionFieldDef<'Root>
     end
+
 and [<CustomEquality; NoComparison>] SubscriptionFieldDefinition<'Root, 'Input, 'Output> =
     {
         Name : string
@@ -1633,17 +1637,20 @@ and [<CustomEquality; NoComparison>] SubscriptionFieldDefinition<'Root, 'Input, 
         if not (Array.isEmpty x.Args)
         then x.Name + "(" + String.Join(", ", x.Args) + "): " + x.TypeDef.ToString()
         else x.Name + ": " + x.TypeDef.ToString()
+
 and SubscriptionObjectDef =
     interface
         abstract Fields : Map<string, SubscriptionFieldDef>
         inherit ObjectDef
     end
+
 and SubscriptionObjectDef<'Val> =
     interface
         inherit SubscriptionObjectDef
         abstract Fields : Map<string, SubscriptionFieldDef<'Val>>
         inherit ObjectDef<'Val>
     end
+
 and [<CustomEquality; NoComparison>] SubscriptionObjectDefinition<'Val> =
     {
         Name : string
@@ -1687,6 +1694,7 @@ and [<CustomEquality; NoComparison>] SubscriptionObjectDefinition<'Val> =
         hash
 
     override x.ToString() = x.Name + "!"
+
 /// GraphQL directive defintion.
 and DirectiveDef =
     { /// Directive's name - it's NOT '@' prefixed.
@@ -1924,6 +1932,15 @@ and TypeMap() =
         let map = TypeMap()
         defs |> Seq.iter (fun def -> map.AddType(def))
         map
+
+[<AutoOpen>]
+module SubscriptionExtensions =
+    type ISubscriptionProvider with
+        member this.Register subscription =
+            this.RegisterAsync(subscription) |> Async.RunSynchronously
+
+        member this.Publish<'T> name subType =
+            this.PublishAsync name subType |> Async.RunSynchronously
 
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module Resolve =


### PR DESCRIPTION
With this PR, I am changing `Register` and `Publish<'T>` methods of `ISubscriptionProvider` and `ILiveFieldSubscriptionProvider` to be asynchronous (also renaming them to have `Async` suffix). To maintain backwards compatibility for the sync methods, they are now extensions that runs their async versions synchronously.