### PR TITLE
Parser updates

### DIFF
--- a/src/FSharp.Data.GraphQL.Shared/Ast.fs
+++ b/src/FSharp.Data.GraphQL.Shared/Ast.fs
@@ -79,23 +79,25 @@ and FragmentDefinition = {
     SelectionSet: Selection list
 }
 
-/// 2.2.7 Input Values
+/// 2.9 Input Values
 and Value = 
-    /// 2.2.7.1 Int Value
+    /// 2.9.1 Int Value
     | IntValue of int64
-    /// 2.2.7.2 Float Value
+    /// 2.9.2 Float Value
     | FloatValue of double
-    /// 2.2.7.3 Boolean Value
+    /// 2.9.3 Boolean Value
     | BooleanValue of bool
-    /// 2.2.7.4 String Value
+    /// 2.9.4 String Value
     | StringValue of string
-    /// 2.2.7.5 Enum Value
+    /// 2.9.5 Null Value
+    | NullValue
+    /// 2.9.6 Enum Value
     | EnumValue of string
-    /// 2.2.7.6 List Value
+    /// 2.9.7 List Value
     | ListValue of Value list
-    /// 2.2.7.7 Input Object Values
+    /// 2.9.8 Input Object Values
     | ObjectValue of Map<string, Value>
-    /// 2.2.8 Variables
+    /// 2.10 Variables
     | Variable of string
 
 /// 2.2.8 Variables

--- a/src/FSharp.Data.GraphQL.Shared/AstExtensions.fs
+++ b/src/FSharp.Data.GraphQL.Shared/AstExtensions.fs
@@ -100,6 +100,7 @@ type Document with
             | BooleanValue x -> sb.Append(if x then "true" else "false")
             | StringValue x -> sb.Append(withQuotes x)
             | EnumValue x -> sb.Append(x)
+            | NullValue -> sb.Append("null")
             | ListValue x ->
                 if x.Length > 0 then sb.Append("[ ")
                 match x with

--- a/src/FSharp.Data.GraphQL.Shared/Parser.fs
+++ b/src/FSharp.Data.GraphQL.Shared/Parser.fs
@@ -142,8 +142,10 @@ module internal Internal =
       pipe3 integerPart fractionPart exponentPart 
         (fun integer fraction exponent -> integer + fraction + exponent ) ] |>> float
 
+  // 2.9.5 Null Value
+  let nullValue = stoken "null" >>% NullValue
 
-  // 2.9.5 EnumValue
+  // 2.9.6 Enum Value
   //   Name but not true or false or null
   //   (boolean parser is run first)
   let enumValue = name
@@ -154,24 +156,26 @@ module internal Internal =
   let variable = pchar '$' >>. name 
 
 
-  // 2.9.7 Input Object Values
+  // 2.9.8 Input Object Values
   let inputObject =
     betweenCharsMany '{' '}' (pairBetween ':' name inputValue <?> "ObjectField") 
     |>> Map.ofList 
   
+  // 2.9.7 List Value
   let listValue =
     betweenCharsMany '[' ']' (token_ws inputValue <?> "Value") 
      
 
   // 2.9 Value 
   //   Variable|IntValue|FloatValue|StringValue|
-  //   BooleanValue|EnumValue|ListValue|ObjectValue
+  //   BooleanValue|NullValue|EnumValue|ListValue|ObjectValue
   inputValueRef :=
     choice [ variable |>> Variable <?> "Variable"
              (attempt floatValue) |>> FloatValue <?> "Float"
              integerValue |>> IntValue <?> "Integer"
              stringValue |>> StringValue <?> "String"
              (attempt booleanValue) |>> BooleanValue <?> "Boolean"
+             nullValue
              enumValue |>> EnumValue  <?> "Enum"
              inputObject |>> ObjectValue  <?> "InputObject"
              listValue |>> ListValue <?> "ListValue" ]  

--- a/tests/FSharp.Data.GraphQL.Tests/ParserTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/ParserTests.fs
@@ -104,6 +104,14 @@ let ``parser should parse simple query with single field``() =
     test expected """{uri}"""
 
 [<Fact>]
+let ``parser should parse simple query with operation identifier, but no operation name``() =
+    let expected =
+        field "uri"
+        |> queryWithSelection
+        |> doc1
+    test expected """query {uri}"""
+
+[<Fact>]
 let ``parser should parse simple query with single field with whitespace``() =
     let expected =
         field "uri"

--- a/tests/FSharp.Data.GraphQL.Tests/ParserTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/ParserTests.fs
@@ -36,6 +36,7 @@ let queryWithSelection selection = queryWithSelections [ selection ]
 
 let arg name value = { Argument.Name = name; Value = value }
 let argInt name value = arg name (IntValue (int64 value))
+let argNull name = arg name NullValue
 let fieldWithNameAndArgsAndSelections name arguments selections =
     Field { Name = name
             Alias = None
@@ -267,6 +268,19 @@ let ``parser should parse GraphQL``() =
         width,
         height
       }
+    }
+  }"""
+  
+[<Fact>]
+let ``parser should parse query with null arguments``() =
+    let expected =
+        [ field "name" ]
+        |> fieldWithNameAndArgsAndSelections "user" [ argNull "id" ]
+        |> queryWithSelection
+        |> doc1
+    test expected """{
+    user(id: null) {
+      name
     }
   }"""
 


### PR DESCRIPTION
With this PR, I am proposing updates to the parser. It needs support for two features of GraphQL:

- [x] Correctly parsing `null` keyword into a [Null Value](https://graphql.github.io/graphql-spec/June2018/#sec-Null-Value). It actually parses the keyword into an Enum Value.
- [x] Correctly parsing an unnamed operation. The parser does recognize short-hand queries, like `{ field }`, but does not recognize unnamed queries with the operation type keyword, like `query { field }`.