### PR TITLE
Defer/Stream parallel issues

### DIFF
--- a/src/FSharp.Data.GraphQL.Server/Execution.fs
+++ b/src/FSharp.Data.GraphQL.Server/Execution.fs
@@ -661,8 +661,8 @@ let private executeQueryOrMutation (resultSet: (string * ExecutionInfo) []) (ctx
                     return 
                         provider.Add (identity value) typeName fieldName
                         |> Observable.map (fun v -> asyncVal {
-                            let tree = AsyncVal.get (buildResolverTree d.Info.ReturnDef fieldCtx fieldExecuteMap (Some v))
-                            let data, err = AsyncVal.get (treeToDict tree)
+                            let! tree = buildResolverTree d.Info.ReturnDef fieldCtx fieldExecuteMap (Some v)
+                            let! data, err = treeToDict tree
                             return mapResult data err path d.Kind } |> AsyncVal.toAsync |> Observable.ofAsync)
                         |> Observable.concat
                         |> Observable.toSeq

--- a/src/FSharp.Data.GraphQL.Server/Execution.fs
+++ b/src/FSharp.Data.GraphQL.Server/Execution.fs
@@ -297,20 +297,6 @@ let private foldChildren (children : AsyncVal<AsyncVal<KeyValuePair<string, obj>
         return c::kvps, e@errs
     }) (Value ([], []))
 
-let private treeToDict2 (tree : ResolverTree) =
-    tree
-    |> ResolverTree.pathFold
-        (fun _ leaf -> KeyValuePair<_,_>(leaf.Name, match leaf.Value with | Some v -> v | None -> null))
-        (fun _ error -> KeyValuePair<_,_>(error.Name, null))
-        (fun _ name value children ->
-            match value with
-            | Some _ -> KeyValuePair<_,_>(name, children |> Array.rev |> box)
-            | None -> KeyValuePair<_,_>(name, null))
-        (fun _ name value children ->
-            match value with
-            | Some _ -> KeyValuePair<_,_>(name, children |> Array.map(AsyncVal.map(fun d -> d.Value)) |> Array.rev |> box)
-            | None -> KeyValuePair<_,_>(name, null))
-
 let private treeToDict =
     ResolverTree.pathFold
         (fun _ leaf -> asyncVal { return KeyValuePair<_,_>(leaf.Name, match leaf.Value with | Some v -> v | None -> null), [] })

--- a/src/FSharp.Data.GraphQL.Server/Execution.fs
+++ b/src/FSharp.Data.GraphQL.Server/Execution.fs
@@ -711,20 +711,6 @@ let private executeQueryOrMutation (resultSet: (string * ExecutionInfo) []) (ctx
             |> Observable.bind Observable.ofSeq
             |> Observable.bind Observable.ofSeq
             |> Some
-            //resultTrees
-            //|> Array.map (AsyncVal.bind (fun tree ->
-            //    ctx.ExecutionPlan.DeferredFields
-            //    |> List.filter (fun d -> (List.head d.Path) = tree.Name)
-            //    |> List.toArray
-            //    |> Array.map (deferredResult tree)
-            //    |> AsyncVal.collectParallel
-            //    |> AsyncVal.map (Array.fold Array.append Array.empty)))
-            //|> AsyncVal.appendParallel
-            //|> AsyncVal.toAsync
-            //|> Observable.ofAsync
-            //|> Observable.bind Observable.ofSeq
-            //|> Observable.bind Observable.ofSeq
-            //|> Some
     dict, deferredResults
 
 let private executeSubscription (resultSet: (string * ExecutionInfo) []) (ctx: ExecutionContext) (objdef: SubscriptionObjectDef) (fieldExecuteMap: FieldExecuteMap) (subscriptionProvider: ISubscriptionProvider) value =

--- a/src/FSharp.Data.GraphQL.Server/Execution.fs
+++ b/src/FSharp.Data.GraphQL.Server/Execution.fs
@@ -668,8 +668,8 @@ let private executeQueryOrMutation (resultSet: (string * ExecutionInfo) []) (ctx
                 let resolver = resolveUnionType possibleTypesFn udef
                 match toOption value with
                 | Some v -> getObjectName (resolver v) value possibleTypesFn
-                | None -> failwithf "Unexpected value of returnDef: %O" returnDef
-            | _ -> failwithf "Unexpected value of returnDef: %O" returnDef
+                | None -> failwithf "Unexpected value of returnDef: %O." returnDef
+            | _ -> failwithf "Unexpected value of returnDef: %O." returnDef
         match d.Kind with
         | LiveExecution ->
             match tree with

--- a/src/FSharp.Data.GraphQL.Server/Execution.fs
+++ b/src/FSharp.Data.GraphQL.Server/Execution.fs
@@ -624,8 +624,7 @@ let private executeQueryOrMutation (resultSet: (string * ExecutionInfo) []) (ctx
     let mapSimple (d : KeyValuePair<string, obj>) (e : Error list) (path : obj list) =
         match d.Value, e with
         | null, [] -> Seq.empty
-        | :? IEnumerable<obj> as x, _ -> x |> Seq.mapi (fun i d -> nvli path i e d)
-        | x, _ -> nvl path e x |> Seq.singleton
+        | x, _ -> nvl path e [x] |> Seq.singleton
     let mapLiveResult (tree : ResolverTree) (path : obj list) (d : DeferredExecutionInfo) (fieldCtx : ResolveFieldContext) =
         let getFieldName (node : ResolverNode) =
             match node.Children |> Array.tryHead with

--- a/src/FSharp.Data.GraphQL.Server/Execution.fs
+++ b/src/FSharp.Data.GraphQL.Server/Execution.fs
@@ -547,7 +547,7 @@ let private executeQueryOrMutation (resultSet: (string * ExecutionInfo) []) (ctx
                     }
                 | [head'; String "__index"; head; String "__index"] as p, ResolverObjectNode n ->
                     asyncVal {
-                        let next = n.Children |> Array.map AsyncVal.get |> Array.tryFind(fun c' -> c'.Name = head.ToString())
+                        let! next = n.Children |> AsyncVal.collectParallel |> AsyncVal.map (Array.tryFind(fun c -> c.Name = head.ToString()))
                         let! res =
                             match next with
                             | Some next' -> traversePath d fieldCtx p (AsyncVal.wrap next') (head'::pathAcc)
@@ -557,7 +557,7 @@ let private executeQueryOrMutation (resultSet: (string * ExecutionInfo) []) (ctx
                 | p, ResolverObjectNode n ->
                     asyncVal {
                         let head = p |> List.head
-                        let next = n.Children |> Array.map AsyncVal.get |> Array.tryFind (fun c' -> c'.Name = head.ToString())
+                        let! next = n.Children |> AsyncVal.collectParallel |> AsyncVal.map (Array.tryFind (fun c -> c.Name = head.ToString()))
                         let! res =
                             match next with
                             | Some next' -> traversePath d fieldCtx p (AsyncVal.wrap next') (head::pathAcc)

--- a/src/FSharp.Data.GraphQL.Server/Execution.fs
+++ b/src/FSharp.Data.GraphQL.Server/Execution.fs
@@ -328,9 +328,13 @@ let private treeToStream =
         |> Observable.map (function 
             | ResolverListNode list -> 
                 list.Children
-                |> Array.map (AsyncVal.toAsync)
+                |> Array.mapi (fun i x -> 
+                    asyncVal {
+                        let! x' = x
+                        return i, x' 
+                    } |> AsyncVal.toAsync)
                 |> Observable.ofAsyncSeq
-                |> Observable.mapi (fun i t -> Some i, treeToDict t)
+                |> Observable.map (fun (i, t) -> Some i, treeToDict t)
             | other -> 
                 async { return None, treeToDict other } |> Observable.ofAsync)
         |> Observable.concat

--- a/src/FSharp.Data.GraphQL.Server/ObservableExtensions.fs
+++ b/src/FSharp.Data.GraphQL.Server/ObservableExtensions.fs
@@ -44,7 +44,7 @@ module internal Observable =
                         let! item' = item
                         observer.OnNext item'
                         lock lockObj checkCompleted
-                    } |> Async.Start
+                    } |> Async.StartAsTask |> ignore
                 items |> Seq.iter onNext
                 { new IDisposable with member __.Dispose() = () }
     }

--- a/src/FSharp.Data.GraphQL.Server/ObservableExtensions.fs
+++ b/src/FSharp.Data.GraphQL.Server/ObservableExtensions.fs
@@ -20,9 +20,6 @@ module internal Observable =
 
     let toSeq (o : IObservable<'T>) : 'T seq = Observable.ToEnumerable(o)
 
-    let mapi (fn : int -> 'T -> 'U) o =
-        toSeq o |> Seq.mapi fn |> ofSeq
-    
     let catch<'Item, 'Exception> (fx : Exception -> IObservable<'Item>) (obs : IObservable<'Item>) =
         obs.Catch(fx)
 

--- a/src/FSharp.Data.GraphQL.Server/ObservableExtensions.fs
+++ b/src/FSharp.Data.GraphQL.Server/ObservableExtensions.fs
@@ -19,6 +19,9 @@ module internal Observable =
     }
 
     let toSeq (o : IObservable<'T>) : 'T seq = Observable.ToEnumerable(o)
+
+    let mapi (fn : int -> 'T -> 'U) o =
+        toSeq o |> Seq.mapi fn |> ofSeq
     
     let catch<'Item, 'Exception> (fx : Exception -> IObservable<'Item>) (obs : IObservable<'Item>) =
         obs.Catch(fx)

--- a/tests/FSharp.Data.GraphQL.Tests/DeferredTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/DeferredTests.fs
@@ -1095,7 +1095,7 @@ let ``Union Defer and Stream`` () =
             actualDeferred |> single |> equals (upcast expectedDeferred)
         | _ -> fail "Expected Deferred GQLRespnse")
 
-[<Fact(Skip="Needs at least two cores to work, not consistent in CI">]
+[<Fact(Skip="Needs at least two cores to work, not consistent in CI")>]
 let ``Each deferred result should be sent as soon as it is computed``() =
     let expectedDirect =
         NameValueLookup.ofList [

--- a/tests/FSharp.Data.GraphQL.Tests/DeferredTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/DeferredTests.fs
@@ -1133,12 +1133,12 @@ let ``Each deferred result should be sent as soon as it is computed``() =
         empty errors
         data.["data"] |> equals (upcast expectedDirect)
         deferred |> Observable.add (fun x -> 
-            actualDeferred.Add(x)
+            if actualDeferred.Count < 2 then actualDeferred.Add(x)
             if actualDeferred.Count = 1 then mre1.Set() |> ignore
             if actualDeferred.Count = 2 then mre2.Set() |> ignore)
         // The second result is a delayed async field, which is set to compute the value for 3 seconds.
         // The first result should come almost instantly, as it is not a delayed computed field.
-        // Therefore, if it does not come in at least 2 seconds, we fail the test.
+        // Therefore, let's assume that if it does not come in at least 2 seconds, test has failed.
         if TimeSpan.FromSeconds(float 2) |> mre1.WaitOne |> not
         then fail "Timeout while waiting for first deferred result"
         if TimeSpan.FromSeconds(float 30) |> mre2.WaitOne |> not
@@ -1192,13 +1192,13 @@ let ``Each streamed result should be sent as soon as it is computed``() =
         empty errors
         data.["data"] |> equals (upcast expectedDirect)
         deferred |> Observable.add (fun x -> 
-            actualDeferred.Add(x)
+            if actualDeferred.Count < 2 then actualDeferred.Add(x)
             if actualDeferred.Count = 1 then mre1.Set() |> ignore
             if actualDeferred.Count = 2 then mre2.Set() |> ignore)
         // The second result is a delayed async field, which is set to compute the value for 3 seconds.
         // The first result should come almost instantly, as it is not a delayed computed field.
-        // Therefore, if it does not come in at least 2 seconds, we fail the test.
-        if TimeSpan.FromSeconds(float 2) |> mre1.WaitOne |> not
+        // Therefore, let's assume that if it does not come in at least 2 seconds, test has failed.
+        if TimeSpan.FromSeconds(float 10) |> mre1.WaitOne |> not
         then fail "Timeout while waiting for first deferred result"
         if TimeSpan.FromSeconds(float 30) |> mre2.WaitOne |> not
         then fail "Timeout while waiting for second deferred result"

--- a/tests/FSharp.Data.GraphQL.Tests/DeferredTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/DeferredTests.fs
@@ -178,9 +178,8 @@ let data = {
        ifaceList = [
             { D.id = "2000"; value = "D" }; { C.id = "3000"; value = "C2" }
        ]
-       delayed = { value = delay 5 "Delayed value" }
+       delayed = { value = delay 15 "Delayed value" }
        delayedList = [
-           //{ value = delay 5 "Delayed value 1" }
            { value = async { return "Delayed value 1" } }
            { value = delay 5 "Delayed value 2" }
        ]
@@ -1140,7 +1139,7 @@ let ``Each deferred result should be sent as soon as it is computed``() =
         // The second result is a delayed async field, which is set to compute the value for 5 seconds.
         // The first result should come almost instantly, as it is not a delayed computed field.
         // Therefore, let's assume that if it does not come in at least 4 seconds, test has failed.
-        if TimeSpan.FromSeconds(float 4) |> mre1.WaitOne |> not
+        if TimeSpan.FromSeconds(float 10) |> mre1.WaitOne |> not
         then fail "Timeout while waiting for first deferred result"
         if TimeSpan.FromSeconds(float 30) |> mre2.WaitOne |> not
         then fail "Timeout while waiting for second deferred result"

--- a/tests/FSharp.Data.GraphQL.Tests/DeferredTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/DeferredTests.fs
@@ -178,10 +178,11 @@ let data = {
        ifaceList = [
             { D.id = "2000"; value = "D" }; { C.id = "3000"; value = "C2" }
        ]
-       delayed = { value = delay 3 "Delayed value" }
+       delayed = { value = delay 5 "Delayed value" }
        delayedList = [
+           //{ value = delay 5 "Delayed value 1" }
            { value = async { return "Delayed value 1" } }
-           { value = delay 3 "Delayed value 2" }
+           { value = delay 5 "Delayed value 2" }
        ]
    }
 
@@ -1136,10 +1137,10 @@ let ``Each deferred result should be sent as soon as it is computed``() =
             if actualDeferred.Count < 2 then actualDeferred.Add(x)
             if actualDeferred.Count = 1 then mre1.Set() |> ignore
             if actualDeferred.Count = 2 then mre2.Set() |> ignore)
-        // The second result is a delayed async field, which is set to compute the value for 3 seconds.
+        // The second result is a delayed async field, which is set to compute the value for 5 seconds.
         // The first result should come almost instantly, as it is not a delayed computed field.
-        // Therefore, let's assume that if it does not come in at least 2 seconds, test has failed.
-        if TimeSpan.FromSeconds(float 2) |> mre1.WaitOne |> not
+        // Therefore, let's assume that if it does not come in at least 4 seconds, test has failed.
+        if TimeSpan.FromSeconds(float 4) |> mre1.WaitOne |> not
         then fail "Timeout while waiting for first deferred result"
         if TimeSpan.FromSeconds(float 30) |> mre2.WaitOne |> not
         then fail "Timeout while waiting for second deferred result"
@@ -1195,10 +1196,10 @@ let ``Each streamed result should be sent as soon as it is computed``() =
             if actualDeferred.Count < 2 then actualDeferred.Add(x)
             if actualDeferred.Count = 1 then mre1.Set() |> ignore
             if actualDeferred.Count = 2 then mre2.Set() |> ignore)
-        // The second result is a delayed async field, which is set to compute the value for 3 seconds.
+        // The second result is a delayed async field, which is set to compute the value for 5 seconds.
         // The first result should come almost instantly, as it is not a delayed computed field.
-        // Therefore, let's assume that if it does not come in at least 2 seconds, test has failed.
-        if TimeSpan.FromSeconds(float 2) |> mre1.WaitOne |> not
+        // Therefore, let's assume that if it does not come in at least 4 seconds, test has failed.
+        if TimeSpan.FromSeconds(float 4) |> mre1.WaitOne |> not
         then fail "Timeout while waiting for first deferred result"
         if TimeSpan.FromSeconds(float 30) |> mre2.WaitOne |> not
         then fail "Timeout while waiting for second deferred result"

--- a/tests/FSharp.Data.GraphQL.Tests/DeferredTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/DeferredTests.fs
@@ -316,7 +316,9 @@ let ``Resolver list error`` () =
         empty errors
         data.["data"] |> equals (upcast expectedDirect)
         deferred
-        |> Observable.add (fun x -> actualDeferred.Add(x); set mre)
+        |> Observable.add (fun x -> 
+            actualDeferred.Add(x)
+            if actualDeferred.Count = 2 then set mre)
         wait mre "Timeout while waiting for Deferred GQLResponse"
         actualDeferred
         |> Seq.cast<NameValueLookup>

--- a/tests/FSharp.Data.GraphQL.Tests/DeferredTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/DeferredTests.fs
@@ -1095,7 +1095,7 @@ let ``Union Defer and Stream`` () =
             actualDeferred |> single |> equals (upcast expectedDeferred)
         | _ -> fail "Expected Deferred GQLRespnse")
 
-[<Fact(Skip = "Not working on CI, investigate the cause of it")>]
+[<Fact>]
 let ``Each deferred result should be sent as soon as it is computed``() =
     let expectedDirect =
         NameValueLookup.ofList [

--- a/tests/FSharp.Data.GraphQL.Tests/DeferredTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/DeferredTests.fs
@@ -1095,7 +1095,7 @@ let ``Union Defer and Stream`` () =
             actualDeferred |> single |> equals (upcast expectedDeferred)
         | _ -> fail "Expected Deferred GQLRespnse")
 
-[<Fact>]
+[<Fact(Skip="Needs at least two cores to work, not consistent in CI">]
 let ``Each deferred result should be sent as soon as it is computed``() =
     let expectedDirect =
         NameValueLookup.ofList [

--- a/tests/FSharp.Data.GraphQL.Tests/DeferredTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/DeferredTests.fs
@@ -1095,7 +1095,7 @@ let ``Union Defer and Stream`` () =
             actualDeferred |> single |> equals (upcast expectedDeferred)
         | _ -> fail "Expected Deferred GQLRespnse")
 
-[<Fact>]
+[<Fact(Skip = "Not working on CI, investigate the cause of it")>]
 let ``Each deferred result should be sent as soon as it is computed``() =
     let expectedDirect =
         NameValueLookup.ofList [

--- a/tests/FSharp.Data.GraphQL.Tests/DeferredTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/DeferredTests.fs
@@ -1198,7 +1198,7 @@ let ``Each streamed result should be sent as soon as it is computed``() =
         // The second result is a delayed async field, which is set to compute the value for 3 seconds.
         // The first result should come almost instantly, as it is not a delayed computed field.
         // Therefore, let's assume that if it does not come in at least 2 seconds, test has failed.
-        if TimeSpan.FromSeconds(float 10) |> mre1.WaitOne |> not
+        if TimeSpan.FromSeconds(float 2) |> mre1.WaitOne |> not
         then fail "Timeout while waiting for first deferred result"
         if TimeSpan.FromSeconds(float 30) |> mre2.WaitOne |> not
         then fail "Timeout while waiting for second deferred result"

--- a/tests/FSharp.Data.GraphQL.Tests/Helpers.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/Helpers.fs
@@ -35,7 +35,7 @@ let sync = Async.RunSynchronously
 let is<'t> (o: obj) = o :? 't
 let hasError errMsg (errors: Error seq) =
     let containsMessage = errors |> Seq.exists (fun (message, _) -> message.Contains(errMsg))
-    Assert.True (containsMessage, sprintf "expected to contain message '%s', but no such message was found. Messages found: %A" errMsg errors)
+    Assert.True (containsMessage, sprintf "Expected to contain message '%s', but no such message was found. Messages found: %A" errMsg errors)
 let (<??) opt other =
     match opt with
     | None -> Some other
@@ -44,6 +44,11 @@ let undefined (value: 't) =
     Assert.True((value = Unchecked.defaultof<'t>), sprintf "Expected value to be undefined, but was: %A" value)
 let contains (expected : 'a) (xs : 'a seq) =
     Assert.Contains(expected, xs); xs
+let itemEquals (index : int) (expected : 'a) (xs : 'a seq) =
+    match xs |> Seq.tryItem index with
+    | Some item -> item |> equals expected
+    | None -> fail <| sprintf "Expected sequence to contain item at index %i, but sequence does not contain enough elements" index
+    xs
 
 let greaterThanOrEqual expected actual =
     Assert.True(actual >= expected, sprintf "Expected value to be greather than or equal to %A, but was: %A" expected actual)


### PR DESCRIPTION
A deferred result or streamed result item should be sent as soon as it finishes processing (resolver function applies). This PR means to fix those issues.

- [x] Validation tests
- [x] When having more than one deferred/streamed field, each field should be deferred/streamed as soon as it finishes computing
- [x] When having a streamed field, each list item should be returned as soon as it finishes computing