### PR TITLE
Correct printing of queries without names

### DIFF
--- a/src/FSharp.Data.GraphQL.Shared/Ast.fs
+++ b/src/FSharp.Data.GraphQL.Shared/Ast.fs
@@ -26,13 +26,16 @@ and Definition =
         | FragmentDefinition frag -> frag.SelectionSet
 
 /// 2.2.1 Operations
-and OperationDefinition = {
-    OperationType: OperationType
-    Name: string option
-    VariableDefinitions: VariableDefinition list 
-    Directives: Directive list
-    SelectionSet: Selection list
-}
+and OperationDefinition =
+    {
+        OperationType: OperationType
+        Name: string option
+        VariableDefinitions: VariableDefinition list
+        Directives: Directive list
+        SelectionSet: Selection list
+    }
+    member x.IsShortHandQuery =
+        x.OperationType = Query && x.Name.IsNone && x.VariableDefinitions.IsEmpty && x.Directives.IsEmpty
 
 and OperationType = 
     | Query

--- a/src/FSharp.Data.GraphQL.Shared/AstExtensions.fs
+++ b/src/FSharp.Data.GraphQL.Shared/AstExtensions.fs
@@ -192,7 +192,8 @@ type Document with
             let printDefinition = function
                 | OperationDefinition odef ->
                     match odef.OperationType with
-                    | Query -> if odef.Name.IsSome then sb.Append("query ")
+                    | Query when odef.IsShortHandQuery -> ()
+                    | Query -> sb.Append("query ")
                     | Mutation -> sb.Append("mutation ")
                     | Subscription -> sb.Append("subscription ")
                     odef.Name 

--- a/tests/FSharp.Data.GraphQL.Tests/AstExtensionsTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/AstExtensionsTests.fs
@@ -92,6 +92,22 @@ fragment friend on Character {
 }"""
 
 [<Fact>]
+let ``Should be able to print a short hand format query`` () =
+    printAndAssert """{
+  field1
+  field2
+}"""
+
+[<Fact>]
+let ``Should not print query without name in short hand format`` () =
+    printAndAssert """query ($rId: Int) {
+  answer(id: $rId) {
+    id
+    answer
+  }
+}"""
+
+[<Fact>]
 let ``Should be able to print a query with inline fragments`` () =
     printAndAssert """query q($myId: String!, $hisId: String!) {
   myHero: hero(id: $myId) {


### PR DESCRIPTION
It would incorrectly print unnamed queries in shorthand format by just
testing the name for being empty. This is not entirely correct as also
variable definitions and directives need to be empty.

Made it more robust by having a member on OperationDefinition that can
tell whether a query can be represented in shorthand format.

Also add a couple of test cases related to this.

Reference:
https://github.com/fsprojects/FSharp.Data.GraphQL/issues/251