### PR TITLE
Defer adjusts 3

### DIFF
--- a/src/FSharp.Data.GraphQL.Server/ObservableExtensions.fs
+++ b/src/FSharp.Data.GraphQL.Server/ObservableExtensions.fs
@@ -38,8 +38,8 @@ module internal Observable =
         let span = TimeSpan.FromMilliseconds(float ms)
         Observable.Buffer(x, span, count) |> Observable.map List.ofSeq
 
-    let catch<'Item, 'Exception> (fx : Exception -> IObservable<'Item>) (obs : IObservable<'Item>) =
-        obs.Catch(fx)
+    let catch<'Item, 'Exception when 'Exception :> exn> (fx : 'Exception -> IObservable<'Item>) (obs : IObservable<'Item>) =
+        obs.Catch<'Item, 'Exception>(Func<'Exception, IObservable<'Item>>(fx))
 
     let choose (f: 'T -> 'U option) (o: IObservable<'T>): IObservable<'U> =
         o.Select(f).Where(Option.isSome).Select(Option.get)

--- a/src/FSharp.Data.GraphQL.Server/ObservableExtensions.fs
+++ b/src/FSharp.Data.GraphQL.Server/ObservableExtensions.fs
@@ -46,6 +46,8 @@ module internal Observable =
 
     let concat (sources : IObservable<IObservable<'T>>) = Observable.Concat(sources)
 
+    let concat2 (source1 : IObservable<'T>) (source2 : IObservable<'T>) = Observable.Concat(source1, source2)
+
     let merge (sources : IObservable<IObservable<'T>>) = Observable.Merge(sources)
 
     let merge2 (source1 : IObservable<'T>) (source2 : IObservable<'T>) = Observable.Merge(source1, source2)

--- a/src/FSharp.Data.GraphQL.Server/ObservableExtensions.fs
+++ b/src/FSharp.Data.GraphQL.Server/ObservableExtensions.fs
@@ -5,12 +5,6 @@ open System.Reactive.Linq
 
 /// Extension methods to observable, used in place of FSharp.Control.Observable
 module internal Observable =
-    let bind (f : 'T -> IObservable<'U>) (o : IObservable<'T>) = o.SelectMany(f)
-
-    let ofAsync x = Observable.FromAsync(fun ct -> Async.StartAsTask(x, cancellationToken = ct))
-
-    let ofAsyncVal x = x |> AsyncVal.toAsync |> ofAsync
-
     let ofSeq<'Item> (items : 'Item seq) = {
         new IObservable<'Item> with
             member __.Subscribe(observer) =
@@ -18,6 +12,12 @@ module internal Observable =
                 observer.OnCompleted()
                 { new IDisposable with member __.Dispose() = () }
     }
+
+    let bind (f : 'T -> IObservable<'U>) (o : IObservable<'T>) = o.SelectMany(f)
+
+    let ofAsync x = Observable.FromAsync(fun ct -> Async.StartAsTask(x, cancellationToken = ct))
+
+    let ofAsyncVal x = x |> AsyncVal.toAsync |> ofAsync
 
     let toSeq (o : IObservable<'T>) : 'T seq = Observable.ToEnumerable(o)
 

--- a/src/FSharp.Data.GraphQL.Server/ObservableExtensions.fs
+++ b/src/FSharp.Data.GraphQL.Server/ObservableExtensions.fs
@@ -63,3 +63,5 @@ module internal Observable =
         items |> Seq.map ofAsyncVal |> Observable.Merge
 
     let empty<'T> = Seq.empty<'T> |> ofSeq
+
+    let singleton (value : 'T) = Seq.singleton value |> ofSeq

--- a/tests/FSharp.Data.GraphQL.Tests/DeferredTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/DeferredTests.fs
@@ -272,17 +272,14 @@ let ``Resolver error`` () =
             }
         }
     }"""
-    use mre = new ManualResetEvent(false)
-    let actualDeferred = ConcurrentBag<Output>()
     let result = query |> executor.AsyncExecute |> sync
     match result with
     | Deferred(data, errors, deferred) ->
         empty errors
         data.["data"] |> equals (upcast expectedDirect)
-        deferred
-        |> Observable.add (fun x -> actualDeferred.Add(x); set mre)
-        wait mre "Timeout while waiting for Deferred GQLResponse"
-        actualDeferred |> single |> equals (upcast expectedDeferred)
+        use sub = Observer.create deferred
+        sub.WaitCompleted()
+        sub.Received |> single |> equals (upcast expectedDeferred)
     | _ -> fail "Expected Deferred GQLResponse"
 
 [<Fact>]
@@ -322,19 +319,14 @@ let ``Resolver list error`` () =
             }
         }
     }"""
-    use mre = new ManualResetEvent(false)
-    let actualDeferred = ConcurrentBag<Output>()
     let result = query |> executor.AsyncExecute |> sync
     match result with
     | Deferred(data, errors, deferred) ->
         empty errors
         data.["data"] |> equals (upcast expectedDirect)
-        deferred
-        |> Observable.add (fun x -> 
-            actualDeferred.Add(x)
-            if actualDeferred.Count = 2 then set mre)
-        wait mre "Timeout while waiting for Deferred GQLResponse"
-        actualDeferred
+        use sub = Observer.create deferred
+        sub.WaitCompleted(2)
+        sub.Received
         |> Seq.cast<NameValueLookup>
         |> contains expectedDeferred1
         |> contains expectedDeferred2
@@ -369,17 +361,14 @@ let ``Nullable error`` () =
             }
         }
     }"""
-    use mre = new ManualResetEvent(false)
-    let actualDeferred = ConcurrentBag<Output>()
     let result = query |> executor.AsyncExecute |> sync
     match result with
     | Deferred(data, errors, deferred) ->
         empty errors
         data.["data"] |> equals (upcast expectedDirect)
-        deferred
-        |> Observable.add (fun x -> actualDeferred.Add(x); set mre)
-        wait mre "Timeout while waiting for Deferred GQLResponse"
-        actualDeferred |> single |> equals (upcast expectedDeferred)
+        use sub = Observer.create deferred
+        sub.WaitCompleted()
+        sub.Received |> single |> equals (upcast expectedDeferred)
     | _ -> fail "Expected Deferred GQLResponse"
 
 [<Fact>]
@@ -408,17 +397,14 @@ let ``Single Root object field - Defer and Stream`` () =
     }"""
     asts query
     |> Seq.iter (fun query ->
-        use mre = new ManualResetEvent(false)
-        let actualDeferred = ConcurrentBag<Output>()
         let result = query |> executor.AsyncExecute |> sync
         match result with
         | Deferred(data, errors, deferred) ->
             empty errors
             data.["data"] |> equals (upcast expectedDirect)
-            deferred |> Observable.add (fun x -> actualDeferred.Add(x); mre.Set() |> ignore)
-            if TimeSpan.FromSeconds(float 30) |> mre.WaitOne |> not
-            then fail "Timeout while waiting for Deferred GQLResponse"
-            actualDeferred |> single |> equals (upcast expectedDeferred)
+            use sub = Observer.create deferred
+            sub.WaitCompleted()
+            sub.Received |> single |> equals (upcast expectedDeferred)
         | _ -> fail "Expected Deferred GQLResponse")
 
 [<Fact>]
@@ -451,17 +437,14 @@ let ``Single Root object list field - Defer`` () =
             }
         }
     }"""
-    use mre = new ManualResetEvent(false)
-    let actualDeferred = ConcurrentBag<Output>()
     let result = query |> executor.AsyncExecute |> sync
     match result with
     | Deferred(data, errors, deferred) ->
         empty errors
         data.["data"] |> equals (upcast expectedDirect)
-        deferred
-        |> Observable.add (fun x -> actualDeferred.Add(x); set mre)
-        wait mre "Timeout while waiting for Deferred GQLResponse"
-        actualDeferred |> single |> equals (upcast expectedDeferred)
+        use sub = Observer.create deferred
+        sub.WaitCompleted()
+        sub.Received |> single |> equals (upcast expectedDeferred)
     | _ -> fail "Expected Deferred GQLResponse"
 
 [<Fact>]
@@ -500,19 +483,14 @@ let ``Single Root object list field - Stream`` () =
             }
         }
     }"""
-    use mre = new ManualResetEvent(false)
-    let actualDeferred = ConcurrentBag<Output>()
     let result = query |> executor.AsyncExecute |> sync
     match result with
     | Deferred(data, errors, deferred) ->
         empty errors
         data.["data"] |> equals (upcast expectedDirect)
-        deferred
-        |> Observable.add (fun x -> 
-            actualDeferred.Add(x)
-            if actualDeferred.Count = 2 then set mre)
-        wait mre "Timeout while waiting for Deferred GQLResponse"
-        actualDeferred
+        use sub = Observer.create deferred
+        sub.WaitCompleted(2)
+        sub.Received
         |> Seq.cast<NameValueLookup>
         |> contains expectedDeferred1
         |> contains expectedDeferred2
@@ -545,17 +523,14 @@ let ``Interface field - Defer and Stream`` () =
     }"""
     asts query
     |> Seq.iter (fun query ->
-        use mre = new ManualResetEvent(false)
-        let actualDeferred = ConcurrentBag<Output>()
         let result = query |> executor.AsyncExecute |> sync
         match result with
         | Deferred(data, errors, deferred) ->
             empty errors
             data.["data"] |> equals (upcast expectedDirect)
-            deferred |> Observable.add (fun x -> actualDeferred.Add(x); mre.Set() |> ignore)
-            if TimeSpan.FromSeconds(float 30) |> mre.WaitOne |> not
-            then fail "Timeout while waiting for Deferred GQLResponse"
-            actualDeferred |> single |> equals (upcast expectedDeferred)
+            use sub = Observer.create deferred
+            sub.WaitCompleted()
+            sub.Received |> single |> equals (upcast expectedDeferred)
         | _ -> fail "Expected Deferred GQLResponse")
 
 [<Fact>]
@@ -595,19 +570,14 @@ let ``Interface list field - Defer and Stream`` () =
     }"""
     asts query
     |> Seq.iter (fun query ->
-        use mre = new ManualResetEvent(false)
-        let actualDeferred = ConcurrentBag<Output>()
         let result = query |> executor.AsyncExecute |> sync
         match result with
         | Deferred(data, errors, deferred) -> 
             empty errors
             data.["data"] |> equals (upcast expectedDirect)
-            deferred
-            |> Observable.add (fun x -> 
-                actualDeferred.Add(x)
-                if actualDeferred.Count = 2 then set mre)
-            wait mre "Timeout while waiting for Deferred GQLResponse"
-            actualDeferred
+            use sub = Observer.create deferred
+            sub.WaitCompleted(2)
+            sub.Received
             |> Seq.cast<NameValueLookup>
             |> contains expectedDeferred1
             |> contains expectedDeferred2
@@ -645,19 +615,17 @@ let ``Each live result should be sent as soon as it is computed`` () =
     }"""
     use mre1 = new ManualResetEvent(false)
     use mre2 = new ManualResetEvent(false)
-    let actualDeferred = List<Output>()
-    resetLiveData ()
+    resetLiveData()
     let result = query |> executor.AsyncExecute |> sync
     match result with
     | Deferred(data, errors, deferred) ->
         empty errors
         data.["data"] |> equals (upcast expectedDirect)
-        deferred |> Observable.add (fun x -> 
-            if actualDeferred.Count < 2 then actualDeferred.Add(x)
-            if actualDeferred.Count = 1 then mre1.Set() |> ignore
-            if actualDeferred.Count = 2 then mre2.Set() |> ignore)
+        use sub = deferred |> Observer.createWithCallback (fun sub _ ->
+            if Seq.length sub.Received = 1 then mre1.Set() |> ignore
+            elif Seq.length sub.Received = 2 then mre2.Set() |> ignore)
         waitFor hasSubscribers 10 "Timeout while waiting for subscribers on GQLResponse"
-        updateLiveData ()
+        updateLiveData()
         // The second result is a delayed async field, which is set to compute the value for 5 seconds.
         // The first result should come as soon as the live value is updated, which sould be almost instantly.
         // Therefore, let's assume that if it does not come in at least 3 seconds, test has failed.
@@ -665,7 +633,7 @@ let ``Each live result should be sent as soon as it is computed`` () =
         then fail "Timeout while waiting for first deferred result"
         if TimeSpan.FromSeconds(float 30) |> mre2.WaitOne |> not
         then fail "Timeout while waiting for second deferred result"
-        actualDeferred
+        sub.Received
         |> Seq.cast<NameValueLookup>
         |> itemEquals 0 expectedLive
         |> itemEquals 1 expectedDeferred
@@ -692,20 +660,17 @@ let ``Live Query`` () =
             live @live
         }
     }"""
-    use mre = new ManualResetEvent(false)
-    let actualDeferred = ConcurrentBag<Output>()
-    resetLiveData ()
+    resetLiveData()
     let result = query |> executor.AsyncExecute |> sync
     match result with
     | Deferred(data, errors, deferred) ->
         empty errors
         data.["data"] |> equals (upcast expectedDirect)
-        deferred
-        |> Observable.add (fun x -> actualDeferred.Add(x); set mre)
+        use sub = Observer.create deferred
         waitFor hasSubscribers 10 "Timeout while waiting for subscribers on GQLResponse"
-        updateLiveData ()
-        wait mre "Timeout while waiting for Deferred GQLResponse"
-        actualDeferred
+        updateLiveData()
+        sub.WaitForItem()
+        sub.Received
         |> Seq.cast<NameValueLookup>
         |> contains expectedLive
         |> ignore
@@ -745,19 +710,14 @@ let ``Parallel Defer`` () =
                 }
             }
         }"""
-    use mre = new ManualResetEvent(false)
-    let actualDeferred = ConcurrentBag<Output>()
     let result = query |> executor.AsyncExecute |> sync
     match result with
     | Deferred(data, errors, deferred) -> 
         empty errors
         data.["data"] |> equals (upcast expectedDirect)
-        deferred
-        |> Observable.add (fun x -> 
-            actualDeferred.Add(x)
-            if actualDeferred.Count = 2 then set mre)
-        wait mre "Timeout while waiting for Deferred GQLResponse"
-        actualDeferred
+        use sub = Observer.create deferred
+        sub.WaitCompleted(2)
+        sub.Received
         |> Seq.cast<NameValueLookup>
         |> contains expectedDeferred1
         |> contains expectedDeferred2
@@ -798,19 +758,14 @@ let ``Parallell Stream`` () =
                 }
             }
         }"""
-    use mre = new ManualResetEvent(false)
-    let actualDeferred = ConcurrentBag<Output>()
     let result = query |> executor.AsyncExecute |> sync
     match result with
     | Deferred(data, errors, deferred) -> 
         empty errors
         data.["data"] |> equals (upcast expectedDirect)
-        deferred
-        |> Observable.add (fun x -> 
-            actualDeferred.Add(x)
-            if actualDeferred.Count = 2 then set mre)
-        wait mre "Timeout while waiting for Deferred GQLResponse"
-        actualDeferred
+        use sub = Observer.create deferred
+        sub.WaitCompleted(2)
+        sub.Received
         |> Seq.cast<NameValueLookup>
         |> contains expectedDeferred1
         |> contains expectedDeferred2
@@ -843,16 +798,14 @@ let ``Inner Object List Defer`` () =
                 }
             }
         }"""
-    use mre = new ManualResetEvent(false)
-    let actualDeferred = ConcurrentBag<Output>()
     let result = query |> executor.AsyncExecute |> sync
     match result with
     | Deferred(data, errors, deferred) -> 
         empty errors
         data.["data"] |> equals (upcast expectedDirect)
-        deferred |> Observable.add (fun x -> actualDeferred.Add(x); set mre)
-        wait mre "Timeout while waiting for Deferred GQLResponse"
-        actualDeferred |> single |> equals (upcast expectedDeferred)
+        use sub = Observer.create deferred
+        sub.WaitCompleted()
+        sub.Received |> single |> equals (upcast expectedDeferred)
     | _ -> fail "Expected Deferred GQLResponse"
 
 [<Fact>]
@@ -881,16 +834,14 @@ let ``Inner Object List Stream`` () =
                 }
             }
         }"""
-    use mre = new ManualResetEvent(false)
-    let actualDeferred = ConcurrentBag<Output>()
     let result = query |> executor.AsyncExecute |> sync
     match result with
     | Deferred(data, errors, deferred) -> 
         empty errors
         data.["data"] |> equals (upcast expectedDirect)
-        deferred |> Observable.add (fun x -> actualDeferred.Add(x); set mre)
-        wait mre "Timeout while waiting for Deferred GQLResponse"
-        actualDeferred |> single |> equals (upcast expectedDeferred)
+        use sub = Observer.create deferred
+        sub.WaitCompleted()
+        sub.Received |> single |> equals (upcast expectedDeferred)
     | _ -> fail "Expected Deferred GQLResponse"
 
 [<Fact>]
@@ -935,19 +886,14 @@ let ``Nested Inner Object List Defer`` () =
                 }
             }
         }"""
-    use mre = new ManualResetEvent(false)
-    let actualDeferred = ConcurrentBag<Output>()
     let result = query |> executor.AsyncExecute |> sync
     match result with
     | Deferred(data, errors, deferred) ->
         empty errors
         data.["data"] |> equals (upcast expectedDirect)
-        deferred
-        |> Observable.add (fun x ->
-            actualDeferred.Add(x)
-            if actualDeferred.Count = 2 then set mre)
-        wait mre "Timeout while waiting for Deferred GQLResponse"
-        actualDeferred
+        use sub = Observer.create deferred
+        sub.WaitCompleted(2)
+        sub.Received
         |> Seq.cast<NameValueLookup>
         |> contains expectedDeferred1
         |> contains expectedDeferred2
@@ -1002,19 +948,14 @@ let ``Nested Inner Object List Stream`` () =
                 }
             }
         }"""
-    use mre = new ManualResetEvent(false)
-    let actualDeferred = ConcurrentBag<Output>()
     let result = query |> executor.AsyncExecute |> sync
     match result with
     | Deferred(data, errors, deferred) ->
         empty errors
         data.["data"] |> equals (upcast expectedDirect)
-        deferred
-        |> Observable.add (fun x ->
-            actualDeferred.Add(x)
-            if actualDeferred.Count = 3 then set mre)
-        wait mre "Timeout while waiting for Deferred GQLResponse"
-        actualDeferred
+        use sub = Observer.create deferred
+        sub.WaitCompleted(3)
+        sub.Received
         |> Seq.cast<NameValueLookup>
         |> contains expectedDeferred1
         |> contains expectedDeferred2
@@ -1044,17 +985,14 @@ let ``Simple Defer and Stream`` () =
     }"""
     asts query
     |> Seq.iter (fun query ->
-        use mre = new ManualResetEvent(false)
-        let actualDeferred = ConcurrentBag<Output>()
         let result = query |> executor.AsyncExecute |> sync
         match result with
         | Deferred(data, errors, deferred) ->
             empty errors
             data.["data"] |> equals (upcast expectedDirect)
-            deferred |> Observable.add (fun x -> actualDeferred.Add(x); mre.Set() |> ignore)
-            if TimeSpan.FromSeconds(float 30) |> mre.WaitOne |> not
-            then fail "Timeout while waiting for Deferred GQLResponse"
-            actualDeferred |> single |> equals (upcast expectedDeferred)
+            use sub = Observer.create deferred
+            sub.WaitCompleted()
+            sub.Received |> single |> equals (upcast expectedDeferred)
         | _ -> fail "Expected Deferred GQLResponse")
 
 [<Fact>]
@@ -1095,17 +1033,14 @@ let ``List Defer``() =
             }
         }
     }"""
-    use mre = new ManualResetEvent(false)
-    let actualDeferred = ConcurrentBag<Output>()
     let result = query |> executor.AsyncExecute |> sync
     match result with
     | Deferred(data, errors, deferred) ->
         empty errors
         data.["data"] |> equals (upcast expectedDirect)
-        deferred |> Observable.add (fun x -> actualDeferred.Add(x); mre.Set() |> ignore)
-        if TimeSpan.FromSeconds(float 30) |> mre.WaitOne |> not
-        then fail "Timeout while waiting for Deferred GQLResponse"
-        actualDeferred |> single |> equals (upcast expectedDeferred)
+        use sub = Observer.create deferred
+        sub.WaitCompleted()
+        sub.Received |> single |> equals (upcast expectedDeferred)
     | _ -> fail "Expected Deferred GQLResponse"
 
 [<Fact>]
@@ -1148,17 +1083,14 @@ let ``List Fragment Defer and Stream - Exclusive``() =
     }"""
     asts query
     |> Seq.iter (fun query ->
-        use mre = new ManualResetEvent(false)
-        let actualDeferred = ConcurrentBag<Output>()
         let result = query |> executor.AsyncExecute |> sync
         match result with
         | Deferred(data, errors, deferred) ->
             empty errors
             data.["data"] |> equals (upcast expectedDirect)
-            deferred |> Observable.add (fun x -> actualDeferred.Add(x); mre.Set() |> ignore)
-            if TimeSpan.FromSeconds(float 30) |> mre.WaitOne |> not
-            then fail "Timeout while waiting for Deferred GQLResponse"
-            actualDeferred |> single |> equals (upcast expectedDeferred)
+            use sub = Observer.create deferred
+            sub.WaitCompleted()
+            sub.Received |> single |> equals (upcast expectedDeferred)
         | _ -> fail "Expected Deferred GQLResponse")
 
 [<Fact>]
@@ -1201,17 +1133,14 @@ let ``List Fragment Defer and Stream - Common``() =
     }"""
     asts query
     |> Seq.iter (fun query ->
-        use mre = new ManualResetEvent(false)
-        let actualDeferred = ConcurrentBag<Output>()
         let result = query |> executor.AsyncExecute |> sync
         match result with
         | Deferred(data, errors, deferred) ->
             empty errors
             data.["data"] |> equals (upcast expectedDirect)
-            deferred |> Observable.add (fun x -> actualDeferred.Add(x); mre.Set() |> ignore)
-            if TimeSpan.FromSeconds(float 30) |> mre.WaitOne |> not
-            then fail "Timeout while waiting for Deferred GQLResponse"
-            actualDeferred |> single |> equals (upcast expectedDeferred)
+            use sub = Observer.create deferred
+            sub.WaitCompleted()
+            sub.Received |> single |> equals (upcast expectedDeferred)
         | _ -> fail "Expected Deferred GQLResponse")
 
 [<Fact>]
@@ -1252,20 +1181,14 @@ let ``List inside root - Stream``() =
             }
         }
     }"""
-    use mre = new ManualResetEvent(false)
-    let actualDeferred = ConcurrentBag<Output>()
     let result = query |> executor.AsyncExecute |> sync
     match result with
     | Deferred(data, errors, deferred) ->
         empty errors
         data.["data"] |> equals (upcast expectedDirect)
-        deferred
-        |> Observable.add (fun x ->
-            actualDeferred.Add(x)
-            if actualDeferred.Count = 2 then mre.Set() |> ignore)
-        if TimeSpan.FromSeconds(float 30) |> mre.WaitOne |> not
-        then fail "Timeout while waiting for Deferred GQLResponse"
-        actualDeferred
+        use sub = Observer.create deferred
+        sub.WaitCompleted(2)
+        sub.Received
         |> Seq.cast<NameValueLookup>
         |> contains expectedDeferred1
         |> contains expectedDeferred2
@@ -1316,20 +1239,14 @@ let ``List Stream``() =
             }
         }
     }"""
-    use mre = new ManualResetEvent(false)
-    let actualDeferred = ConcurrentBag<Output>()
     let result = query |> executor.AsyncExecute |> sync
     match result with
     | Deferred(data, errors, deferred) ->
         empty errors
         data.["data"] |> equals (upcast expectedDirect)
-        deferred
-        |> Observable.add (fun x ->
-            actualDeferred.Add(x)
-            if actualDeferred.Count = 2 then mre.Set() |> ignore)
-        if TimeSpan.FromSeconds(float 30) |> mre.WaitOne |> not
-        then fail "Timeout while waiting for Deferred GQLResponse"
-        actualDeferred
+        use sub = Observer.create deferred
+        sub.WaitCompleted(2)
+        sub.Received
         |> Seq.cast<NameValueLookup>
         |> contains expectedDeferred1
         |> contains expectedDeferred2
@@ -1374,17 +1291,14 @@ let ``Should buffer stream list correctly by timing information``() =
     }"""
     use mre1 = new ManualResetEvent(false)
     use mre2 = new ManualResetEvent(false)
-    let actualDeferred = List<Output>()
     let result = query |> executor.AsyncExecute |> sync
     match result with
     | Deferred(data, errors, deferred) ->
         empty errors
         data.["data"] |> equals (upcast expectedDirect)
-        deferred
-        |> Observable.add (fun x ->
-            if actualDeferred.Count < 2 then actualDeferred.Add(x)
-            if actualDeferred.Count = 1 then mre1.Set() |> ignore
-            if actualDeferred.Count = 2 then mre2.Set() |> ignore)
+        use sub = deferred |> Observer.createWithCallback (fun sub _ ->
+            if Seq.length sub.Received = 1 then mre1.Set() |> ignore
+            elif Seq.length sub.Received = 2 then mre2.Set() |> ignore)
         // The first result is a delayed async field, which is set to compute the value for 5 seconds.
         // The second result is also a delayed async field, computed for 1 second.
         // Third result is a instant returning async field.
@@ -1396,7 +1310,8 @@ let ``Should buffer stream list correctly by timing information``() =
         then fail "Timeout while waiting for first Deferred GQLResponse"
         if TimeSpan.FromSeconds(float 30) |> mre2.WaitOne |> not
         then fail "Timeout while waiting for second Deferred GQLResponse"
-        actualDeferred
+        sub.WaitCompleted()
+        sub.Received
         |> Seq.cast<NameValueLookup>
         |> itemEquals 0 expectedDeferred1
         |> itemEquals 1 expectedDeferred2
@@ -1441,18 +1356,14 @@ let ``Should buffer stream list correctly by count information``() =
     }"""
     use mre1 = new ManualResetEvent(false)
     use mre2 = new ManualResetEvent(false)
-    let actualDeferred = List<Output>()
     let result = query |> executor.AsyncExecute |> sync
     match result with
     | Deferred(data, errors, deferred) ->
         empty errors
         data.["data"] |> equals (upcast expectedDirect)
-        deferred
-        |> Observable.add (fun x ->
-            if actualDeferred.Count < 2 then actualDeferred.Add(x)
-            if actualDeferred.Count = 1 then mre1.Set() |> ignore
-            if actualDeferred.Count = 2 then mre2.Set() |> ignore)
-        if TimeSpan.FromSeconds(float 4) |> mre1.WaitOne |> not
+        use sub = deferred |> Observer.createWithCallback (fun sub _ ->
+            if Seq.length sub.Received = 1 then mre1.Set() |> ignore
+            elif Seq.length sub.Received = 2 then mre2.Set() |> ignore)
         // The first result is a delayed async field, which is set to compute the value for 5 seconds.
         // The second result is also a delayed async field, computed for 1 second.
         // Third result is a instant returning async field.
@@ -1461,10 +1372,12 @@ let ``Should buffer stream list correctly by count information``() =
         // and send them together on the first batch.
         // First result should come in a second batch, as it takes 5 seconds to compute, which should be enough
         // to put the two other results in a batch with the preferred size.
+        if TimeSpan.FromSeconds(float 4) |> mre1.WaitOne |> not
         then fail "Timeout while waiting for first Deferred GQLResponse"
         if TimeSpan.FromSeconds(float 30) |> mre2.WaitOne |> not
         then fail "Timeout while waiting for second Deferred GQLResponse"
-        actualDeferred
+        sub.WaitCompleted()
+        sub.Received
         |> Seq.cast<NameValueLookup>
         |> itemEquals 0 expectedDeferred1
         |> itemEquals 1 expectedDeferred2
@@ -1504,17 +1417,14 @@ let ``Union Defer and Stream`` () =
     }"""
     asts query
     |> Seq.iter (fun query ->
-        use mre = new ManualResetEvent(false)
-        let actualDeferred = ConcurrentBag<Output>()
         let result = query |> executor.AsyncExecute |> sync
         match result with
         | Deferred(data, errors, deferred) ->
             empty errors
             data.["data"] |> equals (upcast expectedDirect)
-            deferred |> Observable.add (fun x -> actualDeferred.Add(x); mre.Set() |> ignore)
-            if TimeSpan.FromSeconds(float 30) |> mre.WaitOne |> not
-            then fail "Timeout while waiting for Deferred GQLResponse"
-            actualDeferred |> single |> equals (upcast expectedDeferred)
+            use sub = Observer.create deferred
+            sub.WaitCompleted()
+            sub.Received |> single |> equals (upcast expectedDeferred)
         | _ -> fail "Expected Deferred GQLRespnse")
 
 [<Fact>]
@@ -1548,16 +1458,14 @@ let ``Each deferred result should be sent as soon as it is computed``() =
     }"""
     use mre1 = new ManualResetEvent(false)
     use mre2 = new ManualResetEvent(false)
-    let actualDeferred = List<Output>()
     let result = query |> executor.AsyncExecute |> sync
     match result with
     | Deferred(data, errors, deferred) ->
         empty errors
         data.["data"] |> equals (upcast expectedDirect)
-        deferred |> Observable.add (fun x -> 
-            if actualDeferred.Count < 2 then actualDeferred.Add(x)
-            if actualDeferred.Count = 1 then mre1.Set() |> ignore
-            if actualDeferred.Count = 2 then mre2.Set() |> ignore)
+        use sub = deferred |> Observer.createWithCallback (fun sub _ ->
+            if Seq.length sub.Received = 1 then mre1.Set() |> ignore
+            elif Seq.length sub.Received = 2 then mre2.Set() |> ignore)
         // The second result is a delayed async field, which is set to compute the value for 5 seconds.
         // The first result should come almost instantly, as it is not a delayed computed field.
         // Therefore, let's assume that if it does not come in at least 3 seconds, test has failed.
@@ -1565,7 +1473,8 @@ let ``Each deferred result should be sent as soon as it is computed``() =
         then fail "Timeout while waiting for first deferred result"
         if TimeSpan.FromSeconds(float 30) |> mre2.WaitOne |> not
         then fail "Timeout while waiting for second deferred result"
-        actualDeferred
+        sub.WaitCompleted()
+        sub.Received
         |> Seq.cast<NameValueLookup>
         |> itemEquals 0 expectedDeferred1
         |> itemEquals 1 expectedDeferred2
@@ -1606,16 +1515,14 @@ let ``Each deferred result of a list should be sent as soon as it is computed`` 
     }"""
     use mre1 = new ManualResetEvent(false)
     use mre2 = new ManualResetEvent(false)
-    let actualDeferred = List<Output>()
     let result = query |> executor.AsyncExecute |> sync
     match result with
     | Deferred(data, errors, deferred) ->
         empty errors
         data.["data"] |> equals (upcast expectedDirect)
-        deferred |> Observable.add (fun x -> 
-            if actualDeferred.Count < 2 then actualDeferred.Add(x)
-            if actualDeferred.Count = 1 then mre1.Set() |> ignore
-            if actualDeferred.Count = 2 then mre2.Set() |> ignore)
+        use sub = deferred |> Observer.createWithCallback (fun sub _ ->
+            if Seq.length sub.Received = 1 then mre1.Set() |> ignore
+            elif Seq.length sub.Received = 2 then mre2.Set() |> ignore)
         // The first result is a delayed async field, which is set to compute the value for 5 seconds.
         // The second result should come first, almost instantly, as it is not a delayed computed field.
         // Therefore, let's assume that if it does not come in at least 4 seconds, test has failed.
@@ -1623,7 +1530,8 @@ let ``Each deferred result of a list should be sent as soon as it is computed`` 
         then fail "Timeout while waiting for first deferred result"
         if TimeSpan.FromSeconds(float 30) |> mre2.WaitOne |> not
         then fail "Timeout while waiting for second deferred result"
-        actualDeferred
+        sub.WaitCompleted()
+        sub.Received
         |> Seq.cast<NameValueLookup>
         |> itemEquals 0 expectedDeferred1
         |> itemEquals 1 expectedDeferred2
@@ -1665,16 +1573,14 @@ let ``Each streamed result should be sent as soon as it is computed``() =
     }"""
     use mre1 = new ManualResetEvent(false)
     use mre2 = new ManualResetEvent(false)
-    let actualDeferred = List<Output>()
     let result = query |> executor.AsyncExecute |> sync
     match result with
     | Deferred(data, errors, deferred) ->
         empty errors
         data.["data"] |> equals (upcast expectedDirect)
-        deferred |> Observable.add (fun x -> 
-            if actualDeferred.Count < 2 then actualDeferred.Add(x)
-            if actualDeferred.Count = 1 then mre1.Set() |> ignore
-            if actualDeferred.Count = 2 then mre2.Set() |> ignore)
+        use sub = deferred |> Observer.createWithCallback (fun sub _ ->
+            if Seq.length sub.Received = 1 then mre1.Set() |> ignore
+            elif Seq.length sub.Received = 2 then mre2.Set() |> ignore)
         // The first result is a delayed async field, which is set to compute the value for 5 seconds.
         // The second result should come first, almost instantly, as it is not a delayed computed field.
         // Therefore, let's assume that if it does not come in at least 4 seconds, test has failed.
@@ -1682,7 +1588,8 @@ let ``Each streamed result should be sent as soon as it is computed``() =
         then fail "Timeout while waiting for first deferred result"
         if TimeSpan.FromSeconds(float 30) |> mre2.WaitOne |> not
         then fail "Timeout while waiting for second deferred result"
-        actualDeferred
+        sub.WaitCompleted()
+        sub.Received
         |> Seq.cast<NameValueLookup>
         |> itemEquals 0 expectedDeferred1
         |> itemEquals 1 expectedDeferred2

--- a/tests/FSharp.Data.GraphQL.Tests/ExecutionTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/ExecutionTests.fs
@@ -3,7 +3,6 @@
 
 module FSharp.Data.GraphQL.Tests.ExecutionTests
 
-open System
 open Xunit
 open FSharp.Data.GraphQL
 open FSharp.Data.GraphQL.Types

--- a/tests/FSharp.Data.GraphQL.Tests/FSharp.Data.GraphQL.Tests.fsproj
+++ b/tests/FSharp.Data.GraphQL.Tests/FSharp.Data.GraphQL.Tests.fsproj
@@ -28,6 +28,7 @@
     <Compile Include="CoercionTests.fs" />
     <Compile Include="IntrospectionTests.fs" />
     <Compile Include="ReflectedSchemaTests.fs" />
+    <Compile Include="ObservableExtensionsTests.fs" />
     <Compile Include="ExecutionTests.fs" />
     <Compile Include="ExecutorMiddlewareTests.fs" />
     <Compile Include="MutationTests.fs" />

--- a/tests/FSharp.Data.GraphQL.Tests/Helpers.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/Helpers.fs
@@ -49,6 +49,8 @@ let itemEquals (index : int) (expected : 'a) (xs : 'a seq) =
     | Some item -> item |> equals expected
     | None -> fail <| sprintf "Expected sequence to contain item at index %i, but sequence does not contain enough elements" index
     xs
+let seqEquals (expected : 'a seq) (actual : 'a seq) =
+    Assert.Equal<'a>(expected, actual)
 
 let greaterThanOrEqual expected actual =
     Assert.True(actual >= expected, sprintf "Expected value to be greather than or equal to %A, but was: %A" expected actual)

--- a/tests/FSharp.Data.GraphQL.Tests/ObservableExtensionsTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/ObservableExtensionsTests.fs
@@ -1,0 +1,45 @@
+﻿/// The MIT License (MIT)
+/// Copyright (c) 2016 Bazinga Technologies Inc
+
+module FSharp.Data.GraphQL.Tests.ObservableExtensionsTests
+
+open System
+open System.Linq
+open System.Collections.Generic
+open Xunit
+open FSharp.Data.GraphQL
+open Helpers
+open System.Threading
+
+type TestObserver<'T>(obs : IObservable<'T>) as this =
+    let received = List<'T>()
+    let mutable isCompleted = false
+    let mre = new ManualResetEvent(false)
+    let mutable subscription = Unchecked.defaultof<IDisposable>
+    do subscription <- obs.Subscribe(this)
+    member __.Received with get() = received.AsEnumerable()
+    member __.WaitCompleted() =
+        wait mre "Timeout waiting for OnCompleted"
+    member __.IsCompleted with get() = isCompleted
+    interface IObserver<'T> with
+        member __.OnCompleted() = 
+            isCompleted <- true
+            mre.Set() |> ignore
+        member __.OnError(error) = raise error
+        member __.OnNext(value) = received.Add(value)
+    interface IDisposable with
+        member __.Dispose() = 
+            subscription.Dispose()
+            mre.Dispose()
+
+[<RequireQualifiedAccess>]
+module Observer =
+    let create (sub : IObservable<'T>) = new TestObserver<'T>(sub)
+
+[<Fact>]
+let ``ofSeq should call OnComplete`` () =
+    let source = seq { for x in 1 .. 5 do yield x }
+    let obs = Observable.ofSeq source
+    use sub = Observer.create obs
+    sub.WaitCompleted()
+    sub.Received |> seqEquals source

--- a/tests/FSharp.Data.GraphQL.Tests/ObservableExtensionsTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/ObservableExtensionsTests.fs
@@ -37,7 +37,7 @@ module Observer =
     let create (sub : IObservable<'T>) = new TestObserver<'T>(sub)
 
 [<Fact>]
-let ``ofSeq should call OnComplete`` () =
+let ``ofSeq should call OnComplete and return items in expected order`` () =
     let source = seq { for x in 1 .. 5 do yield x }
     let obs = Observable.ofSeq source
     use sub = Observer.create obs
@@ -45,7 +45,7 @@ let ``ofSeq should call OnComplete`` () =
     sub.Received |> seqEquals source
 
 [<Fact>]
-let `` bind should call OnComplete`` () =
+let `` bind should call OnComplete and return items in expected order`` () =
     let source = seq { for x in 1 .. 5 do yield x }
     let obs = Observable.ofSeq source |> Observable.bind (fun x -> Observable.ofSeq [x; x])
     use sub = Observer.create obs
@@ -53,7 +53,7 @@ let `` bind should call OnComplete`` () =
     sub.Received |> seqEquals [ 1; 1; 2; 2; 3; 3; 4; 4; 5; 5 ]
 
 [<Fact>]
-let `` ofAsync should call OnComplete`` () =
+let `` ofAsync should call OnComplete and return items in expected order`` () =
     let source = async { return "test" }
     let obs = Observable.ofAsync source
     use sub = Observer.create obs
@@ -62,7 +62,7 @@ let `` ofAsync should call OnComplete`` () =
 
 
 [<Fact>]
-let `` ofAsyncVal should call OnComplete`` () =
+let `` ofAsyncVal should call OnComplete and return items in expected order`` () =
     let source = async { return "test" } |> AsyncVal.ofAsync
     let obs = Observable.ofAsyncVal source
     use sub = Observer.create obs
@@ -77,7 +77,7 @@ let ``toSeq on a finite sequence should generate a finite sequence`` () =
     result |> seqEquals source
 
 [<Fact>]
-let ``ofSeq on an empty sequence should call OnComplete`` () =
+let ``ofSeq on an empty sequence should call OnComplete and return items in expected order`` () =
     let source = Seq.empty<int>
     let obs = Observable.ofSeq source
     use sub = Observer.create obs
@@ -89,7 +89,7 @@ let delay ms x = async {
     return x }
 
 [<Fact>]
-let ``ofAsyncSeq should call OnComplete`` () =
+let ``ofAsyncSeq should call OnComplete and return items in expected order`` () =
     let source = seq { 
         yield delay 300 2
         yield delay 100 1
@@ -100,7 +100,7 @@ let ``ofAsyncSeq should call OnComplete`` () =
     sub.Received |> seqEquals [ 1; 3; 2 ]
 
 [<Fact>]
-let ``ofAsyncValSeq should call OnComplete`` () =
+let ``ofAsyncValSeq should call OnComplete and return items in expected order`` () =
     let source = seq { 
         yield delay 300 2 |> AsyncVal.ofAsync
         yield delay 100 1 |> AsyncVal.ofAsync
@@ -111,7 +111,7 @@ let ``ofAsyncValSeq should call OnComplete`` () =
     sub.Received |> seqEquals [ 1; 3; 2 ]
 
 [<Fact>]
-let ``bufferByTiming should call OnComplete`` () =
+let ``bufferByTiming should call OnComplete and return items in expected order`` () =
     let source = seq { 
         yield delay 500 2
         yield delay 100 1
@@ -122,7 +122,7 @@ let ``bufferByTiming should call OnComplete`` () =
     sub.Received |> seqEquals [ [1; 3]; [2] ]
 
 [<Fact>]
-let ``bufferByElementCount should call OnComplete`` () =
+let ``bufferByElementCount should call OnComplete and return items in expected order`` () =
     let source = seq { 
         yield delay 500 2
         yield delay 100 1
@@ -133,7 +133,7 @@ let ``bufferByElementCount should call OnComplete`` () =
     sub.Received |> seqEquals [ [1; 3]; [2] ]
 
 [<Fact>]
-let ``bufferByTimingAndElementCount should call OnComplete`` () =
+let ``bufferByTimingAndElementCount should call OnComplete and return items in expected order`` () =
     let source = seq { 
         yield delay 500 2
         yield delay 50 1
@@ -149,7 +149,7 @@ type IndexException(index : int) =
     member __.Index = index
 
 [<Fact>]
-let ``catch should call OnComplete`` () =   
+let ``catch should call OnComplete and return items in expected order`` () =   
     let source : int seq = seq { for x in 1 .. 5 do yield raise <| IndexException(x) }
     let obs = 
         Observable.ofSeq source 
@@ -169,7 +169,7 @@ let ``choose should cal OnComplete`` () =
     sub.Received |> seqEquals [ 2; 4 ]
 
 [<Fact>]
-let ``concat should call OnComplete`` () =
+let ``concat should call OnComplete and return items in expected order`` () =
     let source1 = seq { 
         yield delay 500 2
         yield delay 100 1
@@ -187,7 +187,7 @@ let ``concat should call OnComplete`` () =
     sub.Received |> seqEquals [ 1; 3; 2; 5; 4 ]
 
 [<Fact>]
-let ``concat2 should call OnComplete`` () =
+let ``concat2 should call OnComplete and return items in expected order`` () =
     let source1 = seq { 
         yield delay 500 2
         yield delay 100 1
@@ -203,7 +203,7 @@ let ``concat2 should call OnComplete`` () =
     sub.Received |> seqEquals [ 1; 3; 2; 5; 4 ]
 
 [<Fact>]
-let ``merge should call OnComplete`` () =
+let ``merge should call OnComplete and return items in expected order`` () =
     let source1 = seq { 
         yield delay 500 2
         yield delay 100 1
@@ -221,7 +221,7 @@ let ``merge should call OnComplete`` () =
     sub.Received |> seqEquals [ 1; 3; 5; 4; 2 ]
 
 [<Fact>]
-let ``merge2 should call OnComplete`` () =
+let ``merge2 should call OnComplete and return items in expected order`` () =
     let source1 = seq { 
         yield delay 500 2
         yield delay 100 1
@@ -235,3 +235,19 @@ let ``merge2 should call OnComplete`` () =
     use sub = Observer.create obs
     sub.WaitCompleted()
     sub.Received |> seqEquals [ 1; 3; 5; 4; 2 ]
+
+[<Fact>]
+let ``concatSeq should call OnComplete and return items in expected order`` () =
+    let source = seq { for x in 1 .. 5 do yield x }
+    let obs = Observable.singleton source |> Observable.concatSeq
+    use sub = Observer.create obs
+    sub.WaitCompleted()
+    sub.Received |> seqEquals source
+
+[<Fact>]
+let ``mapAsync should call OnComplete and return items in expected order`` () =
+    let source = seq { for x in 1 .. 5 do yield x }
+    let obs = Observable.ofSeq source |> Observable.mapAsync (fun x -> async { return x })
+    use sub = Observer.create obs
+    sub.WaitCompleted()
+    sub.Received |> seqEquals source

--- a/tests/FSharp.Data.GraphQL.Tests/ObservableExtensionsTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/ObservableExtensionsTests.fs
@@ -43,3 +43,138 @@ let ``ofSeq should call OnComplete`` () =
     use sub = Observer.create obs
     sub.WaitCompleted()
     sub.Received |> seqEquals source
+
+[<Fact>]
+let `` bind should call OnComplete`` () =
+    let source = seq { for x in 1 .. 5 do yield x }
+    let obs = Observable.ofSeq source |> Observable.bind (fun x -> Observable.ofSeq [x; x])
+    use sub = Observer.create obs
+    sub.WaitCompleted()
+    sub.Received |> seqEquals [ 1; 1; 2; 2; 3; 3; 4; 4; 5; 5 ]
+
+[<Fact>]
+let `` ofAsync should call OnComplete`` () =
+    let source = async { return "test" }
+    let obs = Observable.ofAsync source
+    use sub = Observer.create obs
+    sub.WaitCompleted()
+    sub.Received |> seqEquals [ "test" ]
+
+
+[<Fact>]
+let `` ofAsyncVal should call OnComplete`` () =
+    let source = async { return "test" } |> AsyncVal.ofAsync
+    let obs = Observable.ofAsyncVal source
+    use sub = Observer.create obs
+    sub.WaitCompleted()
+    sub.Received |> seqEquals [ "test" ]
+
+[<Fact>]
+let ``toSeq on a finite sequence should generate a finite sequence`` () =
+    let source = seq { for x in 1 .. 5 do yield x }
+    let obs = Observable.ofSeq source
+    let result = Observable.toSeq obs
+    result |> seqEquals source
+
+[<Fact>]
+let ``ofSeq on an empty sequence should call OnComplete`` () =
+    let source = Seq.empty<int>
+    let obs = Observable.ofSeq source
+    use sub = Observer.create obs
+    sub.WaitCompleted()
+    sub.Received |> seqEquals source
+
+let delay ms x = async {
+    do! Async.Sleep(ms)
+    return x }
+
+[<Fact>]
+let ``ofAsyncSeq should call OnComplete`` () =
+    let source = seq { 
+        yield delay 300 2
+        yield delay 100 1
+        yield delay 200 3 }
+    let obs = Observable.ofAsyncSeq source
+    use sub = Observer.create obs
+    sub.WaitCompleted()
+    sub.Received |> seqEquals [ 1; 3; 2 ]
+
+[<Fact>]
+let ``ofAsyncValSeq should call OnComplete`` () =
+    let source = seq { 
+        yield delay 300 2 |> AsyncVal.ofAsync
+        yield delay 100 1 |> AsyncVal.ofAsync
+        yield delay 200 3 |> AsyncVal.ofAsync }
+    let obs = Observable.ofAsyncValSeq source
+    use sub = Observer.create obs
+    sub.WaitCompleted()
+    sub.Received |> seqEquals [ 1; 3; 2 ]
+
+[<Fact>]
+let ``bufferByTiming should call OnComplete`` () =
+    let source = seq { 
+        yield delay 500 2
+        yield delay 100 1
+        yield delay 200 3 }
+    let obs = Observable.ofAsyncSeq source |> Observable.bufferByTiming 300
+    use sub = Observer.create obs
+    sub.WaitCompleted()
+    sub.Received |> seqEquals [ [1; 3]; [2] ]
+
+[<Fact>]
+let ``bufferByElementCount should call OnComplete`` () =
+    let source = seq { 
+        yield delay 500 2
+        yield delay 100 1
+        yield delay 200 3 }
+    let obs = Observable.ofAsyncSeq source |> Observable.bufferByElementCount 2
+    use sub = Observer.create obs
+    sub.WaitCompleted()
+    sub.Received |> seqEquals [ [1; 3]; [2] ]
+
+[<Fact>]
+let ``bufferByTimingAndElementCount should call OnComplete`` () =
+    let source = seq { 
+        yield delay 500 2
+        yield delay 50 1
+        yield delay 100 3
+        yield delay 150 4 }
+    let obs = Observable.ofAsyncSeq source |> Observable.bufferByTimingAndElementCount 300 2
+    use sub = Observer.create obs
+    sub.WaitCompleted()
+    sub.Received |> seqEquals [ [1; 3]; [4]; [2] ]
+
+type IndexException(index : int) =
+    inherit exn(sprintf "Error at index %i." index)
+    member __.Index = index
+
+[<Fact>]
+let ``catch should call OnComplete`` () =   
+    let source : int seq = seq { for x in 1 .. 5 do yield raise <| IndexException(x) }
+    let obs = 
+        Observable.ofSeq source 
+        |> Observable.catch (fun (ex : IndexException) -> ex.Index |> AsyncVal.wrap |> Observable.ofAsyncVal)
+    use sub = Observer.create obs
+    sub.WaitCompleted()
+    sub.Received |> seqEquals [ 1 ]
+
+[<Fact>]
+let ``choose should cal OnComplete`` () =
+    let source = seq { for x in 1 .. 5 do yield x }
+    let obs = 
+        Observable.ofSeq source
+        |> Observable.choose (fun x -> match x % 2 with | 0 -> Some x | _ -> None)
+    use sub = Observer.create obs
+    sub.WaitCompleted()
+    sub.Received |> seqEquals [ 2; 4 ]
+
+[<Fact>]
+let ``concat should call OnComplete`` () =
+    let source1 = seq { for x in 1 .. 5 do yield x }
+    let obs = 
+        Observable.ofSeq source1
+        |> Observable.map (fun x -> Observable.ofSeq [x; x])
+        |> Observable.concat
+    use sub = Observer.create obs
+    sub.WaitCompleted()
+    sub.Received |> seqEquals [ 1; 1; 2; 2; 3; 3; 4; 4; 5; 5 ]

--- a/tests/FSharp.Data.GraphQL.Tests/ObservableExtensionsTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/ObservableExtensionsTests.fs
@@ -3,38 +3,9 @@
 
 module FSharp.Data.GraphQL.Tests.ObservableExtensionsTests
 
-open System
-open System.Linq
-open System.Collections.Generic
 open Xunit
 open FSharp.Data.GraphQL
 open Helpers
-open System.Threading
-
-type TestObserver<'T>(obs : IObservable<'T>) as this =
-    let received = List<'T>()
-    let mutable isCompleted = false
-    let mre = new ManualResetEvent(false)
-    let mutable subscription = Unchecked.defaultof<IDisposable>
-    do subscription <- obs.Subscribe(this)
-    member __.Received with get() = received.AsEnumerable()
-    member __.WaitCompleted() =
-        wait mre "Timeout waiting for OnCompleted"
-    member __.IsCompleted with get() = isCompleted
-    interface IObserver<'T> with
-        member __.OnCompleted() = 
-            isCompleted <- true
-            mre.Set() |> ignore
-        member __.OnError(error) = raise error
-        member __.OnNext(value) = received.Add(value)
-    interface IDisposable with
-        member __.Dispose() = 
-            subscription.Dispose()
-            mre.Dispose()
-
-[<RequireQualifiedAccess>]
-module Observer =
-    let create (sub : IObservable<'T>) = new TestObserver<'T>(sub)
 
 [<Fact>]
 let ``ofSeq should call OnComplete and return items in expected order`` () =
@@ -153,7 +124,7 @@ let ``catch should call OnComplete and return items in expected order`` () =
     let source : int seq = seq { for x in 1 .. 5 do yield raise <| IndexException(x) }
     let obs = 
         Observable.ofSeq source 
-        |> Observable.catch (fun (ex : IndexException) -> ex.Index |> AsyncVal.wrap |> Observable.ofAsyncVal)
+        |> Observable.catch (fun (ex : IndexException) -> ex.Index |> Observable.singleton)
     use sub = Observer.create obs
     sub.WaitCompleted()
     sub.Received |> seqEquals [ 1 ]


### PR DESCRIPTION
This PR is meant to be able to track ending of streams and deferred results, by making sure it calls `OnCompleted` on observers.