### PR TITLE
Sub introspection

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -45,3 +45,9 @@
 
 ### 0.0.8-beta - October 27 2018
 * Add subscription field to intospection schema
+
+### 0.0.8-beta01 - October 28 2018
+* Add subscription field to intospection schema
+
+### 0.0.9 - November 2 2018
+* Fixed a bug where output def of a subscription field was not reachable for introspection.

--- a/build.fsx
+++ b/build.fsx
@@ -70,7 +70,7 @@ module Util =
         // Use this in Windows to prevent conflicts with paths too long
         else run "." "cmd" ("/C rmdir /s /q " + Path.GetFullPath dir)
 
-    let compileScript symbols outDir fsxPath =
+    let compileScript symbols outDir (fsxPath : string) =
         let dllFile = Path.ChangeExtension(Path.GetFileName fsxPath, ".dll")
         let opts = [
             yield FscHelper.Out (Path.Combine(outDir, dllFile))

--- a/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
+++ b/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
@@ -1782,6 +1782,15 @@ and TypeMap() =
             match def with
             | :? ScalarDef as sdef -> add sdef.Name def overwrite
             | :? EnumDef as edef -> add edef.Name def overwrite
+            | :? SubscriptionObjectDef as sdef ->
+                add sdef.Name def overwrite
+                sdef.Fields
+                |> Map.toSeq
+                |> Seq.map (fun x -> snd x :?> SubscriptionFieldDef)
+                |> Seq.collect (fun x -> Array.append [| x.OutputTypeDef :> TypeDef |] (x.Args |> Array.map (fun a -> upcast a.TypeDef)))
+                |> Seq.map(fun x -> match named x with Some n -> n | _ -> failwith "Expected a Named type!")
+                |> Seq.filter (fun x -> not (map.ContainsKey(x.Name)))
+                |> Seq.iter insert
             | :? ObjectDef as odef ->
                 add odef.Name def overwrite
                 odef.Fields


### PR DESCRIPTION
This fixes an issue where `OutputTypeDef` was not being added into the reachable types map and had to be manually added into SchemaConfig.Types.