### PR TITLE
Added test cases for object inputs for graphql functions

### DIFF
--- a/tests/FSharp.Data.GraphQL.Tests/AstExtensionsTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/AstExtensionsTests.fs
@@ -46,6 +46,18 @@ let ``Should be able to print a query with variables`` () =
 }"""
 
 [<Fact>]
+let ``Should be able to parse a query with an object input in the internal method`` () =
+    printAndAssert """mutation q($id: String!, $name: String!) {
+  addHero(input: {id: $id, label: $name })
+}"""
+
+[<Fact>]
+let ``Should be able to parse a query with an object having array properties input in the internal method`` () =
+    printAndAssert """mutation q($id: String!, $name: String!, $friend1: String!) {
+  addHero(input: {id: $id, label: $name, friends: [$friend1] })
+}"""
+
+[<Fact>]
 let ``Should be able to print a query with aliases`` () =
     printAndAssert """query q($myId: String!, $hisId: String!) {
   myHero: hero(id: $myId) {


### PR DESCRIPTION
Added test cases for object inputs for graphql functions like are used by TopBraid EDG. Note these currently fail.

This is the output at the command line.
```
[xUnit.net 00:00:34.35]     FSharp.Data.GraphQL.Tests.AstExtensionsTests.Should be able to parse a query with an object having array properties input in the internal method [FAIL]
  X FSharp.Data.GraphQL.Tests.AstExtensionsTests.Should be able to parse a query with an object having array properties input in the internal method [2ms]
  Error Message:
   expected mutation q($id: String!, $name: String!, $friend1: String!) {
  addHero(input: {id: $id, label: $name, friends: [$friend1] })
}
but got mutation q($id: String!, $name: String!, $friend1: String!) {
  addHero(input: { "friends": [ $friend1 ], "id": $id"label": $name)
}
Expected: True
Actual:   False
  Stack Trace:
     at Helpers.equals[x](x expected, x actual) in /home/jgoodwin/src/FSharp.Data.GraphQL/tests/FSharp.Data.GraphQL.Tests/Helpers.fs:line 20
   at FSharp.Data.GraphQL.Tests.AstExtensionsTests.printAndAssert(String query) in /home/jgoodwin/src/FSharp.Data.GraphQL/tests/FSharp.Data.GraphQL.Tests/AstExtensionsTests.fs:line 20
   at FSharp.Data.GraphQL.Tests.AstExtensionsTests.Should be able to parse a query with an object having array properties input in the internal method() in /home/jgoodwin/src/FSharp.Data.GraphQL/tests/FSharp.Data.GraphQL.Tests/AstExtensionsTests.fs:line 56
[xUnit.net 00:00:34.35]     FSharp.Data.GraphQL.Tests.AstExtensionsTests.Should be able to parse a query with an object input in the internal method [FAIL]
[xUnit.net 00:00:34.44]     FSharp.Data.GraphQL.Tests.VariablesTests.Execute handles objects and nullability using inline structs and properly parses single value to list [SKIP]
  X FSharp.Data.GraphQL.Tests.AstExtensionsTests.Should be able to parse a query with an object input in the internal method [1ms]         
  Error Message:
   expected mutation q($id: String!, $name: String!) {
  addHero(input: {id: $id, label: $name })
}
but got mutation q($id: String!, $name: String!) {
  addHero(input: { "id": $id, "label": $name)
}
Expected: True
Actual:   False
  Stack Trace:
     at Helpers.equals[x](x expected, x actual) in /home/jgoodwin/src/FSharp.Data.GraphQL/tests/FSharp.Data.GraphQL.Tests/Helpers.fs:line 20
   at FSharp.Data.GraphQL.Tests.AstExtensionsTests.printAndAssert(String query) in /home/jgoodwin/src/FSharp.Data.GraphQL/tests/FSharp.Data.GraphQL.Tests/AstExtensionsTests.fs:line 20
   at FSharp.Data.GraphQL.Tests.AstExtensionsTests.Should be able to parse a query with an object input in the internal method() in /home/jgoodwin/src/FSharp.Data.GraphQL/tests/FSharp.Data.GraphQL.Tests/AstExtensionsTests.fs:line 50
```