### PR TITLE
Adding assembly redirect resolve inside type provider

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -70,7 +70,7 @@ module Util =
         // Use this in Windows to prevent conflicts with paths too long
         else run "." "cmd" ("/C rmdir /s /q " + Path.GetFullPath dir)
 
-    let compileScript symbols outDir fsxPath =
+    let compileScript symbols outDir (fsxPath : string) =
         let dllFile = Path.ChangeExtension(Path.GetFileName fsxPath, ".dll")
         let opts = [
             yield FscHelper.Out (Path.Combine(outDir, dllFile))

--- a/src/FSharp.Data.GraphQL.Client/GraphQlProvider.fs
+++ b/src/FSharp.Data.GraphQL.Client/GraphQlProvider.fs
@@ -178,7 +178,15 @@ type GraphQlProvider (config : TypeProviderConfig) as this =
 
     let asm = System.Reflection.Assembly.GetExecutingAssembly()
 
-    do
+    do 
+        System.AppDomain.CurrentDomain.add_AssemblyResolve(fun _ args ->
+            let name = System.Reflection.AssemblyName(args.Name)
+            let existingAssembly = 
+                System.AppDomain.CurrentDomain.GetAssemblies()
+                |> Seq.tryFind(fun a -> System.Reflection.AssemblyName.ReferenceMatchesDefinition(name, a.GetName()))
+            match existingAssembly with
+            | Some a -> a
+            | None -> null)
         let ns = "FSharp.Data.GraphQL"
         let generator = ProvidedTypeDefinition(asm, ns, "GraphQLProvider", Some typeof<obj>)
         let handleSchema typeName serverUrl choice =


### PR DESCRIPTION
With this PR, I am adding a routine to treat assembly redirects inside the GraphQL TypeProvider, so new versions of dependencies can be resolved at runtime.