### PR TITLE
samples/star-wars-api/HttpHandlers.fs: copy stream asynchronously 

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,7 @@
 {
   "sdk": {
-    "version" : "2.1.401"
+    "version" : "2.1.401",
+    "rollForward": "latestFeature"
   },
   "projects": [ "src", "tests" ]
 }

--- a/samples/star-wars-api/HttpHandlers.fs
+++ b/samples/star-wars-api/HttpHandlers.fs
@@ -60,7 +60,7 @@ module HttpHandlers =
         
         let readStream (s : Stream) =
             use ms = new MemoryStream(4096)
-            s.CopyTo(ms)
+            s.CopyToAsync(ms) |> Async.AwaitTask |> ignore
             ms.ToArray()
         
         let data = Encoding.UTF8.GetString(readStream ctx.Request.Body) |> deserialize


### PR DESCRIPTION
Removes a synchronous memory copy in the star-wars-api sample. This changes also prepares the sample to be built against dotnetcore 3.1 sdk, and beyond, in the future.

* 8b899c7 addresses the [asp dotnetcore 3.x change which disables synchronous io in all servers](https://docs.microsoft.com/en-us/dotnet/core/compatibility/2.2-3.1#http-synchronous-io-disabled-in-all-servers).

* 82e962b allows builds to `latestFeature` rollFoward in the dotnetcore 2.1.x sdk series. Rather than pinning, specifically, to dotnetcore 2.1.401 sdk.

---

**Note:** the star-wars-api sample *does* successfully build against dotnetcore 3.1 after this patch is applied. To do so one must further loosen the sdk pinning restriction in `global.json`.