### PR TITLE
Open static classes

### DIFF
--- a/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
+++ b/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
@@ -2678,7 +2678,8 @@ module SchemaDefinitions =
     let inline internal strip (fn : 'In -> 'Out) : obj -> obj = fun i -> upcast fn (i :?> 'In)
 
     /// Common space for all definition helper methods.
-    type Define private () =
+    [<AbstractClass; Sealed>]
+    type Define =
 
         /// <summary>
         /// Creates GraphQL type definition for user defined scalars.


### PR DESCRIPTION
This makes a modification to the `Define` type to allow opening define as a static class. https://github.com/fsharp/fslang-design/blob/master/preview/FS-1068-open-static-classes.md

This enables the dropping `Define.` from Schema definitions.