### PR TITLE
Reduce constructors to one: Use optional arguments (wrapped in Option).

### DIFF
--- a/src/FSharp.Data.GraphQL.Client.DesignTime/DesignTimeCache.fs
+++ b/src/FSharp.Data.GraphQL.Client.DesignTime/DesignTimeCache.fs
@@ -15,7 +15,8 @@ type internal ProviderKey =
       CustomHttpHeadersLocation : StringLocation
       UploadInputTypeName : string option
       ResolutionFolder : string
-      ClientQueryValidation: bool }
+      ClientQueryValidation: bool
+      ExplicitOptionalParameters: bool }
 
 module internal ProviderDesignTimeCache =
     let private expiration = CacheExpirationPolicy.SlidingExpiration(TimeSpan.FromSeconds 30.0)

--- a/src/FSharp.Data.GraphQL.Client.DesignTime/ProvidedTypesHelper.fs
+++ b/src/FSharp.Data.GraphQL.Client.DesignTime/ProvidedTypesHelper.fs
@@ -138,7 +138,7 @@ module internal Failures =
 module internal ProvidedRecord =
     let ctor = typeof<RecordBase>.GetConstructors().[0]
 
-    let makeProvidedType(tdef : ProvidedRecordTypeDefinition, properties : RecordPropertyMetadata list) =
+    let makeProvidedType(tdef : ProvidedRecordTypeDefinition, properties : RecordPropertyMetadata list, explicitOptionalParameters: bool) =
         let name = tdef.Name
         tdef.AddMembersDelayed(fun _ -> 
             properties |> List.map (fun metadata ->
@@ -162,13 +162,22 @@ module internal ProvidedRecord =
                 //
                 // I.e. to not send a value the optional parameter can either be set implicitly (by not providing an
                 // argument) or explicitly (`?parameterName = Some None` or `parameterName = None`).
-                // To set a value it has to be wrapped in an option: `parameterName = Some argumentValue`.
+                // To set a value it has to be wrapped in an option: `parameterName = Some argumentValue`
+                // (or `?parameterName = Some (Some argumentValue)`).
+                //
+                // To keep backwards compatibility this constructor is only created if a flag is turned on. Otherwise
+                // we keep the previous behavior: We build a constructor overload for each optional property.
+                // Since RecordBase needs to know each property information in its own constructor,
+                // we also need to know each property that was not filled in the currently used overload. So we make
+                // combinations of all possible overloads, and for each one we map the user's provided values and
+                // fill the others with a null value. This way we can construct the RecordBase type providing all
+                // needed properties.
                 let properties = propertiesGetter()
                 let optionalProperties, requiredProperties = 
                     properties 
                     |> List.map (fun (name, alias, t) -> Option.defaultValue name alias, t) 
                     |> List.partition (fun (_, t) -> isOption t)
-                let constructor =
+                if explicitOptionalParameters then
                     let constructorProperties = requiredProperties @ optionalProperties
                     let propertyNames = constructorProperties |> List.map (fst >> (fun x -> x.FirstCharUpper()))
                     let constructorPropertyTypes = constructorProperties |> List.map snd
@@ -189,8 +198,34 @@ module internal ProvidedRecord =
                     let constructorParams = 
                         constructorProperties
                         |> List.map (fun (name, t) -> ProvidedParameter(name, t, ?optionalValue = if isOption t then Some null else None))
-                    ProvidedConstructor(constructorParams, invoker)
-                [constructor])
+                    [ProvidedConstructor(constructorParams, invoker)]
+                else
+                    List.combinations optionalProperties
+                    |> List.map (fun (optionalProperties, nullValuedProperties) ->
+                        let constructorProperties = requiredProperties @ optionalProperties
+                        let propertyNames = (constructorProperties @ nullValuedProperties) |> List.map (fst >> (fun x -> x.FirstCharUpper()))
+                        let constructorPropertyTypes = constructorProperties |> List.map snd
+                        let nullValuedPropertyTypes = nullValuedProperties |> List.map snd
+                        let invoker (args : Expr list) =
+                            let properties =
+                                let baseConstructorArgs =
+                                    let coercedArgs = 
+                                        (constructorPropertyTypes, args)
+                                        ||> List.map2 (fun t arg ->
+                                            let arg = Expr.Coerce(arg, typeof<obj>)
+                                            if isOption t then <@@ makeSome %%arg @@> else <@@ %%arg @@>)
+                                    let nullValuedArgs = nullValuedPropertyTypes |> List.map (fun _ -> <@@ null @@>)
+                                    (propertyNames, (coercedArgs @ nullValuedArgs))
+                                    ||> List.map2 (fun name value -> <@@ { RecordProperty.Name = name; Value = %%value } @@>)
+                                Expr.NewArray(typeof<RecordProperty>, baseConstructorArgs)
+                            Expr.NewObject(ctor, [Expr.Value(name); properties])
+                        let constructorParams = 
+                            constructorProperties
+                            |> List.map (fun (name, t) ->
+                                match t with
+                                | Option t -> ProvidedParameter(name, t)
+                                | _ -> ProvidedParameter(name, t))
+                        ProvidedConstructor(constructorParams, invoker)))
         match tdef.BaseType with
         | :? ProvidedRecordTypeDefinition as bdef ->
             bdef.AddMembersDelayed(fun _ ->
@@ -418,7 +453,7 @@ type internal ProvidedOperationMetadata =
       TypeWrapper : ProvidedTypeDefinition }
 
 module internal Provider =
-    let getOperationMetadata (schemaTypes : Map<TypeName, IntrospectionType>, uploadInputTypeName : string option, enumProvidedTypes : Map<TypeName, ProvidedTypeDefinition>, operationAstFields, operationTypeRef) =
+    let getOperationMetadata (schemaTypes : Map<TypeName, IntrospectionType>, uploadInputTypeName : string option, enumProvidedTypes : Map<TypeName, ProvidedTypeDefinition>, operationAstFields, operationTypeRef, explicitOptionalParameters: bool) =
         let generateWrapper name = 
             let rec resolveWrapperName actual =
                 if schemaTypes.ContainsKey(actual)
@@ -493,7 +528,7 @@ module internal Provider =
                         let tdef = ProvidedRecord.preBuildProvidedType(metadata, None)
                         providedTypes.Add((path, tref.Name.Value), tdef)
                         includeType path tdef
-                        ProvidedRecord.makeProvidedType(tdef, baseProperties)
+                        ProvidedRecord.makeProvidedType(tdef, baseProperties, explicitOptionalParameters)
                     let createFragmentType (typeName, properties) =
                         let itype =
                             if schemaTypes.ContainsKey(typeName)
@@ -503,7 +538,7 @@ module internal Provider =
                         let tdef = ProvidedRecord.preBuildProvidedType(metadata, Some (upcast baseType))
                         providedTypes.Add((path, typeName), tdef)
                         includeType path tdef
-                        ProvidedRecord.makeProvidedType(tdef, properties) |> ignore
+                        ProvidedRecord.makeProvidedType(tdef, properties, explicitOptionalParameters) |> ignore
                     fragmentProperties |> List.iter createFragmentType
                     Types.makeOption baseType
             | _ -> failwith "Could not find a schema type based on a type reference. The reference has an invalid or unsupported combination of Name, Kind and OfType fields."
@@ -512,7 +547,7 @@ module internal Provider =
           UploadInputTypeName = uploadInputTypeName
           TypeWrapper = rootWrapper }
 
-    let getSchemaProvidedTypes(schema : IntrospectionSchema, uploadInputTypeName : string option) =
+    let getSchemaProvidedTypes(schema : IntrospectionSchema, uploadInputTypeName : string option, explicitOptionalParameters: bool) =
         let providedTypes = ref Map.empty<TypeName, ProvidedTypeDefinition>
         let schemaTypes = Types.getSchemaTypes schema
         let getSchemaType (tref : IntrospectionTypeRef) =
@@ -588,7 +623,7 @@ module internal Provider =
                         |> Option.defaultValue [||]
                         |> Array.map resolveFieldMetadata
                         |> List.ofArray
-                    upcast ProvidedRecord.makeProvidedType(tdef, properties)
+                    upcast ProvidedRecord.makeProvidedType(tdef, properties, explicitOptionalParameters)
                 | TypeKind.INPUT_OBJECT ->
                     let tdef = ProvidedRecord.preBuildProvidedType(metadata, None)
                     providedTypes := (!providedTypes).Add(itype.Name, tdef)
@@ -597,7 +632,7 @@ module internal Provider =
                         |> Option.defaultValue [||]
                         |> Array.map resolveInputFieldMetadata
                         |> List.ofArray
-                    upcast ProvidedRecord.makeProvidedType(tdef, properties)
+                    upcast ProvidedRecord.makeProvidedType(tdef, properties, explicitOptionalParameters)
                 | TypeKind.INTERFACE | TypeKind.UNION ->
                     let bdef = ProvidedInterface.makeProvidedType(metadata)
                     providedTypes := (!providedTypes).Add(itype.Name, bdef)
@@ -636,9 +671,11 @@ module internal Provider =
               ProvidedStaticParameter("httpHeaders", typeof<string>, parameterDefaultValue = "")  
               ProvidedStaticParameter("resolutionFolder", typeof<string>, parameterDefaultValue = resolutionFolder)
               ProvidedStaticParameter("uploadInputTypeName", typeof<string>, parameterDefaultValue = "")
-              ProvidedStaticParameter("clientQueryValidation", typeof<bool>, parameterDefaultValue = true) ]
+              ProvidedStaticParameter("clientQueryValidation", typeof<bool>, parameterDefaultValue = true)
+              ProvidedStaticParameter("explicitOptionalParameters", typeof<bool>, parameterDefaultValue = false) ]
         generator.DefineStaticParameters(staticParams, fun tname args ->
             let clientQueryValidation : bool = downcast args.[4]
+            let explicitOptionalParameters : bool = downcast args.[5]
             let introspectionLocation = IntrospectionLocation.Create(downcast args.[0], downcast args.[2])
             let httpHeadersLocation = StringLocation.Create(downcast args.[1], resolutionFolder)
             let uploadInputTypeName = 
@@ -660,7 +697,7 @@ module internal Provider =
                             | IntrospectionFile path ->
                                 System.IO.File.ReadAllText path
                         let schema = Serialization.deserializeSchema schemaJson
-                        let schemaProvidedTypes = getSchemaProvidedTypes(schema, uploadInputTypeName)
+                        let schemaProvidedTypes = getSchemaProvidedTypes(schema, uploadInputTypeName, explicitOptionalParameters)
                         let typeWrapper = ProvidedTypeDefinition("Types", None, isSealed = true)
                         typeWrapper.AddMembers(schemaProvidedTypes |> Seq.map (fun kvp -> kvp.Value) |> List.ofSeq)
                         let operationWrapper = ProvidedTypeDefinition("Operations", None, isSealed = true)
@@ -773,7 +810,7 @@ module internal Provider =
                                     | Some name, _ -> name.FirstCharUpper()
                                     | None, Some name -> name.FirstCharUpper()
                                     | None, None -> "Operation" + actualQuery.MD5Hash()
-                                let metadata = getOperationMetadata(schemaTypes, uploadInputTypeName, enumProvidedTypes, operationAstFields, operationTypeRef)
+                                let metadata = getOperationMetadata(schemaTypes, uploadInputTypeName, enumProvidedTypes, operationAstFields, operationTypeRef, explicitOptionalParameters)
                                 let operationTypeName : TypeName =
                                     match operationTypeRef.Name with
                                     | Some name -> name
@@ -871,7 +908,8 @@ module internal Provider =
                   CustomHttpHeadersLocation = httpHeadersLocation
                   UploadInputTypeName = uploadInputTypeName
                   ResolutionFolder = resolutionFolder
-                  ClientQueryValidation = clientQueryValidation }
+                  ClientQueryValidation = clientQueryValidation
+                  ExplicitOptionalParameters = explicitOptionalParameters }
             ProviderDesignTimeCache.getOrAdd providerKey maker.Force)
             #else
             maker.Force())

--- a/tests/FSharp.Data.GraphQL.IntegrationTests/FSharp.Data.GraphQL.IntegrationTests.fsproj
+++ b/tests/FSharp.Data.GraphQL.IntegrationTests/FSharp.Data.GraphQL.IntegrationTests.fsproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <Compile Include="Helpers.fs" />
     <Compile Include="LocalProviderTests.fs" />
+    <Compile Include="LocalProviderWithOptionalParametersOnlyTests.fs" />
     <Compile Include="SwapiLocalProviderTests.fs" />
     <Compile Include="SwapiRemoteProviderTests.fs" />
   </ItemGroup>

--- a/tests/FSharp.Data.GraphQL.IntegrationTests/LocalProviderTests.fs
+++ b/tests/FSharp.Data.GraphQL.IntegrationTests/LocalProviderTests.fs
@@ -1,4 +1,4 @@
-﻿module FSharp.Data.GraphQL.IntegrationTests.LocalProviderTests
+module FSharp.Data.GraphQL.IntegrationTests.LocalProviderTests
 
 open Xunit
 open Helpers
@@ -7,7 +7,7 @@ open FSharp.Data.GraphQL
 let [<Literal>] ServerUrl = "http://localhost:8085"
 let [<Literal>] EmptyGuidAsString = "00000000-0000-0000-0000-000000000000"
 
-type Provider = GraphQLProvider<ServerUrl, uploadInputTypeName = "Upload">
+type Provider = GraphQLProvider<ServerUrl, uploadInputTypeName = "Upload", explicitOptionalParameters = false>
 
 let context = Provider.GetContext(ServerUrl)
 

--- a/tests/FSharp.Data.GraphQL.IntegrationTests/LocalProviderTests.fs
+++ b/tests/FSharp.Data.GraphQL.IntegrationTests/LocalProviderTests.fs
@@ -1,4 +1,4 @@
-module FSharp.Data.GraphQL.IntegrationTests.LocalProviderTests
+﻿module FSharp.Data.GraphQL.IntegrationTests.LocalProviderTests
 
 open Xunit
 open Helpers
@@ -73,7 +73,7 @@ let ``Should be able to execute a query without sending input field asynchronous
     |> SimpleOperation.validateResult None
 
 [<Fact>]
-let ``Should be able to execute a query using context, without sending input field, asynchornously``() =
+let ``Should be able to execute a query using context, without sending input field, asynchronously``() =
     SimpleOperation.operation.AsyncRun(context)
     |> Async.RunSynchronously
     |> SimpleOperation.validateResult None
@@ -91,7 +91,7 @@ let ``Should be able to execute a query using context, sending an empty input fi
     |> SimpleOperation.validateResult (Some input)
 
 [<Fact>]
-let ``Should be able to execute a query without sending an empty input field asynchornously``() =
+let ``Should be able to execute a query without sending an empty input field asynchronously``() =
     let input = Input()
     SimpleOperation.operation.AsyncRun(input)
     |> Async.RunSynchronously
@@ -119,7 +119,7 @@ let ``Should be able to execute a query using context, sending an an input field
     |> SimpleOperation.validateResult (Some input)
 
 [<Fact>]
-let ``Should be able to execute a query without sending an an input field with single field asynchornously``() =
+let ``Should be able to execute a query without sending an an input field with single field asynchronously``() =
     let single = InputField("A", 2, System.Uri("http://localhost:1234"),  EmptyGuidAsString)
     let input = Input(single)
     SimpleOperation.operation.AsyncRun(input)
@@ -149,7 +149,7 @@ let ``Should be able to execute a query using context, sending an an input field
     |> SimpleOperation.validateResult (Some input)
 
 [<Fact>]
-let ``Should be able to execute a query without sending an an input field with list field asynchornously``() =
+let ``Should be able to execute a query without sending an an input field with list field asynchronously``() =
     let list = [|InputField("A", 2, System.Uri("http://localhost:4321"),  EmptyGuidAsString)|]
     let input = Input(list)
     SimpleOperation.operation.AsyncRun(input)
@@ -181,7 +181,7 @@ let ``Should be able to execute a query using context, sending an an input field
     |> SimpleOperation.validateResult (Some input)
 
 [<Fact>]
-let ``Should be able to execute a query without sending an an input field with single and list fields asynchornously``() =
+let ``Should be able to execute a query without sending an an input field with single and list fields asynchronously``() =
     let single = InputField("A", 2, System.Uri("http://localhost:1234"), EmptyGuidAsString)
     let list = [|InputField("A", 2, System.Uri("http://localhost:4321"), EmptyGuidAsString)|]
     let input = Input(single, list)

--- a/tests/FSharp.Data.GraphQL.IntegrationTests/LocalProviderWithOptionalParametersOnlyTests.fs
+++ b/tests/FSharp.Data.GraphQL.IntegrationTests/LocalProviderWithOptionalParametersOnlyTests.fs
@@ -1,0 +1,492 @@
+﻿module FSharp.Data.GraphQL.IntegrationTests.LocalProviderWithOptionalParametersOnlyTests
+
+open Xunit
+open Helpers
+open FSharp.Data.GraphQL
+
+let [<Literal>] ServerUrl = "http://localhost:8085"
+let [<Literal>] EmptyGuidAsString = "00000000-0000-0000-0000-000000000000"
+
+type Provider = GraphQLProvider<ServerUrl, uploadInputTypeName = "Upload", explicitOptionalParameters = true>
+
+let context = Provider.GetContext(ServerUrl)
+
+type Input = Provider.Types.Input
+type InputField = Provider.Types.InputField
+
+module SimpleOperation =
+    let operation = 
+        Provider.Operation<"""query Q($input: Input) {
+            echo(input: $input) {
+              single {
+                ...Field
+              }
+              list {
+                ...Field
+              }
+            }
+          }
+
+          fragment Field on OutputField {
+            string
+            stringOption
+            int
+            intOption
+            uri
+            deprecated
+            guid
+          }""">()
+
+    type Operation = Provider.Operations.Q
+
+    let validateResult (input : Input option) (result : Operation.OperationResult) =
+        result.CustomData.ContainsKey("requestType") |> equals true
+        result.CustomData.["requestType"] |> equals (box "Classic")
+        result.Data.IsSome |> equals true
+        input |> Option.iter (fun input ->
+            result.Data.Value.Echo.IsSome |> equals true
+            input.List |> Option.iter (fun list ->
+                result.Data.Value.Echo.Value.List.IsSome |> equals true
+                let input = list |> Array.map (fun x -> x.Int, x.IntOption, x.String, x.StringOption, x.Uri, x.Guid.ToString())
+                let output = result.Data.Value.Echo.Value.List.Value |> Array.map (fun x -> x.Int, x.IntOption, x.String, x.StringOption, x.Uri, x.Guid)
+                input |> equals output)
+            input.Single |> Option.iter (fun single ->
+                result.Data.Value.Echo.Value.Single.IsSome |> equals true
+                let input = single.Int, single.IntOption, single.String, single.StringOption, single.Uri, single.Guid.ToString()
+                let output = result.Data.Value.Echo.Value.Single.Value |> map (fun x -> x.Int, x.IntOption, x.String, x.StringOption, x.Uri, x.Guid)
+                input |> equals output))
+
+[<Fact>]
+let ``Should be able to execute a query without sending input field``() =
+    SimpleOperation.operation.Run()
+    |> SimpleOperation.validateResult None
+
+[<Fact>]
+let ``Should be able to execute a query using context, without sending input field``() =
+    SimpleOperation.operation.Run(context)
+    |> SimpleOperation.validateResult None
+
+[<Fact>]
+let ``Should be able to execute a query without sending input field asynchronously``() =
+    SimpleOperation.operation.AsyncRun()
+    |> Async.RunSynchronously
+    |> SimpleOperation.validateResult None
+
+[<Fact>]
+let ``Should be able to execute a query using context, without sending input field, asynchronously``() =
+    SimpleOperation.operation.AsyncRun(context)
+    |> Async.RunSynchronously
+    |> SimpleOperation.validateResult None
+
+[<Fact>]
+let ``Should be able to execute a query sending an empty input field``() =
+    let input = Input()
+    SimpleOperation.operation.Run(Some input)
+    |> SimpleOperation.validateResult (Some input)
+
+[<Fact>]
+let ``Should be able to execute a query using context, sending an empty input field``() =
+    let input = Input()
+    SimpleOperation.operation.Run(context, Some input)
+    |> SimpleOperation.validateResult (Some input)
+
+[<Fact>]
+let ``Should be able to execute a query without sending an empty input field asynchronously``() =
+    let input = Input()
+    SimpleOperation.operation.AsyncRun(Some input)
+    |> Async.RunSynchronously
+    |> SimpleOperation.validateResult (Some input)
+
+[<Fact>]
+let ``Should be able to execute a query using context, sending an empty input field, asynchronously``() =
+    let input = Input()
+    SimpleOperation.operation.AsyncRun(context, Some input)
+    |> Async.RunSynchronously
+    |> SimpleOperation.validateResult (Some input)
+
+[<Fact>]
+let ``Should be able to execute a query sending an input field with single field``() =
+    let single = InputField("A", 2, System.Uri("http://localhost:1234"), EmptyGuidAsString)
+    let input = Input(Some single)
+    SimpleOperation.operation.Run(Some input)
+    |> SimpleOperation.validateResult (Some input)
+
+[<Fact>]
+let ``Should be able to execute a query using context, sending an an input field with single field``() =
+    let single = InputField("A", 2, System.Uri("http://localhost:1234"),  EmptyGuidAsString)
+    let input = Input(Some single)
+    SimpleOperation.operation.Run(context, Some input)
+    |> SimpleOperation.validateResult (Some input)
+
+[<Fact>]
+let ``Should be able to execute a query without sending an an input field with single field asynchronously``() =
+    let single = InputField("A", 2, System.Uri("http://localhost:1234"),  EmptyGuidAsString)
+    let input = Input(Some single)
+    SimpleOperation.operation.AsyncRun(Some input)
+    |> Async.RunSynchronously
+    |> SimpleOperation.validateResult (Some input)
+
+[<Fact>]
+let ``Should be able to execute a query using context, sending an an input field with single field, asynchronously``() =
+    let single = InputField("A", 2, System.Uri("http://localhost:1234"), EmptyGuidAsString)
+    let input = Input(Some single)
+    SimpleOperation.operation.AsyncRun(context, Some input)
+    |> Async.RunSynchronously
+    |> SimpleOperation.validateResult (Some input)
+
+[<Fact>]
+let ``Should be able to execute a query sending an input field with list field``() =
+    let list = [|InputField("A", 2, System.Uri("http://localhost:4321"), EmptyGuidAsString)|]
+    let input = Input(list = Some list)
+    SimpleOperation.operation.Run(Some input)
+    |> SimpleOperation.validateResult (Some input)
+
+[<Fact>]
+let ``Should be able to execute a query using context, sending an an input field with list field``() =
+    let list = [|InputField("A", 2, System.Uri("http://localhost:4321"), EmptyGuidAsString)|]
+    let input = Input(list = Some list)
+    SimpleOperation.operation.Run(context, Some input)
+    |> SimpleOperation.validateResult (Some input)
+
+[<Fact>]
+let ``Should be able to execute a query without sending an an input field with list field asynchronously``() =
+    let list = [|InputField("A", 2, System.Uri("http://localhost:4321"),  EmptyGuidAsString)|]
+    let input = Input(list = Some list)
+    SimpleOperation.operation.AsyncRun(Some input)
+    |> Async.RunSynchronously
+    |> SimpleOperation.validateResult (Some input)
+
+[<Fact>]
+let ``Should be able to execute a query using context, sending an an input field with list field, asynchronously``() =
+    let list = [|InputField("A", 2, System.Uri("http://localhost:4321"), EmptyGuidAsString)|]
+    let input = Input(list = Some list)
+    SimpleOperation.operation.AsyncRun(context, Some input)
+    |> Async.RunSynchronously
+    |> SimpleOperation.validateResult (Some input)
+
+[<Fact>]
+let ``Should be able to execute a query sending an input field with single and list fields``() =
+    let single = InputField("A", 2, System.Uri("http://localhost:1234"), EmptyGuidAsString)
+    let list = [|InputField("A", 2, System.Uri("http://localhost:4321"), EmptyGuidAsString)|]
+    let input = Input(Some single, Some list)
+    SimpleOperation.operation.Run(Some input)
+    |> SimpleOperation.validateResult (Some input)
+
+[<Fact>]
+let ``Should be able to execute a query using context, sending an an input field with single and list fields``() =
+    let single = InputField("A", 2, System.Uri("http://localhost:1234"), EmptyGuidAsString)
+    let list = [|InputField("A", 2, System.Uri("http://localhost:4321"), EmptyGuidAsString)|]
+    let input = Input(Some single, Some list)
+    SimpleOperation.operation.Run(context, Some input)
+    |> SimpleOperation.validateResult (Some input)
+
+[<Fact>]
+let ``Should be able to execute a query without sending an an input field with single and list fields asynchronously``() =
+    let single = InputField("A", 2, System.Uri("http://localhost:1234"), EmptyGuidAsString)
+    let list = [|InputField("A", 2, System.Uri("http://localhost:4321"), EmptyGuidAsString)|]
+    let input = Input(Some single, Some list)
+    SimpleOperation.operation.AsyncRun(Some input)
+    |> Async.RunSynchronously
+    |> SimpleOperation.validateResult (Some input)
+
+[<Fact>]
+let ``Should be able to execute a query using context, sending an an input field with single and list fields, asynchronously``() =
+    let single = InputField("A", 2, System.Uri("http://localhost:1234"), EmptyGuidAsString)
+    let list = [|InputField("A", 2, System.Uri("http://localhost:4321"), EmptyGuidAsString)|]
+    let input = Input(Some single, Some list)
+    SimpleOperation.operation.AsyncRun(context, Some input)
+    |> Async.RunSynchronously
+    |> SimpleOperation.validateResult (Some input)
+
+module SingleRequiredUploadOperation =
+    let operation =
+        Provider.Operation<"""mutation SingleUpload($file: Upload!) {
+            singleUpload(file: $file) {
+              name
+              contentType
+              contentAsText
+            }
+          }""">()
+
+    type Operation = Provider.Operations.SingleUpload
+
+    let validateResult (file : File) (result : Operation.OperationResult) =
+        result.CustomData.ContainsKey("requestType") |> equals true
+        result.CustomData.["requestType"] |> equals (box "Multipart")
+        result.Data.IsSome |> equals true
+        result.Data.Value.SingleUpload.Name |> equals file.Name
+        result.Data.Value.SingleUpload.ContentAsText |> equals file.Content
+        result.Data.Value.SingleUpload.ContentType |> equals file.ContentType
+
+[<Fact>]
+let ``Should be able to execute a single required upload``() =
+    let file = { Name = "file.txt"; ContentType = "text/plain"; Content = "Sample text file contents" }
+    SingleRequiredUploadOperation.operation.Run(file.MakeUpload())
+    |> SingleRequiredUploadOperation.validateResult file
+
+[<Fact>]
+let ``Should be able to execute a single required upload asynchronously``() =
+    let file = { Name = "file.txt"; ContentType = "text/plain"; Content = "Sample text file contents" }
+    SingleRequiredUploadOperation.operation.AsyncRun(file.MakeUpload())
+    |> Async.RunSynchronously
+    |> SingleRequiredUploadOperation.validateResult file
+
+module SingleOptionalUploadOperation =
+    let operation =
+        Provider.Operation<"""mutation NullableSingleUpload($file: Upload) {
+            nullableSingleUpload(file: $file) {
+              name
+              contentType
+              contentAsText
+            }
+          }""">()
+
+    type Operation = Provider.Operations.NullableSingleUpload
+
+    let validateResult (file : File option) (result : Operation.OperationResult) =
+        result.CustomData.ContainsKey("requestType") |> equals true
+        result.CustomData.["requestType"] |> equals (box "Multipart")
+        result.Data.IsSome |> equals true
+        file |> Option.iter (fun file ->
+        result.Data.Value.NullableSingleUpload.IsSome |> equals true
+        result.Data.Value.NullableSingleUpload.Value.Name |> equals file.Name
+        result.Data.Value.NullableSingleUpload.Value.ContentAsText |> equals file.Content
+        result.Data.Value.NullableSingleUpload.Value.ContentType |> equals file.ContentType)
+
+[<Fact>]
+let ``Should be able to execute a single optional upload by passing a file``() =
+    let file = { Name = "file.txt"; ContentType = "text/plain"; Content = "Sample text file contents" }
+    SingleOptionalUploadOperation.operation.Run(file.MakeUpload() |> Some)
+    |> SingleOptionalUploadOperation.validateResult (Some file)
+
+[<Fact>]
+let ``Should be able to execute a single optional upload by passing a file, asynchronously``() =
+    let file = { Name = "file.txt"; ContentType = "text/plain"; Content = "Sample text file contents" }
+    SingleOptionalUploadOperation.operation.AsyncRun(file.MakeUpload() |> Some)
+    |> Async.RunSynchronously
+    |> SingleOptionalUploadOperation.validateResult (Some file)
+
+[<Fact>]
+let ``Should be able to execute a single optional upload by not passing a file``() =
+    SingleOptionalUploadOperation.operation.Run()
+    |> SingleOptionalUploadOperation.validateResult None
+
+[<Fact>]
+let ``Should be able to execute a single optional upload by not passing a file asynchronously``() =
+    SingleOptionalUploadOperation.operation.AsyncRun()
+    |> Async.RunSynchronously
+    |> SingleOptionalUploadOperation.validateResult None
+
+module RequiredMultipleUploadOperation =
+    let operation =
+        Provider.Operation<"""mutation MultipleUpload($files: [Upload!]!) {
+            multipleUpload(files: $files) {
+              name
+              contentType
+              contentAsText
+            }
+          }""">()
+
+    type Operation = Provider.Operations.MultipleUpload
+
+    let validateResult (files : File []) (result : Operation.OperationResult) =
+        result.CustomData.ContainsKey("requestType") |> equals true
+        result.CustomData.["requestType"] |> equals (box "Multipart")
+        result.Data.IsSome |> equals true
+        let receivedFiles =
+            result.Data.Value.MultipleUpload
+            |> Array.map (fun file -> { Name = file.Name; ContentType = file.ContentType; Content = file.ContentAsText })
+        receivedFiles |> equals files
+
+[<Fact>]
+let ``Should be able to execute a multiple required upload``() =
+    let files = 
+        [| { Name = "file1.txt"; ContentType = "text/plain"; Content = "Sample text file contents 1" }
+           { Name = "file2.txt"; ContentType = "text/plain"; Content = "Sample text file contents 2" } |]
+    RequiredMultipleUploadOperation.operation.Run(files |> Array.map (fun f -> f.MakeUpload()))
+    |> RequiredMultipleUploadOperation.validateResult files
+
+[<Fact>]
+let ``Should be able to execute a multiple required upload asynchronously``() =
+    let files = 
+        [| { Name = "file1.txt"; ContentType = "text/plain"; Content = "Sample text file contents 1" }
+           { Name = "file2.txt"; ContentType = "text/plain"; Content = "Sample text file contents 2" } |]
+    RequiredMultipleUploadOperation.operation.AsyncRun(files |> Array.map (fun f -> f.MakeUpload()))
+    |> Async.RunSynchronously
+    |> RequiredMultipleUploadOperation.validateResult files
+
+module OptionalMultipleUploadOperation =
+    let operation =
+        Provider.Operation<"""mutation NullableMultipleUpload($files: [Upload!]) {
+            nullableMultipleUpload(files: $files) {
+              name
+              contentType
+              contentAsText
+            }
+          }""">()
+
+    type Operation = Provider.Operations.NullableMultipleUpload
+
+    let validateResult (files : File [] option) (result : Operation.OperationResult) =
+        result.CustomData.ContainsKey("requestType") |> equals true
+        result.CustomData.["requestType"] |> equals (box "Multipart")
+        result.Data.IsSome |> equals true
+        let receivedFiles =
+            result.Data.Value.NullableMultipleUpload
+            |> Option.map (Array.map (fun file -> { Name = file.Name; ContentType = file.ContentType; Content = file.ContentAsText }))
+        receivedFiles |> equals files
+
+[<Fact>]
+let ``Should be able to execute a multiple upload``() =
+    let files = 
+        [| { Name = "file1.txt"; ContentType = "text/plain"; Content = "Sample text file contents 1" }
+           { Name = "file2.txt"; ContentType = "text/plain"; Content = "Sample text file contents 2" } |]
+    OptionalMultipleUploadOperation.operation.Run(files |> Array.map (fun f -> f.MakeUpload()) |> Some)
+    |> OptionalMultipleUploadOperation.validateResult (Some files)
+
+[<Fact>]
+let ``Should be able to execute a multiple upload asynchronously``() =
+    let files = 
+        [| { Name = "file1.txt"; ContentType = "text/plain"; Content = "Sample text file contents 1" }
+           { Name = "file2.txt"; ContentType = "text/plain"; Content = "Sample text file contents 2" } |]
+    OptionalMultipleUploadOperation.operation.AsyncRun(files |> Array.map (fun f -> f.MakeUpload()) |> Some)
+    |> Async.RunSynchronously
+    |> OptionalMultipleUploadOperation.validateResult (Some files)
+
+[<Fact>]
+let ``Should be able to execute a multiple upload by sending no uploads``() =
+    OptionalMultipleUploadOperation.operation.Run()
+    |> OptionalMultipleUploadOperation.validateResult None
+
+[<Fact>]
+let ``Should be able to execute a multiple upload asynchronously by sending no uploads``() =
+    OptionalMultipleUploadOperation.operation.AsyncRun()
+    |> Async.RunSynchronously
+    |> OptionalMultipleUploadOperation.validateResult None
+
+module OptionalMultipleOptionalUploadOperation =
+    let operation =
+        Provider.Operation<"""mutation NullableMultipleNullableUpload($files: [Upload]) {
+            nullableMultipleNullableUpload(files: $files) {
+              name
+              contentType
+              contentAsText
+            }
+          }""">()
+
+    type Operation = Provider.Operations.NullableMultipleNullableUpload
+
+    let validateResult (files : File option [] option) (result : Operation.OperationResult) =
+        result.CustomData.ContainsKey("requestType") |> equals true
+        result.CustomData.["requestType"] |> equals (box "Multipart")
+        result.Data.IsSome |> equals true
+        let receivedFiles =
+            result.Data.Value.NullableMultipleNullableUpload
+            |> Option.map (Array.map (Option.map (fun file -> { Name = file.Name; ContentType = file.ContentType; Content = file.ContentAsText })))
+        receivedFiles |> equals files
+
+[<Fact>]
+let ``Should be able to execute a multiple optional upload``() =
+    let files = 
+        [| Some { Name = "file1.txt"; ContentType = "text/plain"; Content = "Sample text file contents 1" }
+           Some { Name = "file2.txt"; ContentType = "text/plain"; Content = "Sample text file contents 2" } |]
+    OptionalMultipleOptionalUploadOperation.operation.Run(files |> Array.map (Option.map (fun f -> f.MakeUpload())) |> Some)
+    |> OptionalMultipleOptionalUploadOperation.validateResult (Some files)
+
+[<Fact>]
+let ``Should be able to execute a multiple optional upload asynchronously``() =
+    let files = 
+        [| Some { Name = "file1.txt"; ContentType = "text/plain"; Content = "Sample text file contents 1" }
+           Some { Name = "file2.txt"; ContentType = "text/plain"; Content = "Sample text file contents 2" } |]
+    OptionalMultipleOptionalUploadOperation.operation.AsyncRun(files |> Array.map (Option.map (fun f -> f.MakeUpload())) |> Some)
+    |> Async.RunSynchronously
+    |> OptionalMultipleOptionalUploadOperation.validateResult (Some files)
+
+[<Fact>]
+let ``Should be able to execute a multiple optional upload by sending no uploads``() =
+    OptionalMultipleOptionalUploadOperation.operation.Run()
+    |> OptionalMultipleOptionalUploadOperation.validateResult None
+
+[<Fact>]
+let ``Should be able to execute a multiple optional upload asynchronously by sending no uploads``() =
+    OptionalMultipleOptionalUploadOperation.operation.AsyncRun()
+    |> Async.RunSynchronously
+    |> OptionalMultipleOptionalUploadOperation.validateResult None
+
+[<Fact>]
+let ``Should be able to execute a multiple optional upload by sending some uploads``() =
+    let files = 
+        [| Some { Name = "file1.txt"; ContentType = "text/plain"; Content = "Sample text file contents 1" }
+           None
+           Some { Name = "file2.txt"; ContentType = "text/plain"; Content = "Sample text file contents 2" }
+           None |]
+    OptionalMultipleOptionalUploadOperation.operation.Run(files |> Array.map (Option.map (fun f -> f.MakeUpload())) |> Some)
+    |> OptionalMultipleOptionalUploadOperation.validateResult (Some files)
+
+[<Fact>]
+let ``Should be able to execute a multiple optional upload asynchronously by sending some uploads``() =
+    let files = 
+        [| Some { Name = "file1.txt"; ContentType = "text/plain"; Content = "Sample text file contents 1" }
+           None
+           Some { Name = "file2.txt"; ContentType = "text/plain"; Content = "Sample text file contents 2" }
+           None |]
+    OptionalMultipleOptionalUploadOperation.operation.AsyncRun(files |> Array.map (Option.map (fun f -> f.MakeUpload())) |> Some)
+    |> Async.RunSynchronously
+    |> OptionalMultipleOptionalUploadOperation.validateResult (Some files)
+
+module UploadRequestOperation =
+    let operation =
+        Provider.Operation<"""mutation UploadRequestOperation($request: UploadRequest!) {
+            uploadRequest(request: $request) {
+              single {
+                ...File
+              }
+              multiple {
+                ...File
+              }
+              nullableMultiple {
+                ...File
+              }
+              nullableMultipleNullable {
+                ...File
+              }
+            }
+          }
+
+          fragment File on UploadedFile {
+            name
+            contentType
+            contentAsText
+          }""">()
+
+    type Operation = Provider.Operations.UploadRequestOperation
+
+    type Request = Provider.Types.UploadRequest
+
+    let validateResult (request : FilesRequest) (result : Operation.OperationResult) =
+        result.CustomData.ContainsKey("requestType") |> equals true
+        result.CustomData.["requestType"] |> equals (box "Multipart")
+        result.Data.IsSome |> equals true
+        result.Data.Value.UploadRequest.Single.ToDictionary() |> File.FromDictionary |> equals request.Single
+        result.Data.Value.UploadRequest.Multiple |> Array.map ((fun x -> x.ToDictionary()) >> File.FromDictionary) |> equals request.Multiple
+        result.Data.Value.UploadRequest.NullableMultiple |> Option.map (Array.map ((fun x -> x.ToDictionary()) >> File.FromDictionary)) |> equals request.NullableMultiple
+        result.Data.Value.UploadRequest.NullableMultipleNullable |> Option.map (Array.map (Option.map ((fun x -> x.ToDictionary()) >> File.FromDictionary))) |> equals request.NullableMultipleNullable
+
+[<Fact>]
+let ``Should be able to upload files inside another input type``() =
+    let request =
+        { Single = { Name = "single.txt"; ContentType = "text/plain"; Content = "Single file content" }
+          Multiple = 
+            [| { Name = "multiple1.txt"; ContentType = "text/plain"; Content = "Multiple files first file content" }
+               { Name = "multiple2.txt"; ContentType = "text/plain"; Content = "Multiple files second file content" } |]
+          NullableMultiple = Some [| { Name = "multiple3.txt"; ContentType = "text/plain"; Content = "Multiple files third file content" } |]
+          NullableMultipleNullable = 
+            Some [| Some { Name = "multiple4.txt"; ContentType = "text/plain"; Content = "Multiple files fourth file content" }; None |] }
+    let input = 
+        let makeUpload (x : File) = x.MakeUpload()
+        UploadRequestOperation.Request(single = makeUpload request.Single, 
+                                       multiple = Array.map makeUpload request.Multiple,
+                                       nullableMultiple = Some (Array.map makeUpload request.NullableMultiple.Value),
+                                       nullableMultipleNullable = Some (Array.map (Option.map makeUpload) request.NullableMultipleNullable.Value))
+    UploadRequestOperation.operation.Run(input)
+    |> UploadRequestOperation.validateResult request


### PR DESCRIPTION
🚨 This PR comes with a breaking change! 🚨

This PR changes the constructor count for record types generated by the type provider to one. This single constructor honors the GraphQL schema by requiring the required parameters and uses optional parameters to set the rest.

As outlined in both the source code before this change, but also in #250, this change requires something one could classify as a workaround of a shortcoming of the F# type provider SDK. This PR resolves the issue in a way that the single constructor can be used in the following manner:
1. Not providing a default parameter results in that parameter _not_ getting included in the request.
2. If `None` or `?parameterName = Some None` is used it has the same effect as bullet point one.
3. To specify an actual value to be sent with the request one has to provide `Some value` (or, if named arguments are required/preferred: `parameterName = Some value`).

Additionally there's something to be aware of:
At least Visual Studio 2019 (with the .NET 5 SDK used) is showing the optional parameters as `[?parameterName TypeName]` in IntelliSense. This is misleading, as shown when hovering over the named argument: The parameter is actually of type `TypeName option` and since it's optional that leads to `(TypeName option) option`. The compiler does not have this issue and adds the necessary diagnostics in case the passed value is of the wrong type.
This explains the above required usage notes.

The _required_ parameters behave as expected: There's no IDE issue, nor any specific usage notes to be aware of.

Resolves #250.

---

I'm opening this PR as a draft for discussion and am asking for feedback. I'm happy to discuss anything raised! Here's what I believe needs to be discussed and ultimately decided on:
1. Is this breaking change of removing all constructor overloads and only keeping this single constructor OK?
	I'm aware that there's a suggestion in #250 to make this constructor optional, by keeping the existing ones (and/or making this behavior configurable for each type provider instance). However, I believe that this solution is the "sweet spot":
	Users don't have to search through all permutations of possible constructor parameter combinations (>500 in my case) in their IDE's IntelliSense/auto-completion, they immediately are greeted by the single contract that is defined by the GraphQL schema.
2. The "usage notes" above seem complex, but I believe it's perfectly fine as is. Users are just able to be explicit about "include this value" and "don't send this value at all". Do we agree? 😄
3. Tests... I'll defer updating the existing ones until we decide on whether to replace all constructors with this single one or add it etc.