### PR TITLE
Traverse list values in argument lists

### DIFF
--- a/src/FSharp.Data.GraphQL.Shared/Validation.fs
+++ b/src/FSharp.Data.GraphQL.Shared/Validation.fs
@@ -964,6 +964,7 @@ module Ast =
         let rec go xs = xs |> List.exists (function
             | Variable varName -> varName = name
             | ObjectValue obj -> go (Map.toList obj |> List.map snd)
+            | ListValue xs -> go xs
             | _ -> false) 
         go (args |> List.map (fun x -> x.Value))        
 

--- a/tests/FSharp.Data.GraphQL.Tests/AstValidationTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/AstValidationTests.fs
@@ -1077,6 +1077,17 @@ query nestedVariables($name: String) {
     |> equals Success
 
 [<Fact>]
+let ``Validation should look for variable being used in list values in arguments`` () =
+    let query1 =
+        """query houseTrainedQuery($atOtherHomes: Boolean) {
+  dog(input: { metafields: [ { namespace: "gss", key: $atOtherHomes } ] }) {
+    isHousetrained(atOtherHomes: true)
+  }
+}"""
+    let shouldPass = getContext query1 |> Validation.Ast.validateAllVariablesUsed
+    shouldPass |> equals Success
+
+[<Fact>]
 let ``Validation should grant that all variables can be used`` () =
     let query1 =
         """query intCannotGoIntoBoolean($intArg: Int) {


### PR DESCRIPTION
Validating usage of variables did not traverse list values in
arguments, resulting in incorrect validation errors.

Also add a test case for it.