### PR TITLE
Allowing GraphQLClientConnection to be reusable between requests

### DIFF
--- a/samples/client-provider/standard_features.fsx
+++ b/samples/client-provider/standard_features.fsx
@@ -54,6 +54,10 @@ let operation =
 // To use different server address or custom HTTP headers at runtime, you need to specify a GraphQLProviderRuntimeContext.
 let runtimeContext = MyProvider.GetContext(serverUrl = "http://localhost:8084")
 
+// You can recycle a connection object between all contexts if desired.
+//let connection = new GraphQLClientConnection()
+//let runtimeContext = MyProvider.GetContext(serverUrl = "http://localhost:8084", connection = connection)
+
 // To run an operation, you just need to call the Run or AsyncRun method.
 let result = operation.Run(runtimeContext)
 //let result = operation.AsyncRun() |> Async.RunSynchronously

--- a/samples/client-provider/standard_features.fsx
+++ b/samples/client-provider/standard_features.fsx
@@ -1,6 +1,6 @@
 // Uncomment those to use build script client assembly
-//#r "../../bin/FSharp.Data.GraphQL.Client/net47/FSharp.Data.GraphQL.Client.dll"
-//#r "../../bin/FSharp.Data.GraphQL.Shared/net47/FSharp.Data.GraphQL.Shared.dll"
+//#r "../../bin/FSharp.Data.GraphQL.Client/net461/FSharp.Data.GraphQL.Client.dll"
+//#r "../../bin/FSharp.Data.GraphQL.Shared/net461/FSharp.Data.GraphQL.Shared.dll"
 
 // Uncomment those to use build script client assembly using netstandard2.0
 //#r "../../bin/FSharp.Data.GraphQL.Shared/netstandard2.0/FSharp.Data.GraphQL.Shared.dll"
@@ -8,8 +8,8 @@
 //#r "../../bin/FSharp.Data.GraphQL.Client/netstandard2.0/FSharp.Data.GraphQL.Client.dll"
 
 // Uncomment those to use dotnet build command for the client assembly
-// #r "../../src/FSharp.Data.GraphQL.Shared/bin/Debug/net47/FSharp.Data.GraphQL.Shared.dll"
-// #r "../../src/FSharp.Data.GraphQL.Client/bin/Debug/net47/FSharp.Data.GraphQL.Client.dll"
+// #r "../../src/FSharp.Data.GraphQL.Shared/bin/Debug/net461/FSharp.Data.GraphQL.Shared.dll"
+// #r "../../src/FSharp.Data.GraphQL.Client/bin/Debug/net461/FSharp.Data.GraphQL.Client.dll"
 
 //Uncomment those to use dotnet build command for the client assembly using netstandard2.0
 #r "../../src/FSharp.Data.GraphQL.Shared/bin/Debug/netstandard2.0/FSharp.Data.GraphQL.Shared.dll"
@@ -52,11 +52,11 @@ let operation =
     }""">()
 
 // To use different server address or custom HTTP headers at runtime, you need to specify a GraphQLProviderRuntimeContext.
-let runtimeContext = MyProvider.GetContext(serverUrl = "http://localhost:8084")
+//let runtimeContext = MyProvider.GetContext(serverUrl = "http://localhost:8084")
 
-// You can recycle a connection object between all contexts if desired.
-//let connection = new GraphQLClientConnection()
-//let runtimeContext = MyProvider.GetContext(serverUrl = "http://localhost:8084", connection = connection)
+// You can specify a connection factory to manage your connection lifecycle if you want.
+let connection = new GraphQLClientConnection()
+let runtimeContext = MyProvider.GetContext(serverUrl = "http://localhost:8084", connectionFactory = fun () -> connection)
 
 // To run an operation, you just need to call the Run or AsyncRun method.
 let result = operation.Run(runtimeContext)

--- a/src/FSharp.Data.GraphQL.Client.DesignTime/FSharp.Data.GraphQL.Client.DesignTime.fsproj
+++ b/src/FSharp.Data.GraphQL.Client.DesignTime/FSharp.Data.GraphQL.Client.DesignTime.fsproj
@@ -30,6 +30,7 @@
     <Compile Include="..\FSharp.Data.GraphQL.Client\Serialization.fs" />
     <Compile Include="..\FSharp.Data.GraphQL.Client\Locations.fs" />
     <Compile Include="..\FSharp.Data.GraphQL.Client\BaseTypes.fs" />
+    <Compile Include="..\FSharp.Data.GraphQL.Client\GraphQLClientConnection.fs" />
     <Compile Include="..\FSharp.Data.GraphQL.Client\GraphQLClient.fs" />
     <Compile Include="..\FSharp.Data.GraphQL.Client\GraphQLProviderRuntimeContext.fs" />
     <Compile Include="DesignTimeCache.fs" />

--- a/src/FSharp.Data.GraphQL.Client/FSharp.Data.GraphQL.Client.fsproj
+++ b/src/FSharp.Data.GraphQL.Client/FSharp.Data.GraphQL.Client.fsproj
@@ -20,6 +20,7 @@
     <Compile Include="Serialization.fs" />
     <Compile Include="Locations.fs" />
     <Compile Include="BaseTypes.fs" />
+    <Compile Include="GraphQLClientConnection.fs" />
     <Compile Include="GraphQLClient.fs" />
     <Compile Include="GraphQLProviderRuntimeContext.fs" />
     <Compile Include="GraphQLProvider.Runtime.fs" />

--- a/src/FSharp.Data.GraphQL.Client/GraphQLClient.fs
+++ b/src/FSharp.Data.GraphQL.Client/GraphQLClient.fs
@@ -9,15 +9,7 @@ open System.Net.Http
 open FSharp.Data.GraphQL
 open FSharp.Data.GraphQL.Client
 open System.Text
-open System.Reflection
 open ReflectionPatterns
-
-/// The connection component for GraphQLClient module.
-type GraphQLClientConnection() =
-    let client = new HttpClient()
-    member internal __.Client = client
-    interface IDisposable with
-        member __.Dispose() = client.Dispose()
 
 /// A requrest object for making GraphQL calls using the GraphQL client module.
 type GraphQLRequest  =

--- a/src/FSharp.Data.GraphQL.Client/GraphQLClientConnection.fs
+++ b/src/FSharp.Data.GraphQL.Client/GraphQLClientConnection.fs
@@ -9,15 +9,22 @@ open System.Net.Http
 /// The connection component for GraphQL client operations.
 [<AllowNullLiteral>]
 type GraphQLClientConnection(invoker : HttpMessageInvoker, ownsInvoker : bool) =
+    do if isNull invoker then raise <| ArgumentNullException("invoker")
+
     /// Creates a new instance of GraphQLClientConnection, using a provided System.Net.Http.HttpMessageInvoker to be wrapped inside.
     /// The provided System.Net.Http.HttpMessageInvoker is not owned by the connection, so it must be disposed when it is not necessary anymore.
     new(invoker) = new GraphQLClientConnection(invoker, false)
+
+    /// Creates a new instance of GraphQLClientConnection, using a provided System.Net.Http.HttpClient as a System.Net.Http.HttpMessageInvoker to be wrapped inside.
+    /// The provided System.Net.Http.HttpMessageInvoker is not owned by the connection, so it must be disposed when it is not necessary anymore.
+    new(invoker : HttpClient) = new GraphQLClientConnection(invoker, false)
 
     /// Creates a new instance of GraphQLClientConnection, using a fresh new instance of System.Net.Http.HttpClient as an System.Net.Http.HttpMessageInvoker.
     /// This instance is owned by the GraphQLClientConnection, being disposed when the connection itself is disposed.
     new() = new GraphQLClientConnection(new HttpClient(), true)
 
-    member internal __.Invoker = invoker
+    /// The System.Net.Http.HttpMessageInvoker used by this connection.
+    member __.Invoker = invoker
     
     interface IDisposable with
         member __.Dispose() = if ownsInvoker then invoker.Dispose()

--- a/src/FSharp.Data.GraphQL.Client/GraphQLClientConnection.fs
+++ b/src/FSharp.Data.GraphQL.Client/GraphQLClientConnection.fs
@@ -9,8 +9,12 @@ open System.Net.Http
 /// The connection component for GraphQL client operations.
 [<AllowNullLiteral>]
 type GraphQLClientConnection(client : HttpClient, ownsClient : bool) =
+    /// Creates a new instance of GraphQLClientConnection, using a provided HttpClient to be wrapped inside.
+    /// The provided HttpClient is not owned by the connection, so it must be disposed when it is not necessary anymore.
     new(client) = new GraphQLClientConnection(client, false)
 
+    /// Creates a new instance of GraphQLClientConnection, using a fresh new instance of HttpClient internally.
+    /// This instance is owned by the GraphQLClientConnection, being disposed when the connection itself is disposed.
     new() = new GraphQLClientConnection(new HttpClient(), true)
 
     member internal __.Client = client

--- a/src/FSharp.Data.GraphQL.Client/GraphQLClientConnection.fs
+++ b/src/FSharp.Data.GraphQL.Client/GraphQLClientConnection.fs
@@ -1,0 +1,26 @@
+/// The MIT License (MIT)
+/// Copyright (c) 2016 Bazinga Technologies Inc
+
+namespace FSharp.Data.GraphQL
+
+open System
+open System.Net.Http
+
+/// The connection component for GraphQL client operations.
+[<AllowNullLiteral>]
+type GraphQLClientConnection() =
+    let client = new HttpClient()
+    let mutable disposed = false
+
+    member internal __.Client = 
+        if not disposed
+        then client
+        else raise <| ObjectDisposedException("GraphQLClientConnection")
+    
+    member internal __.Disposed = disposed
+
+    interface IDisposable with
+        member __.Dispose() =
+            if not disposed then
+                disposed <- true
+                client.Dispose()

--- a/src/FSharp.Data.GraphQL.Client/GraphQLClientConnection.fs
+++ b/src/FSharp.Data.GraphQL.Client/GraphQLClientConnection.fs
@@ -8,19 +8,12 @@ open System.Net.Http
 
 /// The connection component for GraphQL client operations.
 [<AllowNullLiteral>]
-type GraphQLClientConnection() =
-    let client = new HttpClient()
-    let mutable disposed = false
+type GraphQLClientConnection(client : HttpClient, ownsClient : bool) =
+    new(client) = new GraphQLClientConnection(client, false)
 
-    member internal __.Client = 
-        if not disposed
-        then client
-        else raise <| ObjectDisposedException("GraphQLClientConnection")
+    new() = new GraphQLClientConnection(new HttpClient(), true)
+
+    member internal __.Client = client
     
-    member internal __.Disposed = disposed
-
     interface IDisposable with
-        member __.Dispose() =
-            if not disposed then
-                disposed <- true
-                client.Dispose()
+        member __.Dispose() = if ownsClient then client.Dispose()

--- a/src/FSharp.Data.GraphQL.Client/GraphQLClientConnection.fs
+++ b/src/FSharp.Data.GraphQL.Client/GraphQLClientConnection.fs
@@ -8,16 +8,16 @@ open System.Net.Http
 
 /// The connection component for GraphQL client operations.
 [<AllowNullLiteral>]
-type GraphQLClientConnection(client : HttpClient, ownsClient : bool) =
-    /// Creates a new instance of GraphQLClientConnection, using a provided HttpClient to be wrapped inside.
-    /// The provided HttpClient is not owned by the connection, so it must be disposed when it is not necessary anymore.
-    new(client) = new GraphQLClientConnection(client, false)
+type GraphQLClientConnection(invoker : HttpMessageInvoker, ownsInvoker : bool) =
+    /// Creates a new instance of GraphQLClientConnection, using a provided System.Net.Http.HttpMessageInvoker to be wrapped inside.
+    /// The provided System.Net.Http.HttpMessageInvoker is not owned by the connection, so it must be disposed when it is not necessary anymore.
+    new(invoker) = new GraphQLClientConnection(invoker, false)
 
-    /// Creates a new instance of GraphQLClientConnection, using a fresh new instance of HttpClient internally.
+    /// Creates a new instance of GraphQLClientConnection, using a fresh new instance of System.Net.Http.HttpClient as an System.Net.Http.HttpMessageInvoker.
     /// This instance is owned by the GraphQLClientConnection, being disposed when the connection itself is disposed.
     new() = new GraphQLClientConnection(new HttpClient(), true)
 
-    member internal __.Client = client
+    member internal __.Invoker = invoker
     
     interface IDisposable with
-        member __.Dispose() = if ownsClient then client.Dispose()
+        member __.Dispose() = if ownsInvoker then invoker.Dispose()

--- a/src/FSharp.Data.GraphQL.Client/GraphQLProviderRuntimeContext.fs
+++ b/src/FSharp.Data.GraphQL.Client/GraphQLProviderRuntimeContext.fs
@@ -15,8 +15,8 @@ type GraphQLProviderRuntimeContext =
       /// Gets the URL of the server that this context refers to.
     { ServerUrl : string
       /// Gets the HTTP headers used for calls to the server that this context refers to.
-      HttpHeaders : seq<string * string> }
-    /// Gets the connection component used to make calls to the server.
-    member __.Connection = new GraphQLClientConnection()
+      HttpHeaders : seq<string * string> 
+      /// Gets the connection component used to make calls to the server.
+      Connection : GraphQLClientConnection }
     interface IDisposable with
         member x.Dispose() = (x.Connection :> IDisposable).Dispose()

--- a/tests/FSharp.Data.GraphQL.IntegrationTests/SwapiLocalProviderTests.fs
+++ b/tests/FSharp.Data.GraphQL.IntegrationTests/SwapiLocalProviderTests.fs
@@ -3,12 +3,16 @@
 open Xunit
 open Helpers
 open FSharp.Data.GraphQL
+open System.Net.Http
 
 // Local provider should be able to be created from local introspection json file.
 type Provider = GraphQLProvider<"introspection.json">
 
+// We are going to re-use the same HttpClient through all requests.
+let connection = new GraphQLClientConnection(new HttpClient())
+
 // As we are not using a connection to a server to get the introspection, we need a runtime context.
-let getContext() = Provider.GetContext(serverUrl = "http://localhost:8084")
+let getContext() = Provider.GetContext(serverUrl = "http://localhost:8084", connectionFactory = fun () -> connection)
 
 type Episode = Provider.Types.Episode
 

--- a/tests/FSharp.Data.GraphQL.IntegrationTests/paket.references
+++ b/tests/FSharp.Data.GraphQL.IntegrationTests/paket.references
@@ -3,3 +3,6 @@ Microsoft.NET.Test.Sdk
 xunit
 xunit.runner.visualstudio
 FSharp.Core
+
+group NetCoreAndStandard
+System.Net.Http


### PR DESCRIPTION
With this Pull Request, I am proposing a simple working solution for the anti-pattern of creating a new `HttpClient` instance for each `GraphQLClientConnection` usage by the Provider.

First, `GetContext` method of the provider now allows the user to pass an instance of `unit -> GraphQLClientConnection` factory, so the user can control its connection lifecycle the way he wants to.

I think the best approach would be remove the `GraphQLClientConnection` wrapper around the `HttpClient`, but the `HttpClient` has some serious reference issues with Mono, and just trying to make it exposed in design time gives a lot of errors that I could not solve, so I kept it wrapped inside the client connection, using it only internally.

I was able to make a new overload of the `GraphQLClientConnection` constructor so it can receive a new instance of the `HttpClient`, and also allowing the user to decide if the wrapper should owns the connection (disposing it when it is disposed) or not.

I avoided creating a Singleton to cache the `HttpClient` because of [potential issues with DNS changes](https://stackoverflow.com/a/48778707). I think it is best for the client user himself to manage these situations.

UPDATE: the `GraphQLClientConnection` now uses `HttpMessageInvoker` instead of `HttpClient`.