### PR TITLE
add Path to ResolveFieldContext

### DIFF
--- a/src/FSharp.Data.GraphQL.Server/Execution.fs
+++ b/src/FSharp.Data.GraphQL.Server/Execution.fs
@@ -234,7 +234,7 @@ let private createFieldContext objdef argDefs ctx (info: ExecutionInfo) (path : 
       Schema = ctx.Schema
       Args = args
       Variables = ctx.Variables
-      Path = path }
+      Path = path |> List.rev }
 
 let private resolveField (execute: ExecuteField) (ctx: ResolveFieldContext) (parentValue: obj) =
     if ctx.ExecutionInfo.IsNullable
@@ -574,7 +574,7 @@ let private executeQueryOrMutation (resultSet: (string * ExecutionInfo) []) (ctx
               Schema = ctx.Schema
               Args = args
               Variables = ctx.Variables
-              Path = path }
+              Path = path |> List.rev }
         let execute = ctx.FieldExecuteMap.GetExecute(ctx.ExecutionPlan.RootDef.Name, info.Definition.Name)
         asyncVal {
             let! result =
@@ -608,7 +608,7 @@ let private executeSubscription (resultSet: (string * ExecutionInfo) []) (ctx: E
           Schema = ctx.Schema
           Args = args
           Variables = ctx.Variables
-          Path = fieldPath }
+          Path = fieldPath |> List.rev }
     let onValue v = asyncVal {
             match! executeResolvers fieldCtx fieldPath value (toOption v |> AsyncVal.wrap) with
             | Ok (data, None, []) -> return NameValueLookup.ofList["data", box <| NameValueLookup.ofList [nameOrAlias, data.Value]] :> Output

--- a/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
+++ b/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
@@ -878,7 +878,9 @@ and ResolveFieldContext =
       /// parametrized inputs.
       Args : Map<string, obj>
       /// Variables provided by the operation caller.
-      Variables : Map<string, obj> }
+      Variables : Map<string, obj>
+      /// Field path
+      Path : obj list }
 
     /// Remembers an exception, so it can be included in the final response.
     member x.AddError(error : exn) = x.Context.Errors.Add error


### PR DESCRIPTION
This PR adds `Path` to `ResolveFieldContext` to make it easier to make pretty errors when adding custom error handling (with custom exceptions) via middleware and `ctx.AddError`