### PR TITLE
Correct printing of ListValue and ObjectValue

### DIFF
--- a/tests/FSharp.Data.GraphQL.Tests/AstExtensionsTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/AstExtensionsTests.fs
@@ -46,6 +46,18 @@ let ``Should be able to print a query with variables`` () =
 }"""
 
 [<Fact>]
+let ``Should be able to parse a query with an object input in the internal method`` () =
+    printAndAssert """mutation q($id: String!, $name: String!) {
+  addHero(input: {id: $id, label: $name })
+}"""
+
+[<Fact>]
+let ``Should be able to parse a query with an object having array properties input in the internal method`` () =
+    printAndAssert """mutation q($id: String!, $name: String!, $friend1: String!) {
+  addHero(input: {id: $id, label: $name, friends: [$friend1] })
+}"""
+
+[<Fact>]
 let ``Should be able to print a query with aliases`` () =
     printAndAssert """query q($myId: String!, $hisId: String!) {
   myHero: hero(id: $myId) {

--- a/tests/FSharp.Data.GraphQL.Tests/AstExtensionsTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/AstExtensionsTests.fs
@@ -48,13 +48,29 @@ let ``Should be able to print a query with variables`` () =
 [<Fact>]
 let ``Should be able to parse a query with an object input in the internal method`` () =
     printAndAssert """mutation q($id: String!, $name: String!) {
-  addHero(input: {id: $id, label: $name })
+  addHero(input: { id: $id, label: $name })
 }"""
 
 [<Fact>]
 let ``Should be able to parse a query with an object having array properties input in the internal method`` () =
     printAndAssert """mutation q($id: String!, $name: String!, $friend1: String!) {
-  addHero(input: {id: $id, label: $name, friends: [$friend1] })
+  addHero(input: { friends: [ $friend1 ], id: $id, label: $name })
+}"""
+
+[<Fact>]
+let ``Should be able to parse a query with an object having multi-element array input in the internal method`` () =
+    printAndAssert """mutation q($id: String!, $name: String!) {
+  addHero(input: { friends: [ 7, 5, -3 ], id: $id, label: $name })
+}"""
+
+[<Fact>]
+let ``Should be able print ObjectValue names properly`` () =
+    printAndAssert """query GetCampaigns {
+  campaigns(params: { limit: 100, offset: 0 }) {
+    campaigns {
+      code
+    }
+  }
 }"""
 
 [<Fact>]


### PR DESCRIPTION
This fixes issues with recursive printing of ListValue and ObjectValue.

The PR is based on https://github.com/fsprojects/FSharp.Data.GraphQL/pull/254 and contains minor changes to spacing and order of ObjectValue members to make it work.