### PR TITLE
Enable error messages without a path

### DIFF
--- a/src/FSharp.Data.GraphQL.Client/BaseTypes.fs
+++ b/src/FSharp.Data.GraphQL.Client/BaseTypes.fs
@@ -384,6 +384,8 @@ module internal JsonValueHelper =
                         | JsonValue.Integer x -> box x
                         | _ -> failwith "Error parsing response errors. A item in the path is neither a String or a Number."
                     { Message = message; Path = Array.map pathMapper path }
+                | Some (_, JsonValue.String message), None->
+                    { Message = message; Path = [||]}
                 | _ -> failwith "Error parsing response errors. Unsupported errors field format."
             | other -> failwithf "Error parsing response errors. Expected error to be a Record type, but it is %s." (other.ToString())
         Array.map errorMapper errors


### PR DESCRIPTION
Not all error messages sent back from a
GraphQL Server contain a path.

This commit adds an additional case for error
messages without a path. The path is set to
an empty array for the returned type.