### PR TITLE
Add subscription field to introspection schema

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -42,3 +42,6 @@
 ### 0.0.7-beta - September 17 2018
 * **Breaking Change:** Async Pub/Sub methods for subscription and live directive handler interfaces
 * Add Long Scalar definition
+
+### 0.0.8-beta - October 27 2018
+* Add subscription field to intospection schema

--- a/src/FSharp.Data.GraphQL.Server/Schema.fs
+++ b/src/FSharp.Data.GraphQL.Server/Schema.fs
@@ -259,7 +259,7 @@ type Schema<'Root> (query: ObjectDef<'Root>, ?mutation: ObjectDef<'Root>, ?subsc
             |> List.toArray
         { QueryType = Map.find query.Name inamed
           MutationType = mutation |> Option.map (fun m -> Map.find m.Name inamed)
-          SubscriptionType = None
+          SubscriptionType = subscription |> Option.map(fun s -> Map.find s.Name inamed)
           Types = itypes
           Directives = idirectives }
 


### PR DESCRIPTION
This is a minor change to add the subscription object to introspection schema.