### PR TITLE
Defer fixes #2

### DIFF
--- a/src/FSharp.Data.GraphQL.Server/Execution.fs
+++ b/src/FSharp.Data.GraphQL.Server/Execution.fs
@@ -587,7 +587,7 @@ let private executeQueryOrMutation (resultSet: (string * ExecutionInfo) []) (ctx
                     return k::kvps, e@errs}) (Value ([],[]))
             return NameValueLookup(dicts |> List.rev |> List.toArray), (errors |> List.rev)
         }
-    let rec traversePath (d : DeferredExecutionInfo) (fieldCtx : ResolveFieldContext) (path: obj list) (tree: ResolverTree) (pathAcc: obj list) : AsyncVal<IObservable<ResolverTree * obj list>> =
+    let rec traversePath (d : DeferredExecutionInfo) (fieldCtx : ResolveFieldContext) (path: obj list) (tree: ResolverTree) (pathAcc: obj list) : IObservable<ResolverTree * obj list> =
         let removeDuplicatedIndexes (path : obj list) =
             let value = Some ("__index" :> obj)
             let rec remove (path : obj list) last =
@@ -602,54 +602,44 @@ let private executeQueryOrMutation (resultSet: (string * ExecutionInfo) []) (ctx
             | xs -> List.tail xs
         match path', tree with
         | [], t ->
-            asyncVal {
-                let! res = buildResolverTree d.Info.ReturnDef fieldCtx fieldExecuteMap t.Value
+            buildResolverTree d.Info.ReturnDef fieldCtx fieldExecuteMap t.Value
+            |> AsyncVal.map (fun res ->
                 match d.Info.Kind with
-                | SelectFields [f] -> return! async { return [|res, List.rev (box f.Identifier :: pathAcc)|] |> Observable.ofSeq }
-                | _ -> return! async { return [|res, List.rev pathAcc|] |> Observable.ofSeq }
-            }
+                | SelectFields [f] -> [|res, List.rev (box f.Identifier :: pathAcc)|]
+                | _ -> [|res, List.rev pathAcc|])
+            |> Observable.ofAsyncVal
+            |> Observable.concatSeq
         | [String p], t ->
-            asyncVal {
-                let! res = buildResolverTree d.Info.ReturnDef fieldCtx fieldExecuteMap t.Value
+            buildResolverTree d.Info.ReturnDef fieldCtx fieldExecuteMap t.Value
+            |> AsyncVal.map (fun res ->
                 match res with
-                | ResolverError _ -> return! async { return [||] |> Observable.ofSeq } // A deferred fragment that was not found, just ignore it
-                | _ -> return! async { return [|res, List.rev((p :> obj)::pathAcc)|] |> Observable.ofSeq }
-            }
+                | ResolverError _ -> [||] // A deferred fragment that was not found, just ignore it
+                | _ -> [|res, List.rev((p :> obj)::pathAcc)|])
+            |> Observable.ofAsyncVal
+            |> Observable.concatSeq
         | ([p; String "__index"] | [p]), t ->
-            asyncVal {
-                let! res = buildResolverTree d.Info.ReturnDef fieldCtx fieldExecuteMap t.Value
-                return! async { return [|res, List.rev(p::pathAcc)|] |> Observable.ofSeq }
-            }
+            buildResolverTree d.Info.ReturnDef fieldCtx fieldExecuteMap t.Value
+            |> AsyncVal.map (fun res -> [|res, List.rev(p::pathAcc)|])
+            |> Observable.ofAsyncVal
+            |> Observable.concatSeq
         | [head'; String "__index"; head; String "__index"] as p, ResolverObjectNode n ->
-            asyncVal {
-                let! next = n.Children |> AsyncVal.collectParallel |> AsyncVal.map (Array.tryFind(fun c -> c.Name = head.ToString()))
-                let! res =
-                    match next with
-                    | Some next' -> traversePath d fieldCtx p next' (head'::pathAcc)
-                    | None -> AsyncVal.empty
-                return res
-            }
+            n.Children
+            |> Observable.ofAsyncValSeq
+            |> Observable.filter (fun c -> c.Name = head.ToString())
+            |> Observable.bind (fun next -> traversePath d fieldCtx p next (head'::pathAcc))
         | p, ResolverObjectNode n ->
-            asyncVal {
-                let head = p |> List.head
-                let! next = n.Children |> AsyncVal.collectParallel |> AsyncVal.map (Array.tryFind (fun c -> c.Name = head.ToString()))
-                let! res =
-                    match next with
-                    | Some next' -> traversePath d fieldCtx p next' (head::pathAcc)
-                    | None -> AsyncVal.empty
-                return res
-            }
+            let head = p |> List.head
+            n.Children
+            |> Observable.ofAsyncValSeq
+            |> Observable.filter (fun c -> c.Name = head.ToString())
+            |> Observable.bind (fun next -> traversePath d fieldCtx p next (head::pathAcc))
         | p, ResolverListNode l ->
-            asyncVal {
-                let res =
-                    l.Children
-                    |> Seq.mapi (fun i c -> asyncVal { 
-                        let! c' = c
-                        return! traversePath d fieldCtx p c' ((box i)::pathAcc) })
-                    |> Observable.ofAsyncValSeq
-                    |> Observable.merge
-                return res
-            }
+            l.Children
+            |> Seq.mapi (fun i c -> asyncVal { 
+                let! c' = c
+                return i, c' })
+            |> Observable.ofAsyncValSeq
+            |> Observable.bind (fun (i, c) -> traversePath d fieldCtx p c ((box i)::pathAcc))
         | _ ,_ -> raise <| GraphQLException("Path terminated unexpectedly!")
     let bnvli (path : obj list) (indexes : int list) (err : Error list) (data : obj list) =
         match err with
@@ -750,7 +740,7 @@ let private executeQueryOrMutation (resultSet: (string * ExecutionInfo) []) (ctx
             | [] -> [box fdef.Name]
             | xs -> [List.head xs]
         traversePath d fieldCtx path tree head
-        |> AsyncVal.map (Observable.bind (fun (tree, path) ->
+        |> Observable.bind (fun (tree, path) ->
             let outerResult =
                 let deferred = 
                     match d.Kind with
@@ -775,7 +765,7 @@ let private executeQueryOrMutation (resultSet: (string * ExecutionInfo) []) (ctx
                     let fieldCtx = { fieldCtx with ExecutionInfo = d.Info }
                     let path = d.Path |> List.rev |> List.map box
                     traversePath d fieldCtx path tree [List.head path]
-                    |> AsyncVal.map (Observable.bind (fun (tree, path) ->
+                    |> Observable.bind (fun (tree, path) ->
                         let deferred =
                             match d.Kind with
                             | LiveExecution -> Observable.empty
@@ -801,13 +791,9 @@ let private executeQueryOrMutation (resultSet: (string * ExecutionInfo) []) (ctx
                             |> Observable.ofAsyncVal
                             |> Observable.concatSeq
                         Observable.merge2 deferred live))
-                    |> Observable.ofAsyncVal
-                    |> Observable.merge)
                 |> Observable.ofSeq
                 |> Observable.merge
-            Observable.merge2 outerResult innerResult))
-        |> Observable.ofAsyncVal
-        |> Observable.merge
+            Observable.merge2 outerResult innerResult)
     let deferredResults =
         if ctx.ExecutionPlan.DeferredFields.Length = 0
         then None

--- a/src/FSharp.Data.GraphQL.Server/Execution.fs
+++ b/src/FSharp.Data.GraphQL.Server/Execution.fs
@@ -779,7 +779,7 @@ let private executeQueryOrMutation (resultSet: (string * ExecutionInfo) []) (ctx
                 d.DeferredFields
                 |> List.map (fun d ->
                     let fieldCtx = { fieldCtx with ExecutionInfo = d.Info }
-                    let path = d.Path |> List.rev |> List.map (fun x -> x :> obj)
+                    let path = d.Path |> List.rev |> List.map box
                     traversePath d fieldCtx path (AsyncVal.wrap tree) [ List.head path ]
                     |> AsyncVal.bind(Array.map(fun (tree, path) -> asyncVal {
                         let deferred =

--- a/src/FSharp.Data.GraphQL.Server/Execution.fs
+++ b/src/FSharp.Data.GraphQL.Server/Execution.fs
@@ -768,8 +768,7 @@ let private executeQueryOrMutation (resultSet: (string * ExecutionInfo) []) (ctx
                             |> Observable.toSeq
                         | DeferredExecution -> 
                             treeToDict tree
-                            |> AsyncVal.toAsync
-                            |> Observable.ofAsync
+                            |> Observable.ofAsyncVal
                             |> Observable.map (fun (data, err) -> mapDefer data err path)
                             |> Observable.concatSeq
                             |> Observable.toSeq
@@ -869,8 +868,7 @@ let private executeSubscription (resultSet: (string * ExecutionInfo) []) (ctx: E
             match err with
             | [] -> NameValueLookup.ofList["data", box output] :> Output
             | _ -> NameValueLookup.ofList["data", box output; "errors", upcast (formatErrors err)] :> Output)
-        |> AsyncVal.toAsync
-        |> Observable.ofAsync)
+        |> Observable.ofAsyncVal)
 
 let private compileInputObject (indef: InputObjectDef) =
     indef.Fields

--- a/src/FSharp.Data.GraphQL.Server/ObservableExtensions.fs
+++ b/src/FSharp.Data.GraphQL.Server/ObservableExtensions.fs
@@ -61,3 +61,5 @@ module internal Observable =
         items |> Seq.map ofAsyncVal |> Observable.Merge
 
     let empty<'T> = Seq.empty<'T> |> ofSeq
+
+    let singleton (item : 'T) = item |> Seq.singleton |> ofSeq

--- a/src/FSharp.Data.GraphQL.Server/ObservableExtensions.fs
+++ b/src/FSharp.Data.GraphQL.Server/ObservableExtensions.fs
@@ -48,6 +48,8 @@ module internal Observable =
 
     let merge (sources : IObservable<IObservable<'T>>) = Observable.Merge(sources)
 
+    let merge2 (source1 : IObservable<'T>) (source2 : IObservable<'T>) = Observable.Merge(source1, source2)
+
     let concatSeq (source : IObservable<#seq<'T>>) = source |> bind ofSeq
 
     let mapAsync f = Observable.map (fun x -> (ofAsync (f x))) >> concat
@@ -57,3 +59,5 @@ module internal Observable =
 
     let ofAsyncValSeq (items : AsyncVal<'Item> seq) =
         items |> Seq.map ofAsyncVal |> Observable.Merge
+
+    let empty<'T> = Seq.empty<'T> |> ofSeq

--- a/src/FSharp.Data.GraphQL.Server/ObservableExtensions.fs
+++ b/src/FSharp.Data.GraphQL.Server/ObservableExtensions.fs
@@ -61,5 +61,3 @@ module internal Observable =
         items |> Seq.map ofAsyncVal |> Observable.Merge
 
     let empty<'T> = Seq.empty<'T> |> ofSeq
-
-    let singleton (item : 'T) = item |> Seq.singleton |> ofSeq

--- a/tests/FSharp.Data.GraphQL.Tests/DeferredTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/DeferredTests.fs
@@ -1619,8 +1619,8 @@ let ``Each deferred result of a list should be sent as soon as it is computed`` 
         // The first result is a delayed async field, which is set to compute the value for 5 seconds.
         // The second result should come first, almost instantly, as it is not a delayed computed field.
         // Therefore, let's assume that if it does not come in at least 4 seconds, test has failed.
-        // if TimeSpan.FromSeconds(float 4) |> mre1.WaitOne |> not
-        // then fail "Timeout while waiting for first deferred result"
+        if TimeSpan.FromSeconds(float 4) |> mre1.WaitOne |> not
+        then fail "Timeout while waiting for first deferred result"
         if TimeSpan.FromSeconds(float 30) |> mre2.WaitOne |> not
         then fail "Timeout while waiting for second deferred result"
         actualDeferred

--- a/tests/FSharp.Data.GraphQL.Tests/DeferredTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/DeferredTests.fs
@@ -1383,8 +1383,8 @@ let ``Should buffer stream list correctly by count information``() =
             if actualDeferred.Count < 2 then actualDeferred.Add(x)
             if actualDeferred.Count = 1 then mre1.Set() |> ignore
             if actualDeferred.Count = 2 then mre2.Set() |> ignore)
-        //if TimeSpan.FromSeconds(float 4) |> mre1.WaitOne |> not
-        //then fail "Timeout while waiting for first Deferred GQLResponse"
+        if TimeSpan.FromSeconds(float 4) |> mre1.WaitOne |> not
+        then fail "Timeout while waiting for first Deferred GQLResponse"
         if TimeSpan.FromSeconds(float 30) |> mre2.WaitOne |> not
         then fail "Timeout while waiting for second Deferred GQLResponse"
         actualDeferred

--- a/tests/FSharp.Data.GraphQL.Tests/DeferredTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/DeferredTests.fs
@@ -656,6 +656,7 @@ let ``Each live result should be sent as soon as it is computed`` () =
             if actualDeferred.Count < 2 then actualDeferred.Add(x)
             if actualDeferred.Count = 1 then mre1.Set() |> ignore
             if actualDeferred.Count = 2 then mre2.Set() |> ignore)
+        waitFor hasSubscribers 10 "Timeout while waiting for subscribers on GQLResponse"
         updateLiveData ()
         // The second result is a delayed async field, which is set to compute the value for 5 seconds.
         // The first result should come as soon as the live value is updated, which sould be almost instantly.

--- a/tests/FSharp.Data.GraphQL.Tests/Helpers.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/Helpers.fs
@@ -117,8 +117,3 @@ let rec ensureThat (condition : unit -> bool) (times : int) errorMsg =
     then fail errorMsg
     elif times > 0
     then ensureThat condition (times - 1) errorMsg
-
-[<RequireQualifiedAccess>]
-module Observable =
-    let addLocked lockObj (callback : 'T -> unit) source =
-        source |> Observable.add (fun x -> lock lockObj (fun () -> callback x))


### PR DESCRIPTION
This PR is meant to solve an issue where deferred items of a list are being returned sequentially. The solution makes them being returned out-of-order, based on item computation time: items are processed in parallel, each one being returned as soon as it is computed. However, the original index of the item is returned based on the order of the original list.