### PR TITLE
Changing record types constructors to have optional parameters, number parsing fixes

### DIFF
--- a/samples/FSharp.Data.GraphQL.Samples.GiraffeServer/Schema.fs
+++ b/samples/FSharp.Data.GraphQL.Samples.GiraffeServer/Schema.fs
@@ -42,20 +42,30 @@ type Root =
 type IThing =
     abstract member Shape : string
     abstract member Id : string
+    abstract member Order : int
+    abstract member Size : float
 
 type Ball() =
     member __.Id = "1"
     member __.Shape = "Spheric"
+    member __.Order = 0
+    member __.Size = 1.20
     interface IThing with
         member this.Shape = this.Shape
         member this.Id = this.Id
+        member this.Order = this.Order
+        member this.Size = this.Size
 
 type Box() =
     member __.Shape = "Cubic"
     member __.Id = "2"
+    member __.Order = 1
+    member __.Size = 2.155
     interface IThing with
         member this.Shape = this.Shape
         member this.Id = this.Id
+        member this.Order = this.Order
+        member this.Size = this.Size
 
 type Character =
     | Human of Human
@@ -153,6 +163,8 @@ module Schema =
             [
                 Define.Field("format", String, "The format of the shape.", fun _ (t : IThing) -> t.Shape)
                 Define.Field("id", String, "The ID of the shape.", fun _ (t : IThing) -> t.Id)
+                Define.Field("order", Int, "The ID of the shape.", fun _ (t : IThing) -> t.Order)
+                Define.Field("size", Float, "The ID of the shape.", fun _ (t : IThing) -> t.Size)
                 Define.Field("form", String, "The format of the shape.", [], (fun _ (t : IThing) -> t.Shape), deprecationReason = "Use format field instead.")
             ])
 
@@ -166,6 +178,8 @@ module Schema =
             [
                 Define.Field("format", String, "The format of the ball.", fun _ (b : Ball) -> b.Shape)
                 Define.Field("id", String, "The ID of the ball.", fun _ (b : Ball) -> b.Id)
+                Define.Field("order", Int, "The ID of the shape.", fun _ (b : Ball) -> b.Order)
+                Define.Field("size", Float, "The ID of the shape.", fun _ (b : Ball) -> b.Size)
                 Define.Field("form", String, "The format of the shape.", [], (fun _ (b : Ball) -> b.Shape), deprecationReason = "Use format field instead.")
             ]
         )
@@ -180,6 +194,8 @@ module Schema =
             [
                 Define.Field("format", String, "The format of the box.", fun _ (b : Box) -> b.Shape)
                 Define.Field("id", String, "The ID of the box.", fun _ (b : Box) -> b.Id)
+                Define.Field("order", Int, "The ID of the shape.", fun _ (b : Box) -> b.Order)
+                Define.Field("size", Float, "The ID of the shape.", fun _ (b : Box) -> b.Size)
                 Define.Field("form", String, "The format of the shape.", [], (fun _ (b : Box) -> b.Shape), deprecationReason = "Use format field instead.")
             ]
         )

--- a/samples/client-provider/object_parameters.fsx
+++ b/samples/client-provider/object_parameters.fsx
@@ -20,13 +20,14 @@ open FSharp.Data.GraphQL
 
 type MyProvider = GraphQLProvider<"http://localhost:8084">
 
-let filter = MyProvider.Types.ThingFilter(format = "Cubic")
+let filter = MyProvider.Types.ThingFilter(format = "Spheric")
 
 let operation = 
     MyProvider.Operation<"""query q($filter: ThingFilter!) {
     things(filter: $filter) {
       id
       format
+      order
     }
   }""">()
 
@@ -35,3 +36,5 @@ let result = operation.Run(filter = filter)
 printfn "Data: %A\n" result.Data
 printfn "Errors: %A\n" result.Errors
 printfn "Custom data: %A\n" result.CustomData
+
+printfn "Order: %A" result.Data.Value.Things.[0].Order

--- a/samples/client-provider/sample_schema.json
+++ b/samples/client-provider/sample_schema.json
@@ -1,17 +1,14 @@
 {
-  "documentId": -240132443,
+  "documentId": -722816445,
   "data": {
     "__schema": {
       "queryType": {
-        "kind": "OBJECT",
         "name": "Query"
       },
       "mutationType": {
-        "kind": "OBJECT",
         "name": "Mutation"
       },
       "subscriptionType": {
-        "kind": "OBJECT",
         "name": "Subscription"
       },
       "types": [
@@ -105,7 +102,8 @@
                     "name": null,
                     "ofType": {
                       "kind": "OBJECT",
-                      "name": "__Directive"
+                      "name": "__Directive",
+                      "ofType": null
                     }
                   }
                 }
@@ -168,7 +166,8 @@
                     "name": null,
                     "ofType": {
                       "kind": "OBJECT",
-                      "name": "__Type"
+                      "name": "__Type",
+                      "ofType": null
                     }
                   }
                 }
@@ -202,7 +201,8 @@
                     "name": null,
                     "ofType": {
                       "kind": "OBJECT",
-                      "name": "__InputValue"
+                      "name": "__InputValue",
+                      "ofType": null
                     }
                   }
                 }
@@ -237,7 +237,8 @@
                     "name": null,
                     "ofType": {
                       "kind": "ENUM",
-                      "name": "__DirectiveLocation"
+                      "name": "__DirectiveLocation",
+                      "ofType": null
                     }
                   }
                 }
@@ -654,7 +655,8 @@
                     "name": null,
                     "ofType": {
                       "kind": "OBJECT",
-                      "name": "__InputValue"
+                      "name": "__InputValue",
+                      "ofType": null
                     }
                   }
                 }
@@ -848,6 +850,72 @@
               "description": "Location adjacent to an inline fragment.",
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "SCHEMA",
+              "description": "Location adjacent to a schema IDL definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SCALAR",
+              "description": "Location adjacent to a scalar IDL definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "OBJECT",
+              "description": "Location adjacent to an object IDL definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FIELD_DEFINITION",
+              "description": "Location adjacent to a field IDL definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ARGUMENT_DEFINITION",
+              "description": "Location adjacent to a field argument IDL definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INTERFACE",
+              "description": "Location adjacent to an interface IDL definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "UNION",
+              "description": "Location adjacent to an union IDL definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ENUM",
+              "description": "Location adjacent to an enum IDL definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ENUM_VALUE",
+              "description": "Location adjacent to an enum value definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INPUT_OBJECT",
+              "description": "Location adjacent to an input object IDL definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INPUT_FIELD_DEFINITION",
+              "description": "Location adjacent to an input object field IDL definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "possibleTypes": null
@@ -964,7 +1032,8 @@
                     "name": null,
                     "ofType": {
                       "kind": "INTERFACE",
-                      "name": "Thing"
+                      "name": "Thing",
+                      "ofType": null
                     }
                   }
                 }
@@ -998,7 +1067,8 @@
                     "name": null,
                     "ofType": {
                       "kind": "ENUM",
-                      "name": "Episode"
+                      "name": "Episode",
+                      "ofType": null
                     }
                   }
                 }
@@ -1153,7 +1223,8 @@
                     "name": null,
                     "ofType": {
                       "kind": "ENUM",
-                      "name": "Episode"
+                      "name": "Episode",
+                      "ofType": null
                     }
                   }
                 }
@@ -1320,6 +1391,38 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "order",
+              "description": "The ID of the shape.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "size",
+              "description": "The ID of the shape.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
                   "ofType": null
                 }
               },
@@ -1530,6 +1633,38 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "order",
+              "description": "The ID of the shape.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "size",
+              "description": "The ID of the shape.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -1590,6 +1725,38 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "order",
+              "description": "The ID of the shape.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "size",
+              "description": "The ID of the shape.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
                   "ofType": null
                 }
               },

--- a/samples/client-provider/standard_features.fsx
+++ b/samples/client-provider/standard_features.fsx
@@ -32,8 +32,8 @@ type MyProvider = GraphQLProvider<"sample_schema.json">
 // Once mapped, all custom types of the schema (types that are not scalar types)
 // will be mapped into CLR types. You can create those types by filling each of its
 // properties into the constructor.
-let ball = MyProvider.Types.Ball(form = "Spheric", format = "Spheric", id = "1")
-let box = MyProvider.Types.Box(form = "Cubic", format = "Cubic", id = "2")
+let ball = MyProvider.Types.Ball(form = "Spheric", format = "Spheric", id = "1", order = 0, size = 1.11)
+let box = MyProvider.Types.Box(form = "Cubic", format = "Cubic", id = "2", order = 1, size = 2.0)
 
 let things : MyProvider.Types.IThing list = [ball; box]
 

--- a/src/FSharp.Data.GraphQL.Client/BaseTypes.fs
+++ b/src/FSharp.Data.GraphQL.Client/BaseTypes.fs
@@ -300,9 +300,6 @@ module internal JsonValueHelper =
                 | TypeKind.ENUM -> makeNoneIfNeeded typeof<EnumBase>
                 | TypeKind.SCALAR -> getScalarType fieldType |> makeNoneIfNeeded
                 | kind -> failwithf "Unsupported type kind \"%A\"." kind
-            // GraphQL does not have a built-in spec type equivalent to System.Decimal.
-            // So in this case, we convert it to float, even if JsonValue.Parse did parse it to a System.Decimal.
-            | JsonValue.Number n -> makeSomeIfNeeded (float n)
             | JsonValue.Integer n -> makeSomeIfNeeded n
             | JsonValue.String s -> 
                 match fieldType.Kind with

--- a/src/FSharp.Data.GraphQL.Client/BaseTypes.fs
+++ b/src/FSharp.Data.GraphQL.Client/BaseTypes.fs
@@ -300,7 +300,10 @@ module internal JsonValueHelper =
                 | TypeKind.ENUM -> makeNoneIfNeeded typeof<EnumBase>
                 | TypeKind.SCALAR -> getScalarType fieldType |> makeNoneIfNeeded
                 | kind -> failwithf "Unsupported type kind \"%A\"." kind
+            // GraphQL does not have a built-in spec type equivalent to System.Decimal.
+            // So in this case, we convert it to float, even if JsonValue.Parse did parse it to a System.Decimal.
             | JsonValue.Number n -> makeSomeIfNeeded (float n)
+            | JsonValue.Integer n -> makeSomeIfNeeded n
             | JsonValue.String s -> 
                 match fieldType.Kind with
                 | TypeKind.NON_NULL ->
@@ -349,8 +352,7 @@ module internal JsonValueHelper =
                 | Some (_, JsonValue.String message), Some (_, JsonValue.Array path) ->
                     let pathMapper = function
                         | JsonValue.String x -> box x
-                        | JsonValue.Float x -> box (int x)
-                        | JsonValue.Number x -> box (int x)
+                        | JsonValue.Integer x -> box x
                         | _ -> failwith "Error parsing response errors. A item in the path is neither a String or a Number."
                     { Message = message; Path = Array.map pathMapper path }
                 | _ -> failwith "Error parsing response errors. Unsupported errors field format."

--- a/src/FSharp.Data.GraphQL.Client/ReflectionPatterns.fs
+++ b/src/FSharp.Data.GraphQL.Client/ReflectionPatterns.fs
@@ -7,7 +7,6 @@ open System
 open System.Collections
 open Microsoft.FSharp.Reflection
 
-[<AutoOpen>]
 module ReflectionPatterns =
     let private numericTypes =
         [| typeof<decimal>
@@ -30,21 +29,46 @@ module ReflectionPatterns =
 
     let isList (t : Type) =
         if t.IsGenericType
-        then
-            let gtype = t.GetGenericTypeDefinition()
-            if gtype = typedefof<_ list>
-            then true
-            else false
+        then t.GetGenericTypeDefinition() = typedefof<_ list>
         else false
 
     let isSeq (t : Type) =
         if t.IsGenericType
-        then
-            let gtype = t.GetGenericTypeDefinition()
-            if gtype = typedefof<seq<_>>
-            then true
-            else false
+        then t.GetGenericTypeDefinition() = typedefof<seq<_>>
         else false
+
+    let getOptionCases (t: Type) =
+        let otype = typedefof<_ option>.MakeGenericType(t)
+        let cases = FSharpType.GetUnionCases(otype)
+        let some = cases |> Array.find (fun c -> c.Name = "Some")
+        let none = cases |> Array.find (fun c -> c.Name = "None")
+        (some, none, otype)
+
+    let makeArray (itype : Type) (items : obj []) =
+        if Array.exists isNull items
+        then failwith "Array is an array of non null items, but a null item was found."
+        else
+            let arr = Array.CreateInstance(itype, items.Length)
+            items |> Array.iteri (fun i x -> arr.SetValue(x, i))
+            box arr
+
+    let makeOptionArray (itype : Type) (items : obj []) =
+        let (some, none, otype) = getOptionCases(itype)
+        let arr = Array.CreateInstance(otype, items.Length)
+        let mapper (i : int) (x : obj) =
+            if isNull x
+            then arr.SetValue(FSharpValue.MakeUnion(none, [||]), i)
+            else arr.SetValue(FSharpValue.MakeUnion(some, [|x|]), i)
+        items |> Array.iteri mapper
+        box arr
+
+    let makeSome (value : obj) =
+        let (some, _, _) = getOptionCases (value.GetType())
+        FSharpValue.MakeUnion(some, [|value|])
+
+    let makeNone (t : Type) =
+        let (_, none, _) = getOptionCases t
+        FSharpValue.MakeUnion(none, [||])
 
     let (|Option|_|) t =
         if isOption t then Some (Option (t.GetGenericArguments().[0]))
@@ -89,3 +113,15 @@ module ReflectionPatterns =
         if xtype.IsEnum
         then Some (x.ToString())
         else None
+
+    let makeValue (t : Type) (value : obj) =
+        let isOption = isOption t
+        match value, isOption with
+        | null, true -> makeNone t
+        | OptionValue (Some null), true -> box (makeSome (Convert.ChangeType(null, t)))
+        | OptionValue (Some value), true -> box (makeSome value)
+        | OptionValue (Some value), false -> Convert.ChangeType(value, t)
+        | OptionValue None, false -> Convert.ChangeType(null, t)
+        | OptionValue None, true -> box (makeNone t)
+        | value, true -> makeSome value
+        | value, false -> Convert.ChangeType(value, t)

--- a/src/FSharp.Data.GraphQL.Client/Serialization.fs
+++ b/src/FSharp.Data.GraphQL.Client/Serialization.fs
@@ -104,7 +104,6 @@ module Serialization =
             match parsed with
             | JsonValue.Null -> downcastNone t
             | JsonValue.String s -> downcastString t s
-            | JsonValue.Number n -> downcastNumber t n
             | JsonValue.Float n -> downcastNumber t n
             | JsonValue.Integer n -> downcastNumber t n
             | JsonValue.Record jprops ->
@@ -144,7 +143,6 @@ module Serialization =
                 | JsonValue.Record fields -> name, (fields |> helper |> Map.ofArray |> box)
                 | JsonValue.Null -> name, null
                 | JsonValue.String s -> name, box s
-                | JsonValue.Number n -> name, box n
                 | JsonValue.Integer n -> name, box n
                 | JsonValue.Float f -> name, box f
                 | JsonValue.Array items -> name, (items |> Array.map (fun item -> null, item) |> helper |> Array.map snd |> box)
@@ -161,17 +159,8 @@ module Serialization =
                 match x with
                 | null -> JsonValue.Null
                 | OptionValue None -> JsonValue.Null
-                | :? byte as x -> JsonValue.Integer (int x)
-                | :? sbyte as x -> JsonValue.Integer (int x)
-                | :? uint16 as x -> JsonValue.Integer (int x)
-                | :? int16 as x -> JsonValue.Integer (int x)
                 | :? int as x -> JsonValue.Integer (int x)
-                | :? uint32 as x -> JsonValue.Integer (int x)
-                | :? int64 as x -> JsonValue.Integer (int x)
-                | :? uint64 as x -> JsonValue.Integer (int x)
-                | :? single as x -> JsonValue.Float (float x)
-                | :? double as x -> JsonValue.Float x
-                | :? decimal as x -> JsonValue.Number x
+                | :? float as x -> JsonValue.Float x
                 | :? string as x -> JsonValue.String x
                 | :? Guid as x -> JsonValue.String (x.ToString())
                 | :? DateTime as x when x.Date = x -> JsonValue.String (x.ToString(isoDateFormat))

--- a/src/FSharp.Data.GraphQL.Client/Serialization.fs
+++ b/src/FSharp.Data.GraphQL.Client/Serialization.fs
@@ -106,6 +106,7 @@ module Serialization =
             | JsonValue.String s -> downcastString t s
             | JsonValue.Number n -> downcastNumber t n
             | JsonValue.Float n -> downcastNumber t n
+            | JsonValue.Integer n -> downcastNumber t n
             | JsonValue.Record jprops ->
                 let jprops = 
                     jprops 
@@ -143,7 +144,8 @@ module Serialization =
                 | JsonValue.Record fields -> name, (fields |> helper |> Map.ofArray |> box)
                 | JsonValue.Null -> name, null
                 | JsonValue.String s -> name, box s
-                | JsonValue.Number n -> name, box (int n)
+                | JsonValue.Number n -> name, box n
+                | JsonValue.Integer n -> name, box n
                 | JsonValue.Float f -> name, box f
                 | JsonValue.Array items -> name, (items |> Array.map (fun item -> null, item) |> helper |> Array.map snd |> box)
                 | JsonValue.Boolean b -> name, box b)
@@ -159,17 +161,17 @@ module Serialization =
                 match x with
                 | null -> JsonValue.Null
                 | OptionValue None -> JsonValue.Null
-                | :? byte as x -> JsonValue.Number (decimal x)
-                | :? sbyte as x -> JsonValue.Number (decimal x)
-                | :? uint16 as x -> JsonValue.Number (decimal x)
-                | :? int16 as x -> JsonValue.Number (decimal x)
-                | :? int as x -> JsonValue.Number (decimal x)
-                | :? uint32 as x -> JsonValue.Number (decimal x)
-                | :? int64 as x -> JsonValue.Number (decimal x)
-                | :? uint64 as x -> JsonValue.Number (decimal x)
+                | :? byte as x -> JsonValue.Integer (int x)
+                | :? sbyte as x -> JsonValue.Integer (int x)
+                | :? uint16 as x -> JsonValue.Integer (int x)
+                | :? int16 as x -> JsonValue.Integer (int x)
+                | :? int as x -> JsonValue.Integer (int x)
+                | :? uint32 as x -> JsonValue.Integer (int x)
+                | :? int64 as x -> JsonValue.Integer (int x)
+                | :? uint64 as x -> JsonValue.Integer (int x)
                 | :? single as x -> JsonValue.Float (float x)
                 | :? double as x -> JsonValue.Float x
-                | :? decimal as x -> JsonValue.Float (float x)
+                | :? decimal as x -> JsonValue.Number x
                 | :? string as x -> JsonValue.String x
                 | :? Guid as x -> JsonValue.String (x.ToString())
                 | :? DateTime as x when x.Date = x -> JsonValue.String (x.ToString(isoDateFormat))

--- a/src/FSharp.Data.GraphQL.Client/Serialization.fs
+++ b/src/FSharp.Data.GraphQL.Client/Serialization.fs
@@ -9,6 +9,7 @@ open System.Reflection
 open System.Collections.Generic
 open System.Globalization
 open FSharp.Data.GraphQL
+open FSharp.Data.GraphQL.Client.ReflectionPatterns
 
 module Serialization =
     let private isoDateFormat = "yyyy-MM-dd" 

--- a/src/FSharp.Data.GraphQL.Client/TextConversions.fs
+++ b/src/FSharp.Data.GraphQL.Client/TextConversions.fs
@@ -3,7 +3,6 @@
 // This sample code is provided "as is" without warranty of any kind.
 // We disclaim all warranties, either express or implied, including the
 // warranties of merchantability and fitness for a particular purpose.
-//
 // A simple F# portable parser for JSON data
 // --------------------------------------------------------------------------------------
 

--- a/src/FSharp.Data.GraphQL.Client/TextConversions.fs
+++ b/src/FSharp.Data.GraphQL.Client/TextConversions.fs
@@ -42,7 +42,7 @@ type TextConversions private() =
   static member val private DefaultRemovableAdornerCharacters = 
     Set.union TextConversions.DefaultNonCurrencyAdorners TextConversions.DefaultCurrencyAdorners
   
-  static member private RemoveAdorners (value:string) = 
+  static member private RemoveAdorners (value : string) = 
     String(value.ToCharArray() |> Array.filter (not << TextConversions.DefaultRemovableAdornerCharacters.Contains))
 
   static member AsString str =
@@ -50,12 +50,6 @@ type TextConversions private() =
 
   static member AsInteger cultureInfo text = 
     Int32.TryParse(TextConversions.RemoveAdorners text, NumberStyles.Integer, cultureInfo) |> asOption
-  
-  static member AsInteger64 cultureInfo text = 
-    Int64.TryParse(TextConversions.RemoveAdorners text, NumberStyles.Integer, cultureInfo) |> asOption
-  
-  static member AsDecimal cultureInfo text =
-    Decimal.TryParse(TextConversions.RemoveAdorners text, NumberStyles.Currency, cultureInfo) |> asOption
   
   static member AsFloat missingValues useNoneForMissingValues cultureInfo (text:string) = 
     match text.Trim() with

--- a/tests/FSharp.Data.GraphQL.IntegrationTests/CustomHttpHeaderFileTests.fs
+++ b/tests/FSharp.Data.GraphQL.IntegrationTests/CustomHttpHeaderFileTests.fs
@@ -10,8 +10,8 @@ type Provider = GraphQLProvider<"http://localhost:8084", "http_headers1.headerfi
 type Episode = Provider.Types.Episode
 
 // We should be able to create instances of schema types.
-let ball = Provider.Types.Ball(form = "Spheric", format = "Spheric", id = "1")
-let box = Provider.Types.Box(form = "Cubic", format = "Cubic", id = "2")
+let ball = Provider.Types.Ball(form = "Spheric", format = "Spheric", id = "1", order = 0, size = 1.11)
+let box = Provider.Types.Box(form = "Cubic", format = "Cubic", id = "2", order = 1, size = 2.0)
 let things : Provider.Types.IThing list = [ball; box]
 
 module SimpleOperation =
@@ -56,29 +56,33 @@ module SimpleOperation =
         result.Data.Value.Hero.Value.HomePlanet |> equals (Some "Tatooine")
         let actual = normalize <| sprintf "%A" result.Data
         let expected = normalize <| """Some
-            {Hero = Some
-            {AppearsIn = [|NewHope; Empire; Jedi|];
-            Friends = [|Some {HomePlanet = <null>;
-            Name = Some "Han Solo";};
-            Some {HomePlanet = Some "Alderaan";
-            Name = Some "Leia Organa";};
-            Some {Name = Some "C-3PO";
-            PrimaryFunction = Some "Protocol";};
-            Some {Name = Some "R2-D2";
-            PrimaryFunction = Some "Astromech";}|];
-            HomePlanet = Some "Tatooine";
-            Name = Some "Luke Skywalker";};}"""
+          {Hero = Some
+          {AppearsIn = [|NewHope; Empire; Jedi|];
+          Friends = [|Some {HomePlanet = <null>;
+          Name = Some "Han Solo";};
+          Some {HomePlanet = Some "Alderaan";
+          Name = Some "Leia Organa";};
+          Some {Name = Some "C-3PO";
+          PrimaryFunction = Some "Protocol";};
+          Some {Name = Some "R2-D2";
+          PrimaryFunction = Some "Astromech";}|];
+          HomePlanet = Some "Tatooine";
+          Name = Some "Luke Skywalker";};}"""
         actual |> equals expected
 
 [<Fact>]
 let ``Should be able to pretty print schema types`` () =
     let actual = normalize <| sprintf "%A" things
     let expected = normalize <| """[{Form = "Spheric";
-        Format = "Spheric";
-        Id = "1";};
-         {Form = "Cubic";
-        Format = "Cubic";
-        Id = "2";}]"""
+      Format = "Spheric";
+      Id = "1";
+      Order = 0;
+      Size = 1.11;};
+      {Form = "Cubic";
+      Format = "Cubic";
+      Id = "2";
+      Order = 1;
+      Size = 2.0;}]"""
     actual |> equals expected
 
 [<Fact>]

--- a/tests/FSharp.Data.GraphQL.IntegrationTests/CustomHttpHeaderFileTests.fs
+++ b/tests/FSharp.Data.GraphQL.IntegrationTests/CustomHttpHeaderFileTests.fs
@@ -48,26 +48,26 @@ module SimpleOperation =
         result.Data.Value.Hero.IsSome |> equals true
         result.Data.Value.Hero.Value.AppearsIn |> equals [| Episode.NewHope; Episode.Empire; Episode.Jedi |]
         let expectedFriends : Option<Operation.Types.Hero.Friends.Character> [] = 
-          [| Some (upcast Operation.Types.Hero.Friends.Human(name = Some "Han Solo", homePlanet = None))
-             Some (upcast Operation.Types.Hero.Friends.Human(name = Some "Leia Organa", homePlanet = Some "Alderaan"))
-             Some (upcast Operation.Types.Hero.Friends.Droid(name = Some "C-3PO", primaryFunction = Some "Protocol"))
-             Some (upcast Operation.Types.Hero.Friends.Droid(name = Some "R2-D2", primaryFunction = Some "Astromech")) |]
+          [| Some (upcast Operation.Types.Hero.Friends.Human(name = "Han Solo"))
+             Some (upcast Operation.Types.Hero.Friends.Human(name = "Leia Organa", homePlanet = "Alderaan"))
+             Some (upcast Operation.Types.Hero.Friends.Droid(name = "C-3PO", primaryFunction = "Protocol"))
+             Some (upcast Operation.Types.Hero.Friends.Droid(name = "R2-D2", primaryFunction = "Astromech")) |]
         result.Data.Value.Hero.Value.Friends |> equals expectedFriends
         result.Data.Value.Hero.Value.HomePlanet |> equals (Some "Tatooine")
         let actual = normalize <| sprintf "%A" result.Data
         let expected = normalize <| """Some
-  {Hero = Some
-  {Name = Some "Luke Skywalker";
-  AppearsIn = [|NewHope; Empire; Jedi|];
-  HomePlanet = Some "Tatooine";
-  Friends = [|Some {Name = Some "Han Solo";
-  HomePlanet = <null>;};
-  Some {Name = Some "Leia Organa";
-  HomePlanet = Some "Alderaan";};
-  Some {Name = Some "C-3PO";
-  PrimaryFunction = Some "Protocol";};
-  Some {Name = Some "R2-D2";
-  PrimaryFunction = Some "Astromech";}|];};}"""
+            {Hero = Some
+            {AppearsIn = [|NewHope; Empire; Jedi|];
+            Friends = [|Some {HomePlanet = <null>;
+            Name = Some "Han Solo";};
+            Some {HomePlanet = Some "Alderaan";
+            Name = Some "Leia Organa";};
+            Some {Name = Some "C-3PO";
+            PrimaryFunction = Some "Protocol";};
+            Some {Name = Some "R2-D2";
+            PrimaryFunction = Some "Astromech";}|];
+            HomePlanet = Some "Tatooine";
+            Name = Some "Luke Skywalker";};}"""
         actual |> equals expected
 
 [<Fact>]
@@ -123,13 +123,13 @@ let ``Should be able to use pattern matching methods on an union type`` () =
     friends 
     |> Array.choose (fun x -> x.TryAsHuman()) 
     |> equals [|
-        SimpleOperation.Operation.Types.Hero.Friends.Human(name = Some "Han Solo", homePlanet = None)
-        SimpleOperation.Operation.Types.Hero.Friends.Human(name = Some "Leia Organa", homePlanet = Some "Alderaan") |]
+        SimpleOperation.Operation.Types.Hero.Friends.Human(name = "Han Solo")
+        SimpleOperation.Operation.Types.Hero.Friends.Human(name = "Leia Organa", homePlanet = "Alderaan") |]
     friends
     |> Array.choose (fun x -> x.TryAsDroid())
     |> equals [|
-        SimpleOperation.Operation.Types.Hero.Friends.Droid(name = Some "C-3PO", primaryFunction = Some "Protocol")
-        SimpleOperation.Operation.Types.Hero.Friends.Droid(name = Some "R2-D2", primaryFunction = Some "Astromech") |]
+        SimpleOperation.Operation.Types.Hero.Friends.Droid(name = "C-3PO", primaryFunction = "Protocol")
+        SimpleOperation.Operation.Types.Hero.Friends.Droid(name = "R2-D2", primaryFunction = "Astromech") |]
     try
       friends |> Array.map (fun x -> x.AsDroid()) |> ignore
       failwith "Expected exception when trying to get all friends as droids!"
@@ -142,14 +142,14 @@ let ``Should be able to use pattern matching methods on an union type`` () =
     |> Array.filter (fun x -> x.IsHuman())
     |> Array.map (fun x -> x.AsHuman())
     |> equals [|
-        SimpleOperation.Operation.Types.Hero.Friends.Human(name = Some "Han Solo", homePlanet = None)
-        SimpleOperation.Operation.Types.Hero.Friends.Human(name = Some "Leia Organa", homePlanet = Some "Alderaan") |]
+        SimpleOperation.Operation.Types.Hero.Friends.Human(name = "Han Solo")
+        SimpleOperation.Operation.Types.Hero.Friends.Human(name = "Leia Organa", homePlanet = "Alderaan") |]
     friends
     |> Array.filter (fun x -> x.IsDroid())
     |> Array.map (fun x -> x.AsDroid())
     |> equals [|
-        SimpleOperation.Operation.Types.Hero.Friends.Droid(name = Some "C-3PO", primaryFunction = Some "Protocol")
-        SimpleOperation.Operation.Types.Hero.Friends.Droid(name = Some "R2-D2", primaryFunction = Some "Astromech") |]
+        SimpleOperation.Operation.Types.Hero.Friends.Droid(name = "C-3PO", primaryFunction = "Protocol")
+        SimpleOperation.Operation.Types.Hero.Friends.Droid(name = "R2-D2", primaryFunction = "Astromech") |]
   
 module InterfaceOperation =
     let operation =
@@ -184,12 +184,12 @@ module InterfaceOperation =
         result.Data.Value.Things |> equals expectedThings
         let actual = normalize <| sprintf "%A" result.Data
         let expected = normalize <| """Some
-{Things = [|{Id = "1";
-Format = "Spheric";
-Form = "Spheric";};
-{Id = "2";
-Format = "Cubic";
-Form = "Cubic";}|];}"""
+            {Things = [|{Form = "Spheric";
+            Format = "Spheric";
+            Id = "1";};
+            {Form = "Cubic";
+            Format = "Cubic";
+            Id = "2";}|];}"""
         actual |> equals expected
 
 [<Fact>]
@@ -307,26 +307,26 @@ module FileOperation =
         result.Data.Value.Hero.IsSome |> equals true
         result.Data.Value.Hero.Value.AppearsIn |> equals [| Episode.NewHope; Episode.Empire; Episode.Jedi |]
         let expectedFriends : Option<Operation.Types.Hero.Friends.Character> [] = 
-          [| Some (upcast Operation.Types.Hero.Friends.Human(name = Some "Han Solo", homePlanet = None))
-             Some (upcast Operation.Types.Hero.Friends.Human(name = Some "Leia Organa", homePlanet = Some "Alderaan"))
-             Some (upcast Operation.Types.Hero.Friends.Droid(name = Some "C-3PO", primaryFunction = Some "Protocol"))
-             Some (upcast Operation.Types.Hero.Friends.Droid(name = Some "R2-D2", primaryFunction = Some "Astromech")) |]
+          [| Some (upcast Operation.Types.Hero.Friends.Human(name = "Han Solo"))
+             Some (upcast Operation.Types.Hero.Friends.Human(name = "Leia Organa", homePlanet = "Alderaan"))
+             Some (upcast Operation.Types.Hero.Friends.Droid(name = "C-3PO", primaryFunction = "Protocol"))
+             Some (upcast Operation.Types.Hero.Friends.Droid(name = "R2-D2", primaryFunction = "Astromech")) |]
         result.Data.Value.Hero.Value.Friends |> equals expectedFriends
         result.Data.Value.Hero.Value.HomePlanet |> equals (Some "Tatooine")
         let actual = normalize <| sprintf "%A" result.Data
         let expected = normalize <| """Some
-  {Hero = Some
-  {Name = Some "Luke Skywalker";
-  AppearsIn = [|NewHope; Empire; Jedi|];
-  HomePlanet = Some "Tatooine";
-  Friends = [|Some {Name = Some "Han Solo";
-  HomePlanet = <null>;};
-  Some {Name = Some "Leia Organa";
-  HomePlanet = Some "Alderaan";};
-  Some {Name = Some "C-3PO";
-  PrimaryFunction = Some "Protocol";};
-  Some {Name = Some "R2-D2";
-  PrimaryFunction = Some "Astromech";}|];};}"""
+            {Hero = Some
+            {AppearsIn = [|NewHope; Empire; Jedi|];
+            Friends = [|Some {HomePlanet = <null>;
+            Name = Some "Han Solo";};
+            Some {HomePlanet = Some "Alderaan";
+            Name = Some "Leia Organa";};
+            Some {Name = Some "C-3PO";
+            PrimaryFunction = Some "Protocol";};
+            Some {Name = Some "R2-D2";
+            PrimaryFunction = Some "Astromech";}|];
+            HomePlanet = Some "Tatooine";
+            Name = Some "Luke Skywalker";};}"""
         actual |> equals expected
 
 [<Fact>]

--- a/tests/FSharp.Data.GraphQL.IntegrationTests/CustomHttpHeadersTests.fs
+++ b/tests/FSharp.Data.GraphQL.IntegrationTests/CustomHttpHeadersTests.fs
@@ -48,26 +48,26 @@ module SimpleOperation =
         result.Data.Value.Hero.IsSome |> equals true
         result.Data.Value.Hero.Value.AppearsIn |> equals [| Episode.NewHope; Episode.Empire; Episode.Jedi |]
         let expectedFriends : Option<Operation.Types.Hero.Friends.Character> [] = 
-          [| Some (upcast Operation.Types.Hero.Friends.Human(name = Some "Han Solo", homePlanet = None))
-             Some (upcast Operation.Types.Hero.Friends.Human(name = Some "Leia Organa", homePlanet = Some "Alderaan"))
-             Some (upcast Operation.Types.Hero.Friends.Droid(name = Some "C-3PO", primaryFunction = Some "Protocol"))
-             Some (upcast Operation.Types.Hero.Friends.Droid(name = Some "R2-D2", primaryFunction = Some "Astromech")) |]
+          [| Some (upcast Operation.Types.Hero.Friends.Human(name = "Han Solo"))
+             Some (upcast Operation.Types.Hero.Friends.Human(name = "Leia Organa", homePlanet = "Alderaan"))
+             Some (upcast Operation.Types.Hero.Friends.Droid(name = "C-3PO", primaryFunction = "Protocol"))
+             Some (upcast Operation.Types.Hero.Friends.Droid(name = "R2-D2", primaryFunction = "Astromech")) |]
         result.Data.Value.Hero.Value.Friends |> equals expectedFriends
         result.Data.Value.Hero.Value.HomePlanet |> equals (Some "Tatooine")
         let actual = normalize <| sprintf "%A" result.Data
         let expected = normalize <| """Some
-  {Hero = Some
-  {Name = Some "Luke Skywalker";
-  AppearsIn = [|NewHope; Empire; Jedi|];
-  HomePlanet = Some "Tatooine";
-  Friends = [|Some {Name = Some "Han Solo";
-  HomePlanet = <null>;};
-  Some {Name = Some "Leia Organa";
-  HomePlanet = Some "Alderaan";};
-  Some {Name = Some "C-3PO";
-  PrimaryFunction = Some "Protocol";};
-  Some {Name = Some "R2-D2";
-  PrimaryFunction = Some "Astromech";}|];};}"""
+            {Hero = Some
+            {AppearsIn = [|NewHope; Empire; Jedi|];
+            Friends = [|Some {HomePlanet = <null>;
+            Name = Some "Han Solo";};
+            Some {HomePlanet = Some "Alderaan";
+            Name = Some "Leia Organa";};
+            Some {Name = Some "C-3PO";
+            PrimaryFunction = Some "Protocol";};
+            Some {Name = Some "R2-D2";
+            PrimaryFunction = Some "Astromech";}|];
+            HomePlanet = Some "Tatooine";
+            Name = Some "Luke Skywalker";};}"""
         actual |> equals expected
 
 [<Fact>]
@@ -121,13 +121,13 @@ let ``Should be able to use pattern matching methods on an union type`` () =
     friends 
     |> Array.choose (fun x -> x.TryAsHuman()) 
     |> equals [|
-        SimpleOperation.Operation.Types.Hero.Friends.Human(name = Some "Han Solo", homePlanet = None)
-        SimpleOperation.Operation.Types.Hero.Friends.Human(name = Some "Leia Organa", homePlanet = Some "Alderaan") |]
+        SimpleOperation.Operation.Types.Hero.Friends.Human(name = "Han Solo")
+        SimpleOperation.Operation.Types.Hero.Friends.Human(name = "Leia Organa", homePlanet = "Alderaan") |]
     friends
     |> Array.choose (fun x -> x.TryAsDroid())
     |> equals [|
-        SimpleOperation.Operation.Types.Hero.Friends.Droid(name = Some "C-3PO", primaryFunction = Some "Protocol")
-        SimpleOperation.Operation.Types.Hero.Friends.Droid(name = Some "R2-D2", primaryFunction = Some "Astromech") |]
+        SimpleOperation.Operation.Types.Hero.Friends.Droid(name = "C-3PO", primaryFunction = "Protocol")
+        SimpleOperation.Operation.Types.Hero.Friends.Droid(name = "R2-D2", primaryFunction = "Astromech") |]
     try
       friends |> Array.map (fun x -> x.AsDroid()) |> ignore
       failwith "Expected exception when trying to get all friends as droids!"
@@ -140,14 +140,14 @@ let ``Should be able to use pattern matching methods on an union type`` () =
     |> Array.filter (fun x -> x.IsHuman())
     |> Array.map (fun x -> x.AsHuman())
     |> equals [|
-        SimpleOperation.Operation.Types.Hero.Friends.Human(name = Some "Han Solo", homePlanet = None)
-        SimpleOperation.Operation.Types.Hero.Friends.Human(name = Some "Leia Organa", homePlanet = Some "Alderaan") |]
+        SimpleOperation.Operation.Types.Hero.Friends.Human(name = "Han Solo")
+        SimpleOperation.Operation.Types.Hero.Friends.Human(name = "Leia Organa", homePlanet = "Alderaan") |]
     friends
     |> Array.filter (fun x -> x.IsDroid())
     |> Array.map (fun x -> x.AsDroid())
     |> equals [|
-        SimpleOperation.Operation.Types.Hero.Friends.Droid(name = Some "C-3PO", primaryFunction = Some "Protocol")
-        SimpleOperation.Operation.Types.Hero.Friends.Droid(name = Some "R2-D2", primaryFunction = Some "Astromech") |]
+        SimpleOperation.Operation.Types.Hero.Friends.Droid(name = "C-3PO", primaryFunction = "Protocol")
+        SimpleOperation.Operation.Types.Hero.Friends.Droid(name = "R2-D2", primaryFunction = "Astromech") |]
   
 module InterfaceOperation =
     let operation =
@@ -182,12 +182,12 @@ module InterfaceOperation =
         result.Data.Value.Things |> equals expectedThings
         let actual = normalize <| sprintf "%A" result.Data
         let expected = normalize <| """Some
-{Things = [|{Id = "1";
-Format = "Spheric";
-Form = "Spheric";};
-{Id = "2";
-Format = "Cubic";
-Form = "Cubic";}|];}"""
+            {Things = [|{Form = "Spheric";
+            Format = "Spheric";
+            Id = "1";};
+            {Form = "Cubic";
+            Format = "Cubic";
+            Id = "2";}|];}"""
         actual |> equals expected
 
 [<Fact>]
@@ -305,26 +305,26 @@ module FileOperation =
         result.Data.Value.Hero.IsSome |> equals true
         result.Data.Value.Hero.Value.AppearsIn |> equals [| Episode.NewHope; Episode.Empire; Episode.Jedi |]
         let expectedFriends : Option<Operation.Types.Hero.Friends.Character> [] = 
-          [| Some (upcast Operation.Types.Hero.Friends.Human(name = Some "Han Solo", homePlanet = None))
-             Some (upcast Operation.Types.Hero.Friends.Human(name = Some "Leia Organa", homePlanet = Some "Alderaan"))
-             Some (upcast Operation.Types.Hero.Friends.Droid(name = Some "C-3PO", primaryFunction = Some "Protocol"))
-             Some (upcast Operation.Types.Hero.Friends.Droid(name = Some "R2-D2", primaryFunction = Some "Astromech")) |]
+          [| Some (upcast Operation.Types.Hero.Friends.Human(name = "Han Solo"))
+             Some (upcast Operation.Types.Hero.Friends.Human(name = "Leia Organa", homePlanet = "Alderaan"))
+             Some (upcast Operation.Types.Hero.Friends.Droid(name = "C-3PO", primaryFunction = "Protocol"))
+             Some (upcast Operation.Types.Hero.Friends.Droid(name = "R2-D2", primaryFunction = "Astromech")) |]
         result.Data.Value.Hero.Value.Friends |> equals expectedFriends
         result.Data.Value.Hero.Value.HomePlanet |> equals (Some "Tatooine")
         let actual = normalize <| sprintf "%A" result.Data
         let expected = normalize <| """Some
-  {Hero = Some
-  {Name = Some "Luke Skywalker";
-  AppearsIn = [|NewHope; Empire; Jedi|];
-  HomePlanet = Some "Tatooine";
-  Friends = [|Some {Name = Some "Han Solo";
-  HomePlanet = <null>;};
-  Some {Name = Some "Leia Organa";
-  HomePlanet = Some "Alderaan";};
-  Some {Name = Some "C-3PO";
-  PrimaryFunction = Some "Protocol";};
-  Some {Name = Some "R2-D2";
-  PrimaryFunction = Some "Astromech";}|];};}"""
+            {Hero = Some
+            {AppearsIn = [|NewHope; Empire; Jedi|];
+            Friends = [|Some {HomePlanet = <null>;
+            Name = Some "Han Solo";};
+            Some {HomePlanet = Some "Alderaan";
+            Name = Some "Leia Organa";};
+            Some {Name = Some "C-3PO";
+            PrimaryFunction = Some "Protocol";};
+            Some {Name = Some "R2-D2";
+            PrimaryFunction = Some "Astromech";}|];
+            HomePlanet = Some "Tatooine";
+            Name = Some "Luke Skywalker";};}"""
         actual |> equals expected
 [<Fact>]
 let ``Should be able to run a query with variables syncrhonously`` () =

--- a/tests/FSharp.Data.GraphQL.IntegrationTests/CustomHttpHeadersTests.fs
+++ b/tests/FSharp.Data.GraphQL.IntegrationTests/CustomHttpHeadersTests.fs
@@ -10,8 +10,8 @@ type Provider = GraphQLProvider<"http://localhost:8084", "UserData: 45883115-db2
 type Episode = Provider.Types.Episode
 
 // We should be able to create instances of schema types.
-let ball = Provider.Types.Ball(form = "Spheric", format = "Spheric", id = "1")
-let box = Provider.Types.Box(form = "Cubic", format = "Cubic", id = "2")
+let ball = Provider.Types.Ball(form = "Spheric", format = "Spheric", id = "1", order = 0, size = 1.11)
+let box = Provider.Types.Box(form = "Cubic", format = "Cubic", id = "2", order = 1, size = 2.0)
 let things : Provider.Types.IThing list = [ball; box]
 
 module SimpleOperation =
@@ -74,11 +74,15 @@ module SimpleOperation =
 let ``Should be able to pretty print schema types`` () =
     let actual = normalize <| sprintf "%A" things
     let expected = normalize <| """[{Form = "Spheric";
-        Format = "Spheric";
-        Id = "1";};
-         {Form = "Cubic";
-        Format = "Cubic";
-        Id = "2";}]"""
+      Format = "Spheric";
+      Id = "1";
+      Order = 0;
+      Size = 1.11;};
+      {Form = "Cubic";
+      Format = "Cubic";
+      Id = "2";
+      Order = 1;
+      Size = 2.0;}]"""
     actual |> equals expected
 
 [<Fact>]

--- a/tests/FSharp.Data.GraphQL.IntegrationTests/LocalProviderTests.fs
+++ b/tests/FSharp.Data.GraphQL.IntegrationTests/LocalProviderTests.fs
@@ -47,26 +47,26 @@ module SimpleOperation =
         result.Data.Value.Hero.IsSome |> equals true
         result.Data.Value.Hero.Value.AppearsIn |> equals [| Episode.NewHope; Episode.Empire; Episode.Jedi |]
         let expectedFriends : Option<Operation.Types.Hero.Friends.Character> [] = 
-          [| Some (upcast Operation.Types.Hero.Friends.Human(name = Some "Han Solo", homePlanet = None))
-             Some (upcast Operation.Types.Hero.Friends.Human(name = Some "Leia Organa", homePlanet = Some "Alderaan"))
-             Some (upcast Operation.Types.Hero.Friends.Droid(name = Some "C-3PO", primaryFunction = Some "Protocol"))
-             Some (upcast Operation.Types.Hero.Friends.Droid(name = Some "R2-D2", primaryFunction = Some "Astromech")) |]
+          [| Some (upcast Operation.Types.Hero.Friends.Human(name = "Han Solo"))
+             Some (upcast Operation.Types.Hero.Friends.Human(name = "Leia Organa", homePlanet = "Alderaan"))
+             Some (upcast Operation.Types.Hero.Friends.Droid(name = "C-3PO", primaryFunction = "Protocol"))
+             Some (upcast Operation.Types.Hero.Friends.Droid(name = "R2-D2", primaryFunction = "Astromech")) |]
         result.Data.Value.Hero.Value.Friends |> equals expectedFriends
         result.Data.Value.Hero.Value.HomePlanet |> equals (Some "Tatooine")
         let actual = normalize <| sprintf "%A" result.Data
         let expected = normalize <| """Some
-  {Hero = Some
-  {Name = Some "Luke Skywalker";
-  AppearsIn = [|NewHope; Empire; Jedi|];
-  HomePlanet = Some "Tatooine";
-  Friends = [|Some {Name = Some "Han Solo";
-  HomePlanet = <null>;};
-  Some {Name = Some "Leia Organa";
-  HomePlanet = Some "Alderaan";};
-  Some {Name = Some "C-3PO";
-  PrimaryFunction = Some "Protocol";};
-  Some {Name = Some "R2-D2";
-  PrimaryFunction = Some "Astromech";}|];};}"""
+            {Hero = Some
+            {AppearsIn = [|NewHope; Empire; Jedi|];
+            Friends = [|Some {HomePlanet = <null>;
+            Name = Some "Han Solo";};
+            Some {HomePlanet = Some "Alderaan";
+            Name = Some "Leia Organa";};
+            Some {Name = Some "C-3PO";
+            PrimaryFunction = Some "Protocol";};
+            Some {Name = Some "R2-D2";
+            PrimaryFunction = Some "Astromech";}|];
+            HomePlanet = Some "Tatooine";
+            Name = Some "Luke Skywalker";};}"""
         actual |> equals expected
 
 [<Fact>]
@@ -123,13 +123,13 @@ let ``Should be able to use pattern matching methods on an union type`` () =
     friends 
     |> Array.choose (fun x -> x.TryAsHuman()) 
     |> equals [|
-        SimpleOperation.Operation.Types.Hero.Friends.Human(name = Some "Han Solo", homePlanet = None)
-        SimpleOperation.Operation.Types.Hero.Friends.Human(name = Some "Leia Organa", homePlanet = Some "Alderaan") |]
+        SimpleOperation.Operation.Types.Hero.Friends.Human(name = "Han Solo")
+        SimpleOperation.Operation.Types.Hero.Friends.Human(name = "Leia Organa", homePlanet = "Alderaan") |]
     friends
     |> Array.choose (fun x -> x.TryAsDroid())
     |> equals [|
-        SimpleOperation.Operation.Types.Hero.Friends.Droid(name = Some "C-3PO", primaryFunction = Some "Protocol")
-        SimpleOperation.Operation.Types.Hero.Friends.Droid(name = Some "R2-D2", primaryFunction = Some "Astromech") |]
+        SimpleOperation.Operation.Types.Hero.Friends.Droid(name = "C-3PO", primaryFunction = "Protocol")
+        SimpleOperation.Operation.Types.Hero.Friends.Droid(name = "R2-D2", primaryFunction = "Astromech") |]
     try
       friends |> Array.map (fun x -> x.AsDroid()) |> ignore
       failwith "Expected exception when trying to get all friends as droids!"
@@ -142,14 +142,14 @@ let ``Should be able to use pattern matching methods on an union type`` () =
     |> Array.filter (fun x -> x.IsHuman())
     |> Array.map (fun x -> x.AsHuman())
     |> equals [|
-        SimpleOperation.Operation.Types.Hero.Friends.Human(name = Some "Han Solo", homePlanet = None)
-        SimpleOperation.Operation.Types.Hero.Friends.Human(name = Some "Leia Organa", homePlanet = Some "Alderaan") |]
+        SimpleOperation.Operation.Types.Hero.Friends.Human(name = "Han Solo")
+        SimpleOperation.Operation.Types.Hero.Friends.Human(name = "Leia Organa", homePlanet = "Alderaan") |]
     friends
     |> Array.filter (fun x -> x.IsDroid())
     |> Array.map (fun x -> x.AsDroid())
     |> equals [|
-        SimpleOperation.Operation.Types.Hero.Friends.Droid(name = Some "C-3PO", primaryFunction = Some "Protocol")
-        SimpleOperation.Operation.Types.Hero.Friends.Droid(name = Some "R2-D2", primaryFunction = Some "Astromech") |]
+        SimpleOperation.Operation.Types.Hero.Friends.Droid(name = "C-3PO", primaryFunction = "Protocol")
+        SimpleOperation.Operation.Types.Hero.Friends.Droid(name = "R2-D2", primaryFunction = "Astromech") |]
   
 module InterfaceOperation =
     let operation =
@@ -179,12 +179,12 @@ module InterfaceOperation =
         result.Data.Value.Things |> equals expectedThings
         let actual = normalize <| sprintf "%A" result.Data
         let expected = normalize <| """Some
-{Things = [|{Id = "1";
-Format = "Spheric";
-Form = "Spheric";};
-{Id = "2";
-Format = "Cubic";
-Form = "Cubic";}|];}"""
+            {Things = [|{Form = "Spheric";
+            Format = "Spheric";
+            Id = "1";};
+            {Form = "Cubic";
+            Format = "Cubic";
+            Id = "2";}|];}"""
         actual |> equals expected
 
 [<Fact>]
@@ -307,26 +307,26 @@ module FileOperation =
         result.Data.Value.Hero.IsSome |> equals true
         result.Data.Value.Hero.Value.AppearsIn |> equals [| Episode.NewHope; Episode.Empire; Episode.Jedi |]
         let expectedFriends : Option<Operation.Types.Hero.Friends.Character> [] = 
-          [| Some (upcast Operation.Types.Hero.Friends.Human(name = Some "Han Solo", homePlanet = None))
-             Some (upcast Operation.Types.Hero.Friends.Human(name = Some "Leia Organa", homePlanet = Some "Alderaan"))
-             Some (upcast Operation.Types.Hero.Friends.Droid(name = Some "C-3PO", primaryFunction = Some "Protocol"))
-             Some (upcast Operation.Types.Hero.Friends.Droid(name = Some "R2-D2", primaryFunction = Some "Astromech")) |]
+          [| Some (upcast Operation.Types.Hero.Friends.Human(name = "Han Solo"))
+             Some (upcast Operation.Types.Hero.Friends.Human(name = "Leia Organa", homePlanet = "Alderaan"))
+             Some (upcast Operation.Types.Hero.Friends.Droid(name = "C-3PO", primaryFunction = "Protocol"))
+             Some (upcast Operation.Types.Hero.Friends.Droid(name = "R2-D2", primaryFunction = "Astromech")) |]
         result.Data.Value.Hero.Value.Friends |> equals expectedFriends
         result.Data.Value.Hero.Value.HomePlanet |> equals (Some "Tatooine")
         let actual = normalize <| sprintf "%A" result.Data
         let expected = normalize <| """Some
-  {Hero = Some
-  {Name = Some "Luke Skywalker";
-  AppearsIn = [|NewHope; Empire; Jedi|];
-  HomePlanet = Some "Tatooine";
-  Friends = [|Some {Name = Some "Han Solo";
-  HomePlanet = <null>;};
-  Some {Name = Some "Leia Organa";
-  HomePlanet = Some "Alderaan";};
-  Some {Name = Some "C-3PO";
-  PrimaryFunction = Some "Protocol";};
-  Some {Name = Some "R2-D2";
-  PrimaryFunction = Some "Astromech";}|];};}"""
+            {Hero = Some
+            {AppearsIn = [|NewHope; Empire; Jedi|];
+            Friends = [|Some {HomePlanet = <null>;
+            Name = Some "Han Solo";};
+            Some {HomePlanet = Some "Alderaan";
+            Name = Some "Leia Organa";};
+            Some {Name = Some "C-3PO";
+            PrimaryFunction = Some "Protocol";};
+            Some {Name = Some "R2-D2";
+            PrimaryFunction = Some "Astromech";}|];
+            HomePlanet = Some "Tatooine";
+            Name = Some "Luke Skywalker";};}"""
         actual |> equals expected
 
 [<Fact>]

--- a/tests/FSharp.Data.GraphQL.IntegrationTests/LocalProviderTests.fs
+++ b/tests/FSharp.Data.GraphQL.IntegrationTests/LocalProviderTests.fs
@@ -13,8 +13,8 @@ type Episode = Provider.Types.Episode
 let getContext() = Provider.GetContext(serverUrl = "http://localhost:8084")
 
 // We should be able to create instances of schema types.
-let ball = Provider.Types.Ball(form = "Spheric", format = "Spheric", id = "1")
-let box = Provider.Types.Box(form = "Cubic", format = "Cubic", id = "2")
+let ball = Provider.Types.Ball(form = "Spheric", format = "Spheric", id = "1", order = 0, size = 1.11)
+let box = Provider.Types.Box(form = "Cubic", format = "Cubic", id = "2", order = 1, size = 2.0)
 let things : Provider.Types.IThing list = [ball; box]
 
 module SimpleOperation =
@@ -73,11 +73,15 @@ module SimpleOperation =
 let ``Should be able to pretty print schema types`` () =
     let actual = normalize <| sprintf "%A" things
     let expected = normalize <| """[{Form = "Spheric";
-        Format = "Spheric";
-        Id = "1";};
-         {Form = "Cubic";
-        Format = "Cubic";
-        Id = "2";}]"""
+      Format = "Spheric";
+      Id = "1";
+      Order = 0;
+      Size = 1.11;};
+      {Form = "Cubic";
+      Format = "Cubic";
+      Id = "2";
+      Order = 1;
+      Size = 2.0;}]"""
     actual |> equals expected
 
 [<Fact>]

--- a/tests/FSharp.Data.GraphQL.IntegrationTests/RemoteProviderTests.fs
+++ b/tests/FSharp.Data.GraphQL.IntegrationTests/RemoteProviderTests.fs
@@ -9,8 +9,8 @@ type Provider = GraphQLProvider<"http://localhost:8084">
 type Episode = Provider.Types.Episode
 
 // We should be able to create instances of schema types.
-let ball = Provider.Types.Ball(form = "Spheric", format = "Spheric", id = "1")
-let box = Provider.Types.Box(form = "Cubic", format = "Cubic", id = "2")
+let ball = Provider.Types.Ball(form = "Spheric", format = "Spheric", id = "1", order = 0, size = 1.11)
+let box = Provider.Types.Box(form = "Cubic", format = "Cubic", id = "2", order = 1, size = 2.0)
 let things : Provider.Types.IThing list = [ball; box]
 
 module SimpleOperation =
@@ -69,11 +69,15 @@ module SimpleOperation =
 let ``Should be able to pretty print schema types`` () =
     let actual = normalize <| sprintf "%A" things
     let expected = normalize <| """[{Form = "Spheric";
-        Format = "Spheric";
-        Id = "1";};
-         {Form = "Cubic";
-        Format = "Cubic";
-        Id = "2";}]"""
+      Format = "Spheric";
+      Id = "1";
+      Order = 0;
+      Size = 1.11;};
+      {Form = "Cubic";
+      Format = "Cubic";
+      Id = "2";
+      Order = 1;
+      Size = 2.0;}]"""
     actual |> equals expected
 
 [<Fact>]

--- a/tests/FSharp.Data.GraphQL.IntegrationTests/RemoteProviderTests.fs
+++ b/tests/FSharp.Data.GraphQL.IntegrationTests/RemoteProviderTests.fs
@@ -43,26 +43,26 @@ module SimpleOperation =
         result.Data.Value.Hero.IsSome |> equals true
         result.Data.Value.Hero.Value.AppearsIn |> equals [| Episode.NewHope; Episode.Empire; Episode.Jedi |]
         let expectedFriends : Option<Operation.Types.Hero.Friends.Character> [] = 
-          [| Some (upcast Operation.Types.Hero.Friends.Human(name = Some "Han Solo", homePlanet = None))
-             Some (upcast Operation.Types.Hero.Friends.Human(name = Some "Leia Organa", homePlanet = Some "Alderaan"))
-             Some (upcast Operation.Types.Hero.Friends.Droid(name = Some "C-3PO", primaryFunction = Some "Protocol"))
-             Some (upcast Operation.Types.Hero.Friends.Droid(name = Some "R2-D2", primaryFunction = Some "Astromech")) |]
+          [| Some (upcast Operation.Types.Hero.Friends.Human(name = "Han Solo"))
+             Some (upcast Operation.Types.Hero.Friends.Human(name = "Leia Organa", homePlanet = "Alderaan"))
+             Some (upcast Operation.Types.Hero.Friends.Droid(name = "C-3PO", primaryFunction = "Protocol"))
+             Some (upcast Operation.Types.Hero.Friends.Droid(name = "R2-D2", primaryFunction = "Astromech")) |]
         result.Data.Value.Hero.Value.Friends |> equals expectedFriends
         result.Data.Value.Hero.Value.HomePlanet |> equals (Some "Tatooine")
         let actual = normalize <| sprintf "%A" result.Data
         let expected = normalize <| """Some
-  {Hero = Some
-  {Name = Some "Luke Skywalker";
-  AppearsIn = [|NewHope; Empire; Jedi|];
-  HomePlanet = Some "Tatooine";
-  Friends = [|Some {Name = Some "Han Solo";
-  HomePlanet = <null>;};
-  Some {Name = Some "Leia Organa";
-  HomePlanet = Some "Alderaan";};
-  Some {Name = Some "C-3PO";
-  PrimaryFunction = Some "Protocol";};
-  Some {Name = Some "R2-D2";
-  PrimaryFunction = Some "Astromech";}|];};}"""
+            {Hero = Some
+            {AppearsIn = [|NewHope; Empire; Jedi|];
+            Friends = [|Some {HomePlanet = <null>;
+            Name = Some "Han Solo";};
+            Some {HomePlanet = Some "Alderaan";
+            Name = Some "Leia Organa";};
+            Some {Name = Some "C-3PO";
+            PrimaryFunction = Some "Protocol";};
+            Some {Name = Some "R2-D2";
+            PrimaryFunction = Some "Astromech";}|];
+            HomePlanet = Some "Tatooine";
+            Name = Some "Luke Skywalker";};}"""
         actual |> equals expected
 
 [<Fact>]
@@ -116,13 +116,13 @@ let ``Should be able to use pattern matching methods on an union type`` () =
     friends 
     |> Array.choose (fun x -> x.TryAsHuman()) 
     |> equals [|
-        SimpleOperation.Operation.Types.Hero.Friends.Human(name = Some "Han Solo", homePlanet = None)
-        SimpleOperation.Operation.Types.Hero.Friends.Human(name = Some "Leia Organa", homePlanet = Some "Alderaan") |]
+        SimpleOperation.Operation.Types.Hero.Friends.Human(name = "Han Solo")
+        SimpleOperation.Operation.Types.Hero.Friends.Human(name = "Leia Organa", homePlanet = "Alderaan") |]
     friends
     |> Array.choose (fun x -> x.TryAsDroid())
     |> equals [|
-        SimpleOperation.Operation.Types.Hero.Friends.Droid(name = Some "C-3PO", primaryFunction = Some "Protocol")
-        SimpleOperation.Operation.Types.Hero.Friends.Droid(name = Some "R2-D2", primaryFunction = Some "Astromech") |]
+        SimpleOperation.Operation.Types.Hero.Friends.Droid(name = "C-3PO", primaryFunction = "Protocol")
+        SimpleOperation.Operation.Types.Hero.Friends.Droid(name = "R2-D2", primaryFunction = "Astromech") |]
     try
       friends |> Array.map (fun x -> x.AsDroid()) |> ignore
       failwith "Expected exception when trying to get all friends as droids!"
@@ -135,14 +135,14 @@ let ``Should be able to use pattern matching methods on an union type`` () =
     |> Array.filter (fun x -> x.IsHuman())
     |> Array.map (fun x -> x.AsHuman())
     |> equals [|
-        SimpleOperation.Operation.Types.Hero.Friends.Human(name = Some "Han Solo", homePlanet = None)
-        SimpleOperation.Operation.Types.Hero.Friends.Human(name = Some "Leia Organa", homePlanet = Some "Alderaan") |]
+        SimpleOperation.Operation.Types.Hero.Friends.Human(name = "Han Solo")
+        SimpleOperation.Operation.Types.Hero.Friends.Human(name = "Leia Organa", homePlanet = "Alderaan") |]
     friends
     |> Array.filter (fun x -> x.IsDroid())
     |> Array.map (fun x -> x.AsDroid())
     |> equals [|
-        SimpleOperation.Operation.Types.Hero.Friends.Droid(name = Some "C-3PO", primaryFunction = Some "Protocol")
-        SimpleOperation.Operation.Types.Hero.Friends.Droid(name = Some "R2-D2", primaryFunction = Some "Astromech") |]
+        SimpleOperation.Operation.Types.Hero.Friends.Droid(name = "C-3PO", primaryFunction = "Protocol")
+        SimpleOperation.Operation.Types.Hero.Friends.Droid(name = "R2-D2", primaryFunction = "Astromech") |]
   
 module InterfaceOperation =
     let operation =
@@ -172,12 +172,12 @@ module InterfaceOperation =
         result.Data.Value.Things |> equals expectedThings
         let actual = normalize <| sprintf "%A" result.Data
         let expected = normalize <| """Some
-{Things = [|{Id = "1";
-Format = "Spheric";
-Form = "Spheric";};
-{Id = "2";
-Format = "Cubic";
-Form = "Cubic";}|];}"""
+            {Things = [|{Form = "Spheric";
+            Format = "Spheric";
+            Id = "1";};
+            {Form = "Cubic";
+            Format = "Cubic";
+            Id = "2";}|];}"""
         actual |> equals expected
 
 [<Fact>]
@@ -282,26 +282,26 @@ module FileOperation =
         result.Data.Value.Hero.IsSome |> equals true
         result.Data.Value.Hero.Value.AppearsIn |> equals [| Episode.NewHope; Episode.Empire; Episode.Jedi |]
         let expectedFriends : Option<Operation.Types.Hero.Friends.Character> [] = 
-          [| Some (upcast Operation.Types.Hero.Friends.Human(name = Some "Han Solo", homePlanet = None))
-             Some (upcast Operation.Types.Hero.Friends.Human(name = Some "Leia Organa", homePlanet = Some "Alderaan"))
-             Some (upcast Operation.Types.Hero.Friends.Droid(name = Some "C-3PO", primaryFunction = Some "Protocol"))
-             Some (upcast Operation.Types.Hero.Friends.Droid(name = Some "R2-D2", primaryFunction = Some "Astromech")) |]
+          [| Some (upcast Operation.Types.Hero.Friends.Human(name = "Han Solo"))
+             Some (upcast Operation.Types.Hero.Friends.Human(name = "Leia Organa", homePlanet = "Alderaan"))
+             Some (upcast Operation.Types.Hero.Friends.Droid(name = "C-3PO", primaryFunction = "Protocol"))
+             Some (upcast Operation.Types.Hero.Friends.Droid(name = "R2-D2", primaryFunction = "Astromech")) |]
         result.Data.Value.Hero.Value.Friends |> equals expectedFriends
         result.Data.Value.Hero.Value.HomePlanet |> equals (Some "Tatooine")
         let actual = normalize <| sprintf "%A" result.Data
         let expected = normalize <| """Some
-  {Hero = Some
-  {Name = Some "Luke Skywalker";
-  AppearsIn = [|NewHope; Empire; Jedi|];
-  HomePlanet = Some "Tatooine";
-  Friends = [|Some {Name = Some "Han Solo";
-  HomePlanet = <null>;};
-  Some {Name = Some "Leia Organa";
-  HomePlanet = Some "Alderaan";};
-  Some {Name = Some "C-3PO";
-  PrimaryFunction = Some "Protocol";};
-  Some {Name = Some "R2-D2";
-  PrimaryFunction = Some "Astromech";}|];};}"""
+            {Hero = Some
+            {AppearsIn = [|NewHope; Empire; Jedi|];
+            Friends = [|Some {HomePlanet = <null>;
+            Name = Some "Han Solo";};
+            Some {HomePlanet = Some "Alderaan";
+            Name = Some "Leia Organa";};
+            Some {Name = Some "C-3PO";
+            PrimaryFunction = Some "Protocol";};
+            Some {Name = Some "R2-D2";
+            PrimaryFunction = Some "Astromech";}|];
+            HomePlanet = Some "Tatooine";
+            Name = Some "Luke Skywalker";};}"""
         actual |> equals expected
 
 

--- a/tests/FSharp.Data.GraphQL.IntegrationTests/introspection.json
+++ b/tests/FSharp.Data.GraphQL.IntegrationTests/introspection.json
@@ -1,420 +1,100 @@
 {
-    "documentId": -240132443,
-    "data": {
-      "__schema": {
-        "queryType": {
-          "kind": "OBJECT",
-          "name": "Query"
+  "documentId": -722816445,
+  "data": {
+    "__schema": {
+      "queryType": {
+        "name": "Query"
+      },
+      "mutationType": {
+        "name": "Mutation"
+      },
+      "subscriptionType": {
+        "name": "Subscription"
+      },
+      "types": [
+        {
+          "kind": "SCALAR",
+          "name": "Int",
+          "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
         },
-        "mutationType": {
-          "kind": "OBJECT",
-          "name": "Mutation"
+        {
+          "kind": "SCALAR",
+          "name": "String",
+          "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
         },
-        "subscriptionType": {
-          "kind": "OBJECT",
-          "name": "Subscription"
+        {
+          "kind": "SCALAR",
+          "name": "Boolean",
+          "description": "The `Boolean` scalar type represents `true` or `false`.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
         },
-        "types": [
-          {
-            "kind": "SCALAR",
-            "name": "Int",
-            "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.",
-            "fields": null,
-            "inputFields": null,
-            "interfaces": null,
-            "enumValues": null,
-            "possibleTypes": null
-          },
-          {
-            "kind": "SCALAR",
-            "name": "String",
-            "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
-            "fields": null,
-            "inputFields": null,
-            "interfaces": null,
-            "enumValues": null,
-            "possibleTypes": null
-          },
-          {
-            "kind": "SCALAR",
-            "name": "Boolean",
-            "description": "The `Boolean` scalar type represents `true` or `false`.",
-            "fields": null,
-            "inputFields": null,
-            "interfaces": null,
-            "enumValues": null,
-            "possibleTypes": null
-          },
-          {
-            "kind": "SCALAR",
-            "name": "Float",
-            "description": "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).",
-            "fields": null,
-            "inputFields": null,
-            "interfaces": null,
-            "enumValues": null,
-            "possibleTypes": null
-          },
-          {
-            "kind": "SCALAR",
-            "name": "ID",
-            "description": "The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `\"4\"`) or integer (such as `4`) input value will be accepted as an ID.",
-            "fields": null,
-            "inputFields": null,
-            "interfaces": null,
-            "enumValues": null,
-            "possibleTypes": null
-          },
-          {
-            "kind": "SCALAR",
-            "name": "Date",
-            "description": "The `Date` scalar type represents a Date value with Time component. The Date type appears in a JSON response as a String representation compatible with ISO-8601 format.",
-            "fields": null,
-            "inputFields": null,
-            "interfaces": null,
-            "enumValues": null,
-            "possibleTypes": null
-          },
-          {
-            "kind": "SCALAR",
-            "name": "URI",
-            "description": "The `URI` scalar type represents a string resource identifier compatible with URI standard. The URI type appears in a JSON response as a String.",
-            "fields": null,
-            "inputFields": null,
-            "interfaces": null,
-            "enumValues": null,
-            "possibleTypes": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "__Schema",
-            "description": "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.",
-            "fields": [
-              {
-                "name": "directives",
-                "description": "A list of all directives supported by this server.",
-                "args": [],
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "LIST",
-                    "name": null,
-                    "ofType": {
-                      "kind": "NON_NULL",
-                      "name": null,
-                      "ofType": {
-                        "kind": "OBJECT",
-                        "name": "__Directive"
-                      }
-                    }
-                  }
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "mutationType",
-                "description": "If this server supports mutation, the type that mutation operations will be rooted at.",
-                "args": [],
-                "type": {
-                  "kind": "OBJECT",
-                  "name": "__Type",
-                  "ofType": null
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "queryType",
-                "description": "The type that query operations will be rooted at.",
-                "args": [],
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "__Type",
-                    "ofType": null
-                  }
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "subscriptionType",
-                "description": "If this server support subscription, the type that subscription operations will be rooted at.",
-                "args": [],
-                "type": {
-                  "kind": "OBJECT",
-                  "name": "__Type",
-                  "ofType": null
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "types",
-                "description": "A list of all types supported by this server.",
-                "args": [],
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "LIST",
-                    "name": null,
-                    "ofType": {
-                      "kind": "NON_NULL",
-                      "name": null,
-                      "ofType": {
-                        "kind": "OBJECT",
-                        "name": "__Type"
-                      }
-                    }
-                  }
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "inputFields": null,
-            "interfaces": [],
-            "enumValues": null,
-            "possibleTypes": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "__Directive",
-            "description": "A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document. In some cases, you need to provide options to alter GraphQL’s execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.",
-            "fields": [
-              {
-                "name": "args",
-                "description": null,
-                "args": [],
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "LIST",
-                    "name": null,
-                    "ofType": {
-                      "kind": "NON_NULL",
-                      "name": null,
-                      "ofType": {
-                        "kind": "OBJECT",
-                        "name": "__InputValue"
-                      }
-                    }
-                  }
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "description",
-                "description": null,
-                "args": [],
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "locations",
-                "description": null,
-                "args": [],
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "LIST",
-                    "name": null,
-                    "ofType": {
-                      "kind": "NON_NULL",
-                      "name": null,
-                      "ofType": {
-                        "kind": "ENUM",
-                        "name": "__DirectiveLocation"
-                      }
-                    }
-                  }
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "name",
-                "description": null,
-                "args": [],
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "onField",
-                "description": null,
-                "args": [],
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Boolean",
-                    "ofType": null
-                  }
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "onFragment",
-                "description": null,
-                "args": [],
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Boolean",
-                    "ofType": null
-                  }
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "onOperation",
-                "description": null,
-                "args": [],
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Boolean",
-                    "ofType": null
-                  }
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "inputFields": null,
-            "interfaces": [],
-            "enumValues": null,
-            "possibleTypes": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "__InputValue",
-            "description": "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.",
-            "fields": [
-              {
-                "name": "defaultValue",
-                "description": null,
-                "args": [],
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "description",
-                "description": null,
-                "args": [],
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "name",
-                "description": null,
-                "args": [],
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "type",
-                "description": null,
-                "args": [],
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "__Type",
-                    "ofType": null
-                  }
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "inputFields": null,
-            "interfaces": [],
-            "enumValues": null,
-            "possibleTypes": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "__Type",
-            "description": "The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum. Depending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.",
-            "fields": [
-              {
-                "name": "description",
-                "description": null,
-                "args": [],
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "enumValues",
-                "description": null,
-                "args": [
-                  {
-                    "name": "includeDeprecated",
-                    "description": null,
-                    "type": {
-                      "kind": "SCALAR",
-                      "name": "Boolean",
-                      "ofType": null
-                    },
-                    "defaultValue": "False"
-                  }
-                ],
-                "type": {
+        {
+          "kind": "SCALAR",
+          "name": "Float",
+          "description": "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "ID",
+          "description": "The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `\"4\"`) or integer (such as `4`) input value will be accepted as an ID.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Date",
+          "description": "The `Date` scalar type represents a Date value with Time component. The Date type appears in a JSON response as a String representation compatible with ISO-8601 format.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "URI",
+          "description": "The `URI` scalar type represents a string resource identifier compatible with URI standard. The URI type appears in a JSON response as a String.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__Schema",
+          "description": "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.",
+          "fields": [
+            {
+              "name": "directives",
+              "description": "A list of all directives supported by this server.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
@@ -422,30 +102,63 @@
                     "name": null,
                     "ofType": {
                       "kind": "OBJECT",
-                      "name": "__EnumValue",
+                      "name": "__Directive",
                       "ofType": null
                     }
                   }
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
+                }
               },
-              {
-                "name": "fields",
-                "description": null,
-                "args": [
-                  {
-                    "name": "includeDeprecated",
-                    "description": null,
-                    "type": {
-                      "kind": "SCALAR",
-                      "name": "Boolean",
-                      "ofType": null
-                    },
-                    "defaultValue": "False"
-                  }
-                ],
-                "type": {
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mutationType",
+              "description": "If this server supports mutation, the type that mutation operations will be rooted at.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "__Type",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "queryType",
+              "description": "The type that query operations will be rooted at.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "subscriptionType",
+              "description": "If this server support subscription, the type that subscription operations will be rooted at.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "__Type",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "types",
+              "description": "A list of all types supported by this server.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
@@ -453,19 +166,34 @@
                     "name": null,
                     "ofType": {
                       "kind": "OBJECT",
-                      "name": "__Field",
+                      "name": "__Type",
                       "ofType": null
                     }
                   }
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
+                }
               },
-              {
-                "name": "inputFields",
-                "description": null,
-                "args": [],
-                "type": {
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__Directive",
+          "description": "A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document. In some cases, you need to provide options to alter GraphQL’s execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.",
+          "fields": [
+            {
+              "name": "args",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
@@ -477,252 +205,291 @@
                       "ofType": null
                     }
                   }
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
+                }
               },
-              {
-                "name": "interfaces",
-                "description": null,
-                "args": [],
-                "type": {
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "locations",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
                     "kind": "NON_NULL",
                     "name": null,
                     "ofType": {
-                      "kind": "OBJECT",
-                      "name": "__Type",
+                      "kind": "ENUM",
+                      "name": "__DirectiveLocation",
                       "ofType": null
                     }
                   }
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
+                }
               },
-              {
-                "name": "kind",
-                "description": null,
-                "args": [],
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "ENUM",
-                    "name": "__TypeKind",
-                    "ofType": null
-                  }
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "name",
-                "description": null,
-                "args": [],
-                "type": {
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
                   "kind": "SCALAR",
                   "name": "String",
                   "ofType": null
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
+                }
               },
-              {
-                "name": "ofType",
-                "description": null,
-                "args": [],
-                "type": {
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "onField",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "onFragment",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "onOperation",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__InputValue",
+          "description": "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.",
+          "fields": [
+            {
+              "name": "defaultValue",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "type",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
                   "kind": "OBJECT",
                   "name": "__Type",
                   "ofType": null
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
+                }
               },
-              {
-                "name": "possibleTypes",
-                "description": null,
-                "args": [],
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "__Type",
-                      "ofType": null
-                    }
-                  }
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "inputFields": null,
-            "interfaces": [],
-            "enumValues": null,
-            "possibleTypes": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "__EnumValue",
-            "description": "One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.",
-            "fields": [
-              {
-                "name": "deprecationReason",
-                "description": null,
-                "args": [],
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__Type",
+          "description": "The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum. Depending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.",
+          "fields": [
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
-              {
-                "name": "description",
-                "description": null,
-                "args": [],
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "isDeprecated",
-                "description": null,
-                "args": [],
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "enumValues",
+              "description": null,
+              "args": [
+                {
+                  "name": "includeDeprecated",
+                  "description": null,
+                  "type": {
                     "kind": "SCALAR",
                     "name": "Boolean",
                     "ofType": null
-                  }
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "name",
-                "description": null,
-                "args": [],
-                "type": {
+                  },
+                  "defaultValue": "False"
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
+                    "kind": "OBJECT",
+                    "name": "__EnumValue",
                     "ofType": null
                   }
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "inputFields": null,
-            "interfaces": [],
-            "enumValues": null,
-            "possibleTypes": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "__Field",
-            "description": "Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.",
-            "fields": [
-              {
-                "name": "args",
-                "description": null,
-                "args": [],
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "LIST",
-                    "name": null,
-                    "ofType": {
-                      "kind": "NON_NULL",
-                      "name": null,
-                      "ofType": {
-                        "kind": "OBJECT",
-                        "name": "__InputValue"
-                      }
-                    }
-                  }
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
+                }
               },
-              {
-                "name": "deprecationReason",
-                "description": null,
-                "args": [],
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "description",
-                "description": null,
-                "args": [],
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "isDeprecated",
-                "description": null,
-                "args": [],
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fields",
+              "description": null,
+              "args": [
+                {
+                  "name": "includeDeprecated",
+                  "description": null,
+                  "type": {
                     "kind": "SCALAR",
                     "name": "Boolean",
                     "ofType": null
-                  }
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "name",
-                "description": null,
-                "args": [],
-                "type": {
+                  },
+                  "defaultValue": "False"
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
+                    "kind": "OBJECT",
+                    "name": "__Field",
                     "ofType": null
                   }
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
+                }
               },
-              {
-                "name": "type",
-                "description": null,
-                "args": [],
-                "type": {
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "inputFields",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__InputValue",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "interfaces",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
@@ -730,980 +497,1380 @@
                     "name": "__Type",
                     "ofType": null
                   }
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "inputFields": null,
-            "interfaces": [],
-            "enumValues": null,
-            "possibleTypes": null
-          },
-          {
-            "kind": "ENUM",
-            "name": "__TypeKind",
-            "description": "An enum describing what kind of type a given __Type is.",
-            "fields": null,
-            "inputFields": null,
-            "interfaces": null,
-            "enumValues": [
-              {
-                "name": "SCALAR",
-                "description": "Indicates this type is a scalar.",
-                "isDeprecated": false,
-                "deprecationReason": null
+                }
               },
-              {
-                "name": "OBJECT",
-                "description": "Indicates this type is an object. `fields` and `interfaces` are valid fields.",
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "INTERFACE",
-                "description": "Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.",
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "UNION",
-                "description": "Indicates this type is a union. `possibleTypes` is a valid field.",
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "ENUM",
-                "description": "Indicates this type is an enum. `enumValues` is a valid field.",
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "INPUT_OBJECT",
-                "description": "Indicates this type is an input object. `inputFields` is a valid field.",
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "LIST",
-                "description": "Indicates this type is a list. `ofType` is a valid field.",
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "NON_NULL",
-                "description": "Indicates this type is a non-null. `ofType` is a valid field.",
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "possibleTypes": null
-          },
-          {
-            "kind": "ENUM",
-            "name": "__DirectiveLocation",
-            "description": "A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies.",
-            "fields": null,
-            "inputFields": null,
-            "interfaces": null,
-            "enumValues": [
-              {
-                "name": "QUERY",
-                "description": "Location adjacent to a query operation.",
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "MUTATION",
-                "description": "Location adjacent to a mutation operation.",
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "SUBSCRIPTION",
-                "description": "Location adjacent to a subscription operation.",
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "FIELD",
-                "description": "Location adjacent to a field.",
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "FRAGMENT_DEFINITION",
-                "description": "Location adjacent to a fragment definition.",
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "FRAGMENT_SPREAD",
-                "description": "Location adjacent to a fragment spread.",
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "INLINE_FRAGMENT",
-                "description": "Location adjacent to an inline fragment.",
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "possibleTypes": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "Query",
-            "description": null,
-            "fields": [
-              {
-                "name": "droid",
-                "description": "Gets droid",
-                "args": [
-                  {
-                    "name": "id",
-                    "description": null,
-                    "type": {
-                      "kind": "NON_NULL",
-                      "name": null,
-                      "ofType": {
-                        "kind": "SCALAR",
-                        "name": "String",
-                        "ofType": null
-                      }
-                    },
-                    "defaultValue": null
-                  }
-                ],
-                "type": {
-                  "kind": "OBJECT",
-                  "name": "Droid",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kind",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "__TypeKind",
                   "ofType": null
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
+                }
               },
-              {
-                "name": "hero",
-                "description": "Gets human hero",
-                "args": [
-                  {
-                    "name": "id",
-                    "description": null,
-                    "type": {
-                      "kind": "NON_NULL",
-                      "name": null,
-                      "ofType": {
-                        "kind": "SCALAR",
-                        "name": "String",
-                        "ofType": null
-                      }
-                    },
-                    "defaultValue": null
-                  }
-                ],
-                "type": {
-                  "kind": "OBJECT",
-                  "name": "Human",
-                  "ofType": null
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "planet",
-                "description": "Gets planet",
-                "args": [
-                  {
-                    "name": "id",
-                    "description": null,
-                    "type": {
-                      "kind": "NON_NULL",
-                      "name": null,
-                      "ofType": {
-                        "kind": "SCALAR",
-                        "name": "String",
-                        "ofType": null
-                      }
-                    },
-                    "defaultValue": null
-                  }
-                ],
-                "type": {
-                  "kind": "OBJECT",
-                  "name": "Planet",
-                  "ofType": null
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "things",
-                "description": "Gets things",
-                "args": [
-                  {
-                    "name": "filter",
-                    "description": null,
-                    "type": {
-                      "kind": "INPUT_OBJECT",
-                      "name": "ThingFilter",
-                      "ofType": null
-                    },
-                    "defaultValue": null
-                  }
-                ],
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "LIST",
-                    "name": null,
-                    "ofType": {
-                      "kind": "NON_NULL",
-                      "name": null,
-                      "ofType": {
-                        "kind": "INTERFACE",
-                        "name": "Thing"
-                      }
-                    }
-                  }
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "inputFields": null,
-            "interfaces": [],
-            "enumValues": null,
-            "possibleTypes": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "Droid",
-            "description": "A mechanical creature in the Star Wars universe.",
-            "fields": [
-              {
-                "name": "appearsIn",
-                "description": "Which movies they appear in.",
-                "args": [],
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "LIST",
-                    "name": null,
-                    "ofType": {
-                      "kind": "NON_NULL",
-                      "name": null,
-                      "ofType": {
-                        "kind": "ENUM",
-                        "name": "Episode"
-                      }
-                    }
-                  }
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "friends",
-                "description": "The friends of the Droid, or an empty list if they have none.",
-                "args": [
-                  {
-                    "name": "filter",
-                    "description": null,
-                    "type": {
-                      "kind": "SCALAR",
-                      "name": "ObjectListFilter",
-                      "ofType": null
-                    },
-                    "defaultValue": null
-                  }
-                ],
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "LIST",
-                    "name": null,
-                    "ofType": {
-                      "kind": "UNION",
-                      "name": "Character",
-                      "ofType": null
-                    }
-                  }
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "id",
-                "description": "The id of the droid.",
-                "args": [],
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "name",
-                "description": "The name of the Droid.",
-                "args": [],
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "primaryFunction",
-                "description": "The primary function of the droid.",
-                "args": [],
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "inputFields": null,
-            "interfaces": [],
-            "enumValues": null,
-            "possibleTypes": null
-          },
-          {
-            "kind": "ENUM",
-            "name": "Episode",
-            "description": "One of the films in the Star Wars Trilogy.",
-            "fields": null,
-            "inputFields": null,
-            "interfaces": null,
-            "enumValues": [
-              {
-                "name": "NewHope",
-                "description": "Released in 1977.",
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "Empire",
-                "description": "Released in 1980.",
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "Jedi",
-                "description": "Released in 1983.",
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "possibleTypes": null
-          },
-          {
-            "kind": "UNION",
-            "name": "Character",
-            "description": "A character in the Star Wars Trilogy.",
-            "fields": null,
-            "inputFields": null,
-            "interfaces": null,
-            "enumValues": null,
-            "possibleTypes": [
-              {
-                "kind": "OBJECT",
-                "name": "Human",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               },
-              {
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ofType",
+              "description": null,
+              "args": [],
+              "type": {
                 "kind": "OBJECT",
-                "name": "Droid",
-                "ofType": null
-              }
-            ]
-          },
-          {
-            "kind": "OBJECT",
-            "name": "Human",
-            "description": "A humanoid creature in the Star Wars universe.",
-            "fields": [
-              {
-                "name": "appearsIn",
-                "description": "Which movies they appear in.",
-                "args": [],
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "LIST",
-                    "name": null,
-                    "ofType": {
-                      "kind": "NON_NULL",
-                      "name": null,
-                      "ofType": {
-                        "kind": "ENUM",
-                        "name": "Episode"
-                      }
-                    }
-                  }
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "friends",
-                "description": "The friends of the human, or an empty list if they have none.",
-                "args": [
-                  {
-                    "name": "filter",
-                    "description": null,
-                    "type": {
-                      "kind": "SCALAR",
-                      "name": "ObjectListFilter",
-                      "ofType": null
-                    },
-                    "defaultValue": null
-                  }
-                ],
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "LIST",
-                    "name": null,
-                    "ofType": {
-                      "kind": "UNION",
-                      "name": "Character",
-                      "ofType": null
-                    }
-                  }
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "homePlanet",
-                "description": "The home planet of the human, or null if unknown.",
-                "args": [],
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "id",
-                "description": "The id of the human.",
-                "args": [],
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "name",
-                "description": "The name of the human.",
-                "args": [],
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "inputFields": null,
-            "interfaces": [],
-            "enumValues": null,
-            "possibleTypes": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "Planet",
-            "description": "A planet in the Star Wars universe.",
-            "fields": [
-              {
-                "name": "id",
-                "description": "The id of the planet",
-                "args": [],
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "isMoon",
-                "description": "Is that a moon?",
-                "args": [],
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "name",
-                "description": "The name of the planet.",
-                "args": [],
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "inputFields": null,
-            "interfaces": [],
-            "enumValues": null,
-            "possibleTypes": null
-          },
-          {
-            "kind": "INTERFACE",
-            "name": "Thing",
-            "description": "A thing.",
-            "fields": [
-              {
-                "name": "format",
-                "description": "The format of the shape.",
-                "args": [],
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "id",
-                "description": "The ID of the shape.",
-                "args": [],
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "form",
-                "description": "The format of the shape.",
-                "args": [],
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "isDeprecated": true,
-                "deprecationReason": "Use format field instead."
-              }
-            ],
-            "inputFields": null,
-            "interfaces": null,
-            "enumValues": null,
-            "possibleTypes": [
-              {
-                "kind": "OBJECT",
-                "name": "Box",
+                "name": "__Type",
                 "ofType": null
               },
-              {
-                "kind": "OBJECT",
-                "name": "Ball",
-                "ofType": null
-              }
-            ]
-          },
-          {
-            "kind": "INPUT_OBJECT",
-            "name": "ThingFilter",
-            "description": "A filter used to select a thing.",
-            "fields": null,
-            "inputFields": [
-              {
-                "name": "format",
-                "description": "The format of  the shape to be filtered.",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              }
-            ],
-            "interfaces": null,
-            "enumValues": null,
-            "possibleTypes": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "Subscription",
-            "description": null,
-            "fields": [
-              {
-                "name": "watchMoon",
-                "description": "Watches to see if a planet is a moon",
-                "args": [
-                  {
-                    "name": "id",
-                    "description": null,
-                    "type": {
-                      "kind": "NON_NULL",
-                      "name": null,
-                      "ofType": {
-                        "kind": "SCALAR",
-                        "name": "String",
-                        "ofType": null
-                      }
-                    },
-                    "defaultValue": null
-                  }
-                ],
-                "type": {
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "possibleTypes",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
                     "kind": "OBJECT",
-                    "name": "Planet",
+                    "name": "__Type",
                     "ofType": null
                   }
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "inputFields": null,
-            "interfaces": [],
-            "enumValues": null,
-            "possibleTypes": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "Mutation",
-            "description": null,
-            "fields": [
-              {
-                "name": "setMoon",
-                "description": "Sets a moon status",
-                "args": [
-                  {
-                    "name": "id",
-                    "description": null,
-                    "type": {
-                      "kind": "NON_NULL",
-                      "name": null,
-                      "ofType": {
-                        "kind": "SCALAR",
-                        "name": "String",
-                        "ofType": null
-                      }
-                    },
-                    "defaultValue": null
-                  },
-                  {
-                    "name": "isMoon",
-                    "description": null,
-                    "type": {
-                      "kind": "NON_NULL",
-                      "name": null,
-                      "ofType": {
-                        "kind": "SCALAR",
-                        "name": "Boolean",
-                        "ofType": null
-                      }
-                    },
-                    "defaultValue": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__EnumValue",
+          "description": "One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.",
+          "fields": [
+            {
+              "name": "deprecationReason",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isDeprecated",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__Field",
+          "description": "Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.",
+          "fields": [
+            {
+              "name": "args",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__InputValue",
+                      "ofType": null
+                    }
                   }
-                ],
-                "type": {
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deprecationReason",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isDeprecated",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "type",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "__TypeKind",
+          "description": "An enum describing what kind of type a given __Type is.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "SCALAR",
+              "description": "Indicates this type is a scalar.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "OBJECT",
+              "description": "Indicates this type is an object. `fields` and `interfaces` are valid fields.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INTERFACE",
+              "description": "Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "UNION",
+              "description": "Indicates this type is a union. `possibleTypes` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ENUM",
+              "description": "Indicates this type is an enum. `enumValues` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INPUT_OBJECT",
+              "description": "Indicates this type is an input object. `inputFields` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "LIST",
+              "description": "Indicates this type is a list. `ofType` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "NON_NULL",
+              "description": "Indicates this type is a non-null. `ofType` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "__DirectiveLocation",
+          "description": "A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "QUERY",
+              "description": "Location adjacent to a query operation.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MUTATION",
+              "description": "Location adjacent to a mutation operation.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SUBSCRIPTION",
+              "description": "Location adjacent to a subscription operation.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FIELD",
+              "description": "Location adjacent to a field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FRAGMENT_DEFINITION",
+              "description": "Location adjacent to a fragment definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FRAGMENT_SPREAD",
+              "description": "Location adjacent to a fragment spread.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INLINE_FRAGMENT",
+              "description": "Location adjacent to an inline fragment.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SCHEMA",
+              "description": "Location adjacent to a schema IDL definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SCALAR",
+              "description": "Location adjacent to a scalar IDL definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "OBJECT",
+              "description": "Location adjacent to an object IDL definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FIELD_DEFINITION",
+              "description": "Location adjacent to a field IDL definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ARGUMENT_DEFINITION",
+              "description": "Location adjacent to a field argument IDL definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INTERFACE",
+              "description": "Location adjacent to an interface IDL definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "UNION",
+              "description": "Location adjacent to an union IDL definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ENUM",
+              "description": "Location adjacent to an enum IDL definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ENUM_VALUE",
+              "description": "Location adjacent to an enum value definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INPUT_OBJECT",
+              "description": "Location adjacent to an input object IDL definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INPUT_FIELD_DEFINITION",
+              "description": "Location adjacent to an input object field IDL definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Query",
+          "description": null,
+          "fields": [
+            {
+              "name": "droid",
+              "description": "Gets droid",
+              "args": [
+                {
+                  "name": "id",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Droid",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hero",
+              "description": "Gets human hero",
+              "args": [
+                {
+                  "name": "id",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Human",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "planet",
+              "description": "Gets planet",
+              "args": [
+                {
+                  "name": "id",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Planet",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "things",
+              "description": "Gets things",
+              "args": [
+                {
+                  "name": "filter",
+                  "description": null,
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ThingFilter",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INTERFACE",
+                      "name": "Thing",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Droid",
+          "description": "A mechanical creature in the Star Wars universe.",
+          "fields": [
+            {
+              "name": "appearsIn",
+              "description": "Which movies they appear in.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "Episode",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "friends",
+              "description": "The friends of the Droid, or an empty list if they have none.",
+              "args": [
+                {
+                  "name": "filter",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ObjectListFilter",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "UNION",
+                    "name": "Character",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": "The id of the droid.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "The name of the Droid.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "primaryFunction",
+              "description": "The primary function of the droid.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "Episode",
+          "description": "One of the films in the Star Wars Trilogy.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "NewHope",
+              "description": "Released in 1977.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "Empire",
+              "description": "Released in 1980.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "Jedi",
+              "description": "Released in 1983.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "UNION",
+          "name": "Character",
+          "description": "A character in the Star Wars Trilogy.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "Human",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Droid",
+              "ofType": null
+            }
+          ]
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Human",
+          "description": "A humanoid creature in the Star Wars universe.",
+          "fields": [
+            {
+              "name": "appearsIn",
+              "description": "Which movies they appear in.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "Episode",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "friends",
+              "description": "The friends of the human, or an empty list if they have none.",
+              "args": [
+                {
+                  "name": "filter",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ObjectListFilter",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "UNION",
+                    "name": "Character",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "homePlanet",
+              "description": "The home planet of the human, or null if unknown.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": "The id of the human.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "The name of the human.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Planet",
+          "description": "A planet in the Star Wars universe.",
+          "fields": [
+            {
+              "name": "id",
+              "description": "The id of the planet",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isMoon",
+              "description": "Is that a moon?",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "The name of the planet.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INTERFACE",
+          "name": "Thing",
+          "description": "A thing.",
+          "fields": [
+            {
+              "name": "format",
+              "description": "The format of the shape.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": "The ID of the shape.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "order",
+              "description": "The ID of the shape.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "size",
+              "description": "The ID of the shape.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "form",
+              "description": "The format of the shape.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use format field instead."
+            }
+          ],
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "Box",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Ball",
+              "ofType": null
+            }
+          ]
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "ThingFilter",
+          "description": "A filter used to select a thing.",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "format",
+              "description": "The format of  the shape to be filtered.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Subscription",
+          "description": null,
+          "fields": [
+            {
+              "name": "watchMoon",
+              "description": "Watches to see if a planet is a moon",
+              "args": [
+                {
+                  "name": "id",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
                   "kind": "OBJECT",
                   "name": "Planet",
                   "ofType": null
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "inputFields": null,
-            "interfaces": [],
-            "enumValues": null,
-            "possibleTypes": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "Ball",
-            "description": "A ball.",
-            "fields": [
-              {
-                "name": "form",
-                "description": "The format of the shape.",
-                "args": [],
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "isDeprecated": true,
-                "deprecationReason": "Use format field instead."
+                }
               },
-              {
-                "name": "format",
-                "description": "The format of the ball.",
-                "args": [],
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Mutation",
+          "description": null,
+          "fields": [
+            {
+              "name": "setMoon",
+              "description": "Sets a moon status",
+              "args": [
+                {
+                  "name": "id",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
                 },
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "id",
-                "description": "The ID of the ball.",
-                "args": [],
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "inputFields": null,
-            "interfaces": [
-              {
-                "kind": "INTERFACE",
-                "name": "Thing",
+                {
+                  "name": "isMoon",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Boolean",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Planet",
                 "ofType": null
-              }
-            ],
-            "enumValues": null,
-            "possibleTypes": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "Box",
-            "description": "A box.",
-            "fields": [
-              {
-                "name": "form",
-                "description": "The format of the shape.",
-                "args": [],
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "isDeprecated": true,
-                "deprecationReason": "Use format field instead."
               },
-              {
-                "name": "format",
-                "description": "The format of the box.",
-                "args": [],
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Ball",
+          "description": "A ball.",
+          "fields": [
+            {
+              "name": "form",
+              "description": "The format of the shape.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
               },
-              {
-                "name": "id",
-                "description": "The ID of the box.",
-                "args": [],
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "inputFields": null,
-            "interfaces": [
-              {
-                "kind": "INTERFACE",
-                "name": "Thing",
-                "ofType": null
-              }
-            ],
-            "enumValues": null,
-            "possibleTypes": null
-          },
-          {
-            "kind": "SCALAR",
-            "name": "ObjectListFilter",
-            "description": "The `Filter` scalar type represents a filter on one or more fields of an object in an object list. The filter is represented by a JSON object where the fields are the complemented by specific suffixes to represent a query.",
-            "fields": null,
-            "inputFields": null,
-            "interfaces": null,
-            "enumValues": null,
-            "possibleTypes": null
-          }
-        ],
-        "directives": [
-          {
-            "name": "include",
-            "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
-            "locations": [
-              "FIELD",
-              "FRAGMENT_SPREAD",
-              "INLINE_FRAGMENT"
-            ],
-            "args": [
-              {
-                "name": "if",
-                "description": "Included when true.",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Boolean",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              }
-            ]
-          },
-          {
-            "name": "skip",
-            "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
-            "locations": [
-              "FIELD",
-              "FRAGMENT_SPREAD",
-              "INLINE_FRAGMENT"
-            ],
-            "args": [
-              {
-                "name": "if",
-                "description": "Skipped when true.",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Boolean",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              }
-            ]
-          },
-          {
-            "name": "defer",
-            "description": "Defers the resolution of this field or fragment",
-            "locations": [
-              "FIELD",
-              "FRAGMENT_DEFINITION",
-              "FRAGMENT_SPREAD",
-              "INLINE_FRAGMENT"
-            ],
-            "args": []
-          },
-          {
-            "name": "stream",
-            "description": "Streams the resolution of this field or fragment",
-            "locations": [
-              "FIELD",
-              "FRAGMENT_DEFINITION",
-              "FRAGMENT_SPREAD",
-              "INLINE_FRAGMENT"
-            ],
-            "args": []
-          },
-          {
-            "name": "live",
-            "description": "Subscribes for live updates of this field or fragment",
-            "locations": [
-              "FIELD",
-              "FRAGMENT_DEFINITION",
-              "FRAGMENT_SPREAD",
-              "INLINE_FRAGMENT"
-            ],
-            "args": []
-          }
-        ]
-      }
+              "isDeprecated": true,
+              "deprecationReason": "Use format field instead."
+            },
+            {
+              "name": "format",
+              "description": "The format of the ball.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": "The ID of the ball.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "order",
+              "description": "The ID of the shape.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "size",
+              "description": "The ID of the shape.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Thing",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Box",
+          "description": "A box.",
+          "fields": [
+            {
+              "name": "form",
+              "description": "The format of the shape.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use format field instead."
+            },
+            {
+              "name": "format",
+              "description": "The format of the box.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": "The ID of the box.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "order",
+              "description": "The ID of the shape.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "size",
+              "description": "The ID of the shape.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Thing",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "ObjectListFilter",
+          "description": "The `Filter` scalar type represents a filter on one or more fields of an object in an object list. The filter is represented by a JSON object where the fields are the complemented by specific suffixes to represent a query.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        }
+      ],
+      "directives": [
+        {
+          "name": "include",
+          "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
+          "locations": [
+            "FIELD",
+            "FRAGMENT_SPREAD",
+            "INLINE_FRAGMENT"
+          ],
+          "args": [
+            {
+              "name": "if",
+              "description": "Included when true.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ]
+        },
+        {
+          "name": "skip",
+          "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
+          "locations": [
+            "FIELD",
+            "FRAGMENT_SPREAD",
+            "INLINE_FRAGMENT"
+          ],
+          "args": [
+            {
+              "name": "if",
+              "description": "Skipped when true.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ]
+        },
+        {
+          "name": "defer",
+          "description": "Defers the resolution of this field or fragment",
+          "locations": [
+            "FIELD",
+            "FRAGMENT_DEFINITION",
+            "FRAGMENT_SPREAD",
+            "INLINE_FRAGMENT"
+          ],
+          "args": []
+        },
+        {
+          "name": "stream",
+          "description": "Streams the resolution of this field or fragment",
+          "locations": [
+            "FIELD",
+            "FRAGMENT_DEFINITION",
+            "FRAGMENT_SPREAD",
+            "INLINE_FRAGMENT"
+          ],
+          "args": []
+        },
+        {
+          "name": "live",
+          "description": "Subscribes for live updates of this field or fragment",
+          "locations": [
+            "FIELD",
+            "FRAGMENT_DEFINITION",
+            "FRAGMENT_SPREAD",
+            "INLINE_FRAGMENT"
+          ],
+          "args": []
+        }
+      ]
     }
   }
+}


### PR DESCRIPTION
This PR is meant to treat optional properties as optional parameters in the constructors of RecordBase types. It also does have a fix to help parsing number types in queries.