### PR TITLE
Adjusting tests for machines with less processor cores

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -205,6 +205,7 @@ Target "Build" (fun _ ->
 )
 
 Target "RunTests" (fun _ ->
+    Console.WriteLine("Number of processors: {0}", Environment.ProcessorCount)
     DotNetCli.Test (fun p -> { p with 
 #if MONO 
                                     Framework = "netcoreapp2.0"

--- a/build.fsx
+++ b/build.fsx
@@ -210,6 +210,7 @@ Target "RunTests" (fun _ ->
 #if MONO 
                                     Framework = "netcoreapp2.0"
 #endif
+                                    AdditionalArgs = [ "--no-build"; "-v=normal" ]
                                     Configuration = "Release"
                                     Project = "tests/FSharp.Data.GraphQL.Tests/FSharp.Data.GraphQL.Tests.fsproj" })  
 )

--- a/tests/FSharp.Data.GraphQL.Tests/DeferredTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/DeferredTests.fs
@@ -7,8 +7,6 @@ open FSharp.Data.GraphQL
 open FSharp.Data.GraphQL.Parser
 open FSharp.Data.GraphQL.Execution
 open System.Threading
-open System.Collections.Generic
-open System.Collections.Concurrent
 open FSharp.Data.GraphQL.Types
 
 #nowarn "40"
@@ -1320,7 +1318,7 @@ let ``Should buffer stream list correctly by timing information``() =
         then fail "Timeout while waiting for first Deferred GQLResponse"
         if TimeSpan.FromSeconds(float (ms 10)) |> mre2.WaitOne |> not
         then fail "Timeout while waiting for second Deferred GQLResponse"
-        sub.WaitCompleted()
+        sub.WaitCompleted(timeout = ms 10)
         sub.Received
         |> Seq.cast<NameValueLookup>
         |> itemEquals 0 expectedDeferred1
@@ -1386,7 +1384,7 @@ let ``Should buffer stream list correctly by count information``() =
         then fail "Timeout while waiting for first Deferred GQLResponse"
         if TimeSpan.FromSeconds(float (ms 10)) |> mre2.WaitOne |> not
         then fail "Timeout while waiting for second Deferred GQLResponse"
-        sub.WaitCompleted()
+        sub.WaitCompleted(timeout = ms 10)
         sub.Received
         |> Seq.cast<NameValueLookup>
         |> itemEquals 0 expectedDeferred1
@@ -1483,7 +1481,7 @@ let ``Each deferred result should be sent as soon as it is computed``() =
         then fail "Timeout while waiting for first deferred result"
         if TimeSpan.FromSeconds(float (ms 10)) |> mre2.WaitOne |> not
         then fail "Timeout while waiting for second deferred result"
-        sub.WaitCompleted()
+        sub.WaitCompleted(timeout = ms 10)
         sub.Received
         |> Seq.cast<NameValueLookup>
         |> itemEquals 0 expectedDeferred1
@@ -1540,7 +1538,7 @@ let ``Each deferred result of a list should be sent as soon as it is computed`` 
         then fail "Timeout while waiting for first deferred result"
         if TimeSpan.FromSeconds(float (ms 10)) |> mre2.WaitOne |> not
         then fail "Timeout while waiting for second deferred result"
-        sub.WaitCompleted()
+        sub.WaitCompleted(timeout = ms 10)
         sub.Received
         |> Seq.cast<NameValueLookup>
         |> itemEquals 0 expectedDeferred1
@@ -1598,7 +1596,7 @@ let ``Each streamed result should be sent as soon as it is computed - async seq`
         then fail "Timeout while waiting for first deferred result"
         if TimeSpan.FromSeconds(float (ms 10)) |> mre2.WaitOne |> not
         then fail "Timeout while waiting for second deferred result"
-        sub.WaitCompleted()
+        sub.WaitCompleted(timeout = ms 10)
         sub.Received
         |> Seq.cast<NameValueLookup>
         |> itemEquals 0 expectedDeferred1

--- a/tests/FSharp.Data.GraphQL.Tests/DeferredTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/DeferredTests.fs
@@ -13,6 +13,18 @@ open FSharp.Data.GraphQL.Types
 
 #nowarn "40"
 
+let ms x =
+    let factor =
+        match Environment.ProcessorCount with
+        | x when x >= 8 -> 1
+        | x when x >= 4 -> 4
+        | _ -> 6
+    x * factor
+
+let delay time x = async {
+    do! Async.Sleep(ms time)
+    return x }
+
 type TestSubject = {
     id: string
     a: string
@@ -156,11 +168,6 @@ let DataType =
             Define.Field("nullableListError", ListOf AsyncDataType, (fun _ d -> d.nullableListError))
             Define.Field("bufferedList", ListOf AsyncDataType, (fun _ d -> d.bufferedList))
         ])
-
-let delay ms x = async {
-    do! Async.Sleep(ms)
-    return x
-}
 
 let data = {
        id = "1"
@@ -629,9 +636,9 @@ let ``Each live result should be sent as soon as it is computed`` () =
         // The second result is a delayed async field, which is set to compute the value for 5 seconds.
         // The first result should come as soon as the live value is updated, which sould be almost instantly.
         // Therefore, let's assume that if it does not come in at least 3 seconds, test has failed.
-        if TimeSpan.FromSeconds(float 3) |> mre1.WaitOne |> not
+        if TimeSpan.FromSeconds(float (ms 3)) |> mre1.WaitOne |> not
         then fail "Timeout while waiting for first deferred result"
-        if TimeSpan.FromSeconds(float 30) |> mre2.WaitOne |> not
+        if TimeSpan.FromSeconds(float (ms 10)) |> mre2.WaitOne |> not
         then fail "Timeout while waiting for second deferred result"
         sub.Received
         |> Seq.cast<NameValueLookup>
@@ -1282,13 +1289,16 @@ let ``Should buffer stream list correctly by timing information``() =
             ]
             "path", upcast [box "testData"; upcast "bufferedList"; upcast [0]]
         ]   
-    let query = parse """{
-        testData {
-            bufferedList @stream(interval : 3000) {
-                value
+    let query = 
+        ms 3000
+        |> sprintf """{
+            testData {
+                bufferedList @stream(interval : %i) {
+                    value
+                }
             }
-        }
-    }"""
+        }"""
+        |> parse
     use mre1 = new ManualResetEvent(false)
     use mre2 = new ManualResetEvent(false)
     let result = query |> executor.AsyncExecute |> sync
@@ -1306,9 +1316,9 @@ let ``Should buffer stream list correctly by timing information``() =
         // to buffer results 3 and 2 (in this order), as together they take less than 3 seconds to compute,
         // and send them together on the first batch.
         // First result should come in a second batch, as it takes 5 seconds to compute, more than the time limit of the buffer.
-        if TimeSpan.FromSeconds(float 4) |> mre1.WaitOne |> not
+        if TimeSpan.FromSeconds(float (ms 4)) |> mre1.WaitOne |> not
         then fail "Timeout while waiting for first Deferred GQLResponse"
-        if TimeSpan.FromSeconds(float 30) |> mre2.WaitOne |> not
+        if TimeSpan.FromSeconds(float (ms 10)) |> mre2.WaitOne |> not
         then fail "Timeout while waiting for second Deferred GQLResponse"
         sub.WaitCompleted()
         sub.Received
@@ -1372,9 +1382,9 @@ let ``Should buffer stream list correctly by count information``() =
         // and send them together on the first batch.
         // First result should come in a second batch, as it takes 5 seconds to compute, which should be enough
         // to put the two other results in a batch with the preferred size.
-        if TimeSpan.FromSeconds(float 4) |> mre1.WaitOne |> not
+        if TimeSpan.FromSeconds(float (ms 4)) |> mre1.WaitOne |> not
         then fail "Timeout while waiting for first Deferred GQLResponse"
-        if TimeSpan.FromSeconds(float 30) |> mre2.WaitOne |> not
+        if TimeSpan.FromSeconds(float (ms 10)) |> mre2.WaitOne |> not
         then fail "Timeout while waiting for second Deferred GQLResponse"
         sub.WaitCompleted()
         sub.Received
@@ -1469,9 +1479,9 @@ let ``Each deferred result should be sent as soon as it is computed``() =
         // The second result is a delayed async field, which is set to compute the value for 5 seconds.
         // The first result should come almost instantly, as it is not a delayed computed field.
         // Therefore, let's assume that if it does not come in at least 3 seconds, test has failed.
-        if TimeSpan.FromSeconds(float 3) |> mre1.WaitOne |> not
+        if TimeSpan.FromSeconds(float (ms 3)) |> mre1.WaitOne |> not
         then fail "Timeout while waiting for first deferred result"
-        if TimeSpan.FromSeconds(float 30) |> mre2.WaitOne |> not
+        if TimeSpan.FromSeconds(float (ms 10)) |> mre2.WaitOne |> not
         then fail "Timeout while waiting for second deferred result"
         sub.WaitCompleted()
         sub.Received
@@ -1526,9 +1536,9 @@ let ``Each deferred result of a list should be sent as soon as it is computed`` 
         // The first result is a delayed async field, which is set to compute the value for 5 seconds.
         // The second result should come first, almost instantly, as it is not a delayed computed field.
         // Therefore, let's assume that if it does not come in at least 4 seconds, test has failed.
-        if TimeSpan.FromSeconds(float 4) |> mre1.WaitOne |> not
+        if TimeSpan.FromSeconds(float (ms 4)) |> mre1.WaitOne |> not
         then fail "Timeout while waiting for first deferred result"
-        if TimeSpan.FromSeconds(float 30) |> mre2.WaitOne |> not
+        if TimeSpan.FromSeconds(float (ms 10)) |> mre2.WaitOne |> not
         then fail "Timeout while waiting for second deferred result"
         sub.WaitCompleted()
         sub.Received
@@ -1539,7 +1549,65 @@ let ``Each deferred result of a list should be sent as soon as it is computed`` 
     | _ -> fail "Expected Deferred GQLRespnse"
 
 [<Fact>]
-let ``Each streamed result should be sent as soon as it is computed``() =
+let ``Each streamed result should be sent as soon as it is computed - normal seq`` () =
+    let expectedDirect =
+        NameValueLookup.ofList [
+            "testData", upcast NameValueLookup.ofList [
+                "syncSeq", upcast []
+            ]
+        ]
+    let expectedDeferred1 =
+        NameValueLookup.ofList [
+            "data", upcast [
+                box <| NameValueLookup.ofList [
+                    "value", upcast "Sync 2"
+                ]
+            ]
+            "path", upcast [box "testData"; upcast "syncSeq"; upcast 0]
+        ]
+    let expectedDeferred2 =
+        NameValueLookup.ofList [
+            "data", upcast [
+                box <| NameValueLookup.ofList [
+                    "value", upcast "Sync 1"
+                ]
+            ]
+            "path", upcast [box "testData"; upcast "syncSeq"; upcast 1]
+        ]
+    let query = parse """{
+        testData {
+            syncSeq @stream {
+                value
+            }
+        }
+    }"""
+    use mre1 = new ManualResetEvent(false)
+    use mre2 = new ManualResetEvent(false)
+    let result = query |> executor.AsyncExecute |> sync
+    match result with
+    | Deferred(data, errors, deferred) ->
+        empty errors
+        data.["data"] |> equals (upcast expectedDirect)
+        use sub = deferred |> Observer.createWithCallback (fun sub _ ->
+            if Seq.length sub.Received = 1 then mre1.Set() |> ignore
+            elif Seq.length sub.Received = 2 then mre2.Set() |> ignore)
+        // The first result is a delayed async field exposed through the sequence, which is set to compute the value for 5 seconds.
+        // The second result should come first, as its computation time is set for 1 second.
+        // Therefore, let's assume that if it does not come in at least 4 seconds, test has failed.
+        if TimeSpan.FromSeconds(float (ms 4)) |> mre1.WaitOne |> not
+        then fail "Timeout while waiting for first deferred result"
+        if TimeSpan.FromSeconds(float (ms 10)) |> mre2.WaitOne |> not
+        then fail "Timeout while waiting for second deferred result"
+        sub.WaitCompleted()
+        sub.Received
+        |> Seq.cast<NameValueLookup>
+        |> itemEquals 0 expectedDeferred1
+        |> itemEquals 1 expectedDeferred2
+        |> ignore
+    | _ -> fail "Expected Deferred GQLRespnse"
+
+[<Fact>]
+let ``Each streamed result should be sent as soon as it is computed - async seq``() =
     let expectedDirect =
         NameValueLookup.ofList [
             "testData", upcast NameValueLookup.ofList [
@@ -1584,9 +1652,9 @@ let ``Each streamed result should be sent as soon as it is computed``() =
         // The first result is a delayed async field, which is set to compute the value for 5 seconds.
         // The second result should come first, almost instantly, as it is not a delayed computed field.
         // Therefore, let's assume that if it does not come in at least 4 seconds, test has failed.
-        if TimeSpan.FromSeconds(float 4) |> mre1.WaitOne |> not
+        if TimeSpan.FromSeconds(float (ms 4)) |> mre1.WaitOne |> not
         then fail "Timeout while waiting for first deferred result"
-        if TimeSpan.FromSeconds(float 30) |> mre2.WaitOne |> not
+        if TimeSpan.FromSeconds(float (ms 10)) |> mre2.WaitOne |> not
         then fail "Timeout while waiting for second deferred result"
         sub.WaitCompleted()
         sub.Received

--- a/tests/FSharp.Data.GraphQL.Tests/MiddlewaresTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/MiddlewaresTests.fs
@@ -198,7 +198,7 @@ let ``Deferred queries : Should pass when below threshold``() =
     | Deferred(data, errors, deferred) ->
         empty errors
         data.["data"] |> equals (upcast expected)
-        let sub = Observer.create deferred
+        use sub = Observer.create deferred
         sub.WaitCompleted()
         sub.Received |> single |> equals (upcast expectedDeferred)
     | _ -> fail "Expected Deferred GQLResponse"
@@ -251,7 +251,7 @@ let ``Streamed queries : Should pass when below threshold``() =
     | Deferred(data, errors, deferred) ->
         empty errors
         data.["data"] |> equals (upcast expected)
-        let sub = Observer.create deferred
+        use sub = Observer.create deferred
         sub.WaitCompleted(2)
         sub.Received
         |> Seq.cast<NameValueLookup>

--- a/tests/FSharp.Data.GraphQL.Tests/ObservableExtensionsTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/ObservableExtensionsTests.fs
@@ -25,7 +25,7 @@ let ``ofSeq should call OnComplete and return items in expected order`` () =
     let source = seq { for x in 1 .. 5 do yield x }
     let obs = Observable.ofSeq source
     use sub = Observer.create obs
-    sub.WaitCompleted()
+    sub.WaitCompleted(timeout = ms 10)
     sub.Received |> seqEquals source
 
 [<Fact>]
@@ -33,7 +33,7 @@ let `` bind should call OnComplete and return items in expected order`` () =
     let source = seq { for x in 1 .. 5 do yield x }
     let obs = Observable.ofSeq source |> Observable.bind (fun x -> Observable.ofSeq [x; x])
     use sub = Observer.create obs
-    sub.WaitCompleted()
+    sub.WaitCompleted(timeout = ms 10)
     sub.Received |> seqEquals [ 1; 1; 2; 2; 3; 3; 4; 4; 5; 5 ]
 
 [<Fact>]
@@ -41,7 +41,7 @@ let `` ofAsync should call OnComplete and return items in expected order`` () =
     let source = async { return "test" }
     let obs = Observable.ofAsync source
     use sub = Observer.create obs
-    sub.WaitCompleted()
+    sub.WaitCompleted(timeout = ms 10)
     sub.Received |> seqEquals [ "test" ]
 
 
@@ -50,7 +50,7 @@ let `` ofAsyncVal should call OnComplete and return items in expected order`` ()
     let source = async { return "test" } |> AsyncVal.ofAsync
     let obs = Observable.ofAsyncVal source
     use sub = Observer.create obs
-    sub.WaitCompleted()
+    sub.WaitCompleted(timeout = ms 10)
     sub.Received |> seqEquals [ "test" ]
 
 [<Fact>]
@@ -65,7 +65,7 @@ let ``ofSeq on an empty sequence should call OnComplete and return items in expe
     let source = Seq.empty<int>
     let obs = Observable.ofSeq source
     use sub = Observer.create obs
-    sub.WaitCompleted()
+    sub.WaitCompleted(timeout = ms 10)
     sub.Received |> seqEquals source
 
 [<Fact>]
@@ -76,7 +76,7 @@ let ``ofAsyncSeq should call OnComplete and return items in expected order`` () 
         yield delay 200 3 }
     let obs = Observable.ofAsyncSeq source
     use sub = Observer.create obs
-    sub.WaitCompleted()
+    sub.WaitCompleted(timeout = ms 10)
     sub.Received |> seqEquals [ 1; 3; 2 ]
 
 [<Fact>]
@@ -87,7 +87,7 @@ let ``ofAsyncValSeq should call OnComplete and return items in expected order`` 
         yield delay 200 3 |> AsyncVal.ofAsync }
     let obs = Observable.ofAsyncValSeq source
     use sub = Observer.create obs
-    sub.WaitCompleted()
+    sub.WaitCompleted(timeout = ms 10)
     sub.Received |> seqEquals [ 1; 3; 2 ]
 
 [<Fact>]
@@ -98,7 +98,7 @@ let ``bufferByTiming should call OnComplete and return items in expected order``
         yield delay 200 3 }
     let obs = Observable.ofAsyncSeq source |> Observable.bufferByTiming (ms 300)
     use sub = Observer.create obs
-    sub.WaitCompleted()
+    sub.WaitCompleted(timeout = ms 10)
     sub.Received |> seqEquals [ [1; 3]; [2] ]
 
 [<Fact>]
@@ -109,7 +109,7 @@ let ``bufferByElementCount should call OnComplete and return items in expected o
         yield delay 200 3 }
     let obs = Observable.ofAsyncSeq source |> Observable.bufferByElementCount 2
     use sub = Observer.create obs
-    sub.WaitCompleted()
+    sub.WaitCompleted(timeout = ms 10)
     sub.Received |> seqEquals [ [1; 3]; [2] ]
 
 [<Fact>]
@@ -121,7 +121,7 @@ let ``bufferByTimingAndElementCount should call OnComplete and return items in e
         yield delay 150 4 }
     let obs = Observable.ofAsyncSeq source |> Observable.bufferByTimingAndElementCount (ms 300) 2
     use sub = Observer.create obs
-    sub.WaitCompleted()
+    sub.WaitCompleted(timeout = ms 10)
     sub.Received |> seqEquals [ [1; 3]; [4]; [2] ]
 
 type IndexException(index : int) =
@@ -135,7 +135,7 @@ let ``catch should call OnComplete and return items in expected order`` () =
         Observable.ofSeq source 
         |> Observable.catch (fun (ex : IndexException) -> ex.Index |> Observable.singleton)
     use sub = Observer.create obs
-    sub.WaitCompleted()
+    sub.WaitCompleted(timeout = ms 10)
     sub.Received |> seqEquals [ 1 ]
 
 [<Fact>]
@@ -145,7 +145,7 @@ let ``choose should cal OnComplete`` () =
         Observable.ofSeq source
         |> Observable.choose (fun x -> match x % 2 with | 0 -> Some x | _ -> None)
     use sub = Observer.create obs
-    sub.WaitCompleted()
+    sub.WaitCompleted(timeout = ms 10)
     sub.Received |> seqEquals [ 2; 4 ]
 
 [<Fact>]
@@ -163,7 +163,7 @@ let ``concat should call OnComplete and return items in expected order`` () =
         |> Observable.map Observable.ofAsyncSeq
         |> Observable.concat
     use sub = Observer.create obs
-    sub.WaitCompleted()
+    sub.WaitCompleted(timeout = ms 10)
     sub.Received |> seqEquals [ 1; 3; 2; 5; 4 ]
 
 [<Fact>]
@@ -179,7 +179,7 @@ let ``concat2 should call OnComplete and return items in expected order`` () =
         Observable.ofAsyncSeq source2
         |> Observable.concat2 (Observable.ofAsyncSeq source1)
     use sub = Observer.create obs
-    sub.WaitCompleted()
+    sub.WaitCompleted(timeout = ms 10)
     sub.Received |> seqEquals [ 1; 3; 2; 5; 4 ]
 
 [<Fact>]
@@ -197,7 +197,7 @@ let ``merge should call OnComplete and return items in expected order`` () =
         |> Observable.map Observable.ofAsyncSeq
         |> Observable.merge
     use sub = Observer.create obs
-    sub.WaitCompleted()
+    sub.WaitCompleted(timeout = ms 10)
     sub.Received |> seqEquals [ 1; 3; 5; 4; 2 ]
 
 [<Fact>]
@@ -213,7 +213,7 @@ let ``merge2 should call OnComplete and return items in expected order`` () =
         Observable.ofAsyncSeq source2
         |> Observable.merge2 (Observable.ofAsyncSeq source1)
     use sub = Observer.create obs
-    sub.WaitCompleted()
+    sub.WaitCompleted(timeout = ms 10)
     sub.Received |> seqEquals [ 1; 3; 5; 4; 2 ]
 
 [<Fact>]
@@ -221,7 +221,7 @@ let ``concatSeq should call OnComplete and return items in expected order`` () =
     let source = seq { for x in 1 .. 5 do yield x }
     let obs = Observable.singleton source |> Observable.concatSeq
     use sub = Observer.create obs
-    sub.WaitCompleted()
+    sub.WaitCompleted(timeout = ms 10)
     sub.Received |> seqEquals source
 
 [<Fact>]
@@ -229,5 +229,5 @@ let ``mapAsync should call OnComplete and return items in expected order`` () =
     let source = seq { for x in 1 .. 5 do yield x }
     let obs = Observable.ofSeq source |> Observable.mapAsync (fun x -> async { return x })
     use sub = Observer.create obs
-    sub.WaitCompleted()
+    sub.WaitCompleted(timeout = ms 10)
     sub.Received |> seqEquals source

--- a/tests/FSharp.Data.GraphQL.Tests/Program.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/Program.fs
@@ -1,4 +1,4 @@
 ﻿module Program
 
 [<EntryPoint>]
-let main args = 0
+let main _ = 0

--- a/tests/FSharp.Data.GraphQL.Tests/Relay/NodeTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/Relay/NodeTests.fs
@@ -63,7 +63,7 @@ let execAndValidateNode (query: string) expectedDirect expectedDeferred =
             let expectedItemCount = Seq.length expectedDeferred
             empty errors
             data.["data"] |> equals (upcast NameValueLookup.ofList ["node", upcast expectedDirect])
-            let sub = Observer.create deferred
+            use sub = Observer.create deferred
             sub.WaitCompleted(expectedItemCount)
             sub.Received
             |> Seq.cast<NameValueLookup>

--- a/tests/FSharp.Data.GraphQL.Tests/SubscriptionTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/SubscriptionTests.fs
@@ -119,15 +119,13 @@ let ``Should be able to subscribe to sync field and get results``() =
             data
         }
     }"""
-    use mre = new ManualResetEvent(false)
-    let actual = ConcurrentBag<Output>()
     let result = executor.AsyncExecute(query) |> sync
     match result with
     | Stream data ->
-        data |> Observable.add (fun x -> actual.Add(x); set mre)
+        let sub = Observer.create data
         updateValue 1 "Updated value 1"
-        wait mre "Timeout while waiting for Stream GQLResponse"
-        actual
+        sub.WaitForItem()
+        sub.Received
         |> Seq.cast<NameValueLookup>
         |> contains expected
         |> ignore
@@ -149,15 +147,13 @@ let ``Should be able to subscribe to tagged sync field and get results with expe
             data
         }
     }"""
-    use mre = new ManualResetEvent(false)
-    let actual = ConcurrentBag<Output>()
     let result = executor.AsyncExecute(query) |> sync
     match result with
     | Stream data ->
-        data |> Observable.add (fun x -> actual.Add(x); set mre)
+        let sub = Observer.create data
         updateValue 1 "Updated value 1"
-        wait mre "Timeout while waiting for Stream GQLResponse"
-        actual
+        sub.WaitForItem()
+        sub.Received
         |> Seq.cast<NameValueLookup>
         |> contains expected
         |> ignore
@@ -171,14 +167,12 @@ let ``Should be able to subscribe to tagged sync field and do not get results wi
             data
         }
     }"""
-    use mre = new ManualResetEvent(false)
-    let actual = ConcurrentBag<Output>()
     let result = executor.AsyncExecute(query) |> sync
     match result with
     | Stream data ->
-        data |> Observable.add (fun x -> actual.Add(x); set mre)
+        let sub = Observer.create data
         updateValue 1 "Updated value 1"
-        ensureThat (fun () -> actual.IsEmpty) 10 "Should not get results with given tag"
+        ensureThat (fun () -> Seq.isEmpty sub.Received) 50 "Should not get results with given tag"
     | _ -> failwith "Expected Stream GQLResponse"
 
 [<Fact>]
@@ -197,15 +191,13 @@ let ``Should be able to subscribe to async field and get results``() =
     data
   }
 }"""
-    let mre = new ManualResetEvent(false)
-    let actual = ConcurrentBag<Output>()
     let result = executor.AsyncExecute(query) |> sync
     match result with
     | Stream data ->
-        data |> Observable.add (fun x -> actual.Add(x); set mre)
+        let sub = Observer.create data
         updateValue 1 "Updated value 1"
-        wait mre "Timeout while waiting for Stream GQLResponse"
-        actual
+        sub.WaitForItem()
+        sub.Received
         |> Seq.cast<NameValueLookup>
         |> contains expected
         |> ignore
@@ -227,15 +219,13 @@ let ``Should be able to subscribe to tagged async field and get results with exp
     data
   }
 }"""
-    use mre = new ManualResetEvent(false)
-    let actual = ConcurrentBag<Output>()
     let result = executor.AsyncExecute(query) |> sync
     match result with
     | Stream data ->
-        data |> Observable.add (fun x -> actual.Add(x); set mre)
+        let sub = Observer.create data
         updateValue 1 "Updated value 1"
-        wait mre "Timeout while waiting for Stream GQLResponse"
-        actual
+        sub.WaitForItem()
+        sub.Received
         |> Seq.cast<NameValueLookup>
         |> contains expected
         |> ignore
@@ -249,12 +239,10 @@ let ``Should be able to subscribe to tagged async field and do not get results w
             data
         }
     }"""
-    use mre = new ManualResetEvent(false)
-    let actual = ConcurrentBag<Output>()
     let result = executor.AsyncExecute(query) |> sync
     match result with
     | Stream data ->
-        data |> Observable.add (fun x -> actual.Add(x); set mre)
+        let sub = Observer.create data
         updateValue 1 "Updated value 1"
-        ensureThat (fun () -> actual.IsEmpty) 10 "Should not get results with given tag"
+        ensureThat (fun () -> Seq.isEmpty sub.Received) 50 "Should not get results with given tag"
     | _ -> failwith "Expected Stream GQLResponse"

--- a/tests/FSharp.Data.GraphQL.Tests/SubscriptionTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/SubscriptionTests.fs
@@ -122,7 +122,7 @@ let ``Should be able to subscribe to sync field and get results``() =
     let result = executor.AsyncExecute(query) |> sync
     match result with
     | Stream data ->
-        let sub = Observer.create data
+        use sub = Observer.create data
         updateValue 1 "Updated value 1"
         sub.WaitForItem()
         sub.Received
@@ -150,7 +150,7 @@ let ``Should be able to subscribe to tagged sync field and get results with expe
     let result = executor.AsyncExecute(query) |> sync
     match result with
     | Stream data ->
-        let sub = Observer.create data
+        use sub = Observer.create data
         updateValue 1 "Updated value 1"
         sub.WaitForItem()
         sub.Received
@@ -170,7 +170,7 @@ let ``Should be able to subscribe to tagged sync field and do not get results wi
     let result = executor.AsyncExecute(query) |> sync
     match result with
     | Stream data ->
-        let sub = Observer.create data
+        use sub = Observer.create data
         updateValue 1 "Updated value 1"
         ensureThat (fun () -> Seq.isEmpty sub.Received) 50 "Should not get results with given tag"
     | _ -> failwith "Expected Stream GQLResponse"
@@ -194,7 +194,7 @@ let ``Should be able to subscribe to async field and get results``() =
     let result = executor.AsyncExecute(query) |> sync
     match result with
     | Stream data ->
-        let sub = Observer.create data
+        use sub = Observer.create data
         updateValue 1 "Updated value 1"
         sub.WaitForItem()
         sub.Received
@@ -222,7 +222,7 @@ let ``Should be able to subscribe to tagged async field and get results with exp
     let result = executor.AsyncExecute(query) |> sync
     match result with
     | Stream data ->
-        let sub = Observer.create data
+        use sub = Observer.create data
         updateValue 1 "Updated value 1"
         sub.WaitForItem()
         sub.Received
@@ -242,7 +242,7 @@ let ``Should be able to subscribe to tagged async field and do not get results w
     let result = executor.AsyncExecute(query) |> sync
     match result with
     | Stream data ->
-        let sub = Observer.create data
+        use sub = Observer.create data
         updateValue 1 "Updated value 1"
         ensureThat (fun () -> Seq.isEmpty sub.Received) 50 "Should not get results with given tag"
     | _ -> failwith "Expected Stream GQLResponse"


### PR DESCRIPTION
This PR is meant to solve the inconsistency in test runs made against machines with less cores - specially CI ones (which normally run with 2 cores).