### PR TITLE
fix-nullable-enum-input

### DIFF
--- a/src/FSharp.Data.GraphQL.Server/Values.fs
+++ b/src/FSharp.Data.GraphQL.Server/Values.fs
@@ -147,6 +147,7 @@ let rec private coerceVariableValue isNullable typedef (vardef: VarDef) (input: 
         match input with
         | :? string as s ->
             ReflectionHelper.parseUnion enumdef.Type s
+        | null -> null
         | o when Enum.IsDefined(enumdef.Type, o) -> o
         | _ ->
             raise (GraphQLException <| errMsg + (sprintf "Cannot coerce value of type '%O' to type Enum '%s'" (input.GetType()) enumdef.Name))


### PR DESCRIPTION
`Enum.IsDefined` will raise an exception if given a `null` value, currently making nullable enum inputs unusable.