### PR TITLE
Add Schema Post-Compilation Middleware

### DIFF
--- a/src/FSharp.Data.GraphQL.Server.Middlewares/MiddlewareDefinitions.fs
+++ b/src/FSharp.Data.GraphQL.Server.Middlewares/MiddlewareDefinitions.fs
@@ -50,6 +50,7 @@ type internal QueryWeightMiddleware(threshold : float, reportToMetadata : bool) 
         else error ctx
     interface IExecutorMiddleware with
         member __.CompileSchema = None
+        member __.PostCompileSchema = None
         member __.PlanOperation = None
         member __.ExecuteOperationAsync = Some (middleware threshold)
 
@@ -106,6 +107,7 @@ type internal ObjectListFilterMiddleware<'ObjectType, 'ListType>(reportToMetadat
         next ctx
     interface IExecutorMiddleware with
         member __.CompileSchema = Some compileMiddleware
+        member __.PostCompileSchema = None
         member __.PlanOperation = None
         member __.ExecuteOperationAsync = Some reportMiddleware
 
@@ -145,5 +147,6 @@ type internal LiveQueryMiddleware(identityNameResolver : IdentityNameResolver) =
         next ctx
     interface IExecutorMiddleware with
         member __.CompileSchema = Some middleware
+        member __.PostCompileSchema = None
         member __.PlanOperation = None
         member __.ExecuteOperationAsync = None

--- a/src/FSharp.Data.GraphQL.Server/DefineExtensions.fs
+++ b/src/FSharp.Data.GraphQL.Server/DefineExtensions.fs
@@ -11,10 +11,12 @@ module DefineExtensions =
         /// Defines an executor middleware by setting their sub-middleware functions.
         /// </summary>
         /// <param name="compile">The schema compile sub-middleware function.</param>
+        /// <param name="postCompile">The schema post-compile sub-middleware function.</param>
         /// <param name="plan">The operation planning sub-middleware function.</param>
         /// <param name="execute">The operation execution sub-middleware function.</param>
-        static member ExecutorMiddleware(?compile, ?plan, ?execute) : IExecutorMiddleware =
+        static member ExecutorMiddleware(?compile, ?postCompile, ?plan, ?execute) : IExecutorMiddleware =
             { new IExecutorMiddleware with 
-                member __.CompileSchema = compile 
+                member __.CompileSchema = compile
+                member __.PostCompileSchema = postCompile
                 member __.PlanOperation = plan
                 member __.ExecuteOperationAsync = execute }

--- a/tests/FSharp.Data.GraphQL.Tests/ExecutorMiddlewareTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/ExecutorMiddlewareTests.fs
@@ -3,6 +3,7 @@ module FSharp.Data.GraphQL.Tests.ExecutorMiddlewareTests
 open Xunit
 open FSharp.Data.GraphQL
 open FSharp.Data.GraphQL.Types
+open FSharp.Data.GraphQL.Types.Patterns
 open FSharp.Data.GraphQL.Parser
 open FSharp.Data.GraphQL.Execution
 open FSharp.Data.GraphQL.Ast
@@ -29,6 +30,7 @@ let DataType =
             Define.Field("a", String, resolve = fun _ dt -> dt.a)
             Define.Field("b", String, resolve = fun _ dt -> dt.b)
             Define.Field("c", String, resolve = fun _ dt -> dt.c)
+            Define.Field("hasFoo", Boolean, resolve = fun ctx _ -> ctx.Context.Variables.ContainsKey "foo")
         ])
 let Query =
     Define.Object<TestSubject>(
@@ -42,6 +44,7 @@ let ast = parse """{
             a
             b
             c
+            hasFoo
         }
     }"""
 
@@ -50,6 +53,17 @@ let compileMiddleware (ctx : SchemaCompileContext) (next : SchemaCompileContext 
     let fieldDef = Define.Field("a", String, fun _ dt -> dt.c)
     ctx.FieldExecuteMap.SetExecute("Data", fieldDef)
     next ctx
+
+// After the schema has been compiled, inject a fake variable "foo" to every input object
+let postCompileMiddleware (schema : ISchema) (next : ISchema -> unit) =
+    schema.TypeMap.ToSeq()
+    |> Seq.iter(fun (n, def) ->
+                    match def with
+                    | InputObject iobj ->
+                        iobj.Fields
+                        |> Array.iter(fun f -> f.ExecuteInput <- (fun value vars -> f.ExecuteInput value (Map.add "foo" (upcast 1) vars)))
+                    | _ -> ())
+    next schema
 
 // On the planning phase, we watch the time needed to do the operation
 let planningMiddleware (ctx : PlanningContext) (next : PlanningContext -> ExecutionPlan) =
@@ -83,6 +97,7 @@ let executionMiddleware (ctx : ExecutionContext) (next : ExecutionContext -> Asy
 let middleware =
     { new IExecutorMiddleware with
         member __.CompileSchema = Some compileMiddleware
+        member __.PostCompileSchema = Some postCompileMiddleware
         member __.PlanOperation = Some planningMiddleware
         member __.ExecuteOperationAsync = Some executionMiddleware }
 
@@ -96,7 +111,8 @@ let ``Executor middleware: change fields and measure planning time`` () =
                 [ "testData", 
                     upcast NameValueLookup.ofList 
                         [ "a", upcast "Cookie" 
-                          "b", upcast "Banana" ] ]
+                          "b", upcast "Banana"
+                          "hasFoo", upcast true ] ]
     match result with
     | Direct (data, errors) ->
         empty errors

--- a/tests/FSharp.Data.GraphQL.Tests/ExecutorMiddlewareTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/ExecutorMiddlewareTests.fs
@@ -63,9 +63,9 @@ let postCompileMiddleware (schema : ISchema) (next : ISchema -> unit) =
     schema.TypeMap.ToSeq()
     |> Seq.iter(fun (n, def) ->
                     match def with
-                    | InputObject iobj ->
-                        iobj.Fields
-                        |> Array.iter(fun f -> f.ExecuteInput <- (flipBools f.ExecuteInput))
+                    | Object obj ->
+                        obj.Fields
+                        |> Map.iter(fun _ f -> f.Args |> Array.iter(fun f -> f.ExecuteInput <- (flipBools f.ExecuteInput)))
                     | _ -> ())
     next schema
 


### PR DESCRIPTION
Some middleware requires access to data that is constructed after schema compilation is complete, yet should only be run once, rather than on every single request. This PR adds another middleware phase that runs after the schema is constructed. It's signature looks like
```
type SchemaPostCompileMiddleware =
    ISchema -> (ISchema -> unit) -> unit
```