### PR TITLE
Fix recursive definition of InputObject fields

### DIFF
--- a/samples/star-wars-api/HttpHandlers.fs
+++ b/samples/star-wars-api/HttpHandlers.fs
@@ -1,4 +1,4 @@
-﻿namespace FSharp.Data.GraphQL.Samples.StarWarsApi
+namespace FSharp.Data.GraphQL.Samples.StarWarsApi
 
 open System.IO
 open System.Text
@@ -13,6 +13,7 @@ open FSharp.Data.GraphQL.Types
 type HttpHandler = HttpFunc -> HttpContext -> HttpFuncResult
 
 module HttpHandlers =
+
     let private converters : JsonConverter[] = [| OptionConverter () |]
     let private jsonSettings = jsonSerializerSettings converters
 

--- a/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
+++ b/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
@@ -1528,15 +1528,15 @@ and InputObjectDefinition<'Val> =
       Name : string
       /// Optional input object description.
       Description : string option
-      /// Function used to define field inputs. It must be lazy
-      /// in order to support self-referencing types.
-      FieldsFn : unit -> InputFieldDef [] }
+      /// Lazy resolver for the input object fields. It must be lazy in
+      /// order to allow self-recursive type references.
+      FieldsFn : Lazy<InputFieldDef[]> }
     interface InputDef
 
     interface InputObjectDef with
         member x.Name = x.Name
         member x.Description = x.Description
-        member x.Fields = x.FieldsFn()
+        member x.Fields = x.FieldsFn.Force()
 
     interface TypeDef<'Val>
     interface InputDef<'Val>
@@ -2775,31 +2775,31 @@ module SchemaDefinitions =
 
         /// <summary>
         /// Creates a custom GraphQL input object type. Unlike GraphQL objects, input objects are valid input types,
-        /// that can be included in GraphQL query strings. Input object maps to a .NET type, which can be strandard
+        /// that can be included in GraphQL query strings. Input object maps to a .NET type, which can be standard
         /// .NET class or struct, or a F# record.
         /// </summary>
         /// <param name="name">Type name. Must be unique in scope of the current schema.</param>
         /// <param name="fieldsFn">
-        /// Function which generates a list of input fields defined by the current input object. Usefull, when object defines recursive dependencies.
+        /// Function which generates a list of input fields defined by the current input object. Useful, when object defines recursive dependencies.
         /// </param>
-        /// <param name="description">Optional input object description. Usefull for generating documentation.</param>
+        /// <param name="description">Optional input object description. Useful for generating documentation.</param>
         static member InputObject(name : string, fieldsFn : unit -> InputFieldDef list, ?description : string) : InputObjectDefinition<'Out> =
             { Name = name
-              FieldsFn = fun () -> fieldsFn() |> List.toArray
+              FieldsFn = lazy (fieldsFn () |> List.toArray)
               Description = description }
 
         /// <summary>
         /// Creates a custom GraphQL input object type. Unlike GraphQL objects, input objects are valid input types,
-        /// that can be included in GraphQL query strings. Input object maps to a .NET type, which can be strandard
+        /// that can be included in GraphQL query strings. Input object maps to a .NET type, which can be standard
         /// .NET class or struct, or a F# record.
         /// </summary>
         /// <param name="name">Type name. Must be unique in scope of the current schema.</param>
         /// <param name="fields">List of input fields defined by the current input object. </param>
-        /// <param name="description">Optional input object description. Usefull for generating documentation.</param>
+        /// <param name="description">Optional input object description. Useful for generating documentation.</param>   
         static member InputObject(name : string, fields : InputFieldDef list, ?description : string) : InputObjectDefinition<'Out> =
             { Name = name
               Description = description
-              FieldsFn = fun () -> fields |> List.toArray }
+              FieldsFn = lazy (fields |> List.toArray) }
 
         /// <summary>
         /// Creates the top level subscription object that holds all of the possible subscriptions as fields.

--- a/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
+++ b/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
@@ -1530,13 +1530,13 @@ and InputObjectDefinition<'Val> =
       Description : string option
       /// Lazy resolver for the input object fields. It must be lazy in
       /// order to allow self-recursive type references.
-      FieldsFn : Lazy<InputFieldDef[]> }
+      Fields : Lazy<InputFieldDef[]> }
     interface InputDef
 
     interface InputObjectDef with
         member x.Name = x.Name
         member x.Description = x.Description
-        member x.Fields = x.FieldsFn.Force()
+        member x.Fields = x.Fields.Force()
 
     interface TypeDef<'Val>
     interface InputDef<'Val>
@@ -2785,7 +2785,7 @@ module SchemaDefinitions =
         /// <param name="description">Optional input object description. Useful for generating documentation.</param>
         static member InputObject(name : string, fieldsFn : unit -> InputFieldDef list, ?description : string) : InputObjectDefinition<'Out> =
             { Name = name
-              FieldsFn = lazy (fieldsFn () |> List.toArray)
+              Fields = lazy (fieldsFn () |> List.toArray)
               Description = description }
 
         /// <summary>
@@ -2795,11 +2795,11 @@ module SchemaDefinitions =
         /// </summary>
         /// <param name="name">Type name. Must be unique in scope of the current schema.</param>
         /// <param name="fields">List of input fields defined by the current input object. </param>
-        /// <param name="description">Optional input object description. Useful for generating documentation.</param>   
+        /// <param name="description">Optional input object description. Useful for generating documentation.</param>
         static member InputObject(name : string, fields : InputFieldDef list, ?description : string) : InputObjectDefinition<'Out> =
             { Name = name
               Description = description
-              FieldsFn = lazy (fields |> List.toArray) }
+              Fields = lazy (fields |> List.toArray) }
 
         /// <summary>
         /// Creates the top level subscription object that holds all of the possible subscriptions as fields.

--- a/tests/FSharp.Data.GraphQL.Tests/VariablesTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/VariablesTests.fs
@@ -45,6 +45,7 @@ type TestNestedInput = {
     na: TestInput option
     nb: string
 }
+
 let TestNestedInputObject =
   Define.InputObject<TestNestedInput>(
     name = "TestNestedInputObject",
@@ -57,6 +58,8 @@ type TestRecusiveInput = {
     ra: TestRecusiveInput option
     rb: string
 }
+
+#nowarn "40"
 let rec TestRecursiveInputObject =
   Define.InputObject<TestRecusiveInput>(
     name = "TestRecusiveInput",
@@ -92,7 +95,7 @@ let TestType =
         Define.Field("fieldWithNonNullableStringInput", String, "", [ Define.Input("input", String) ], stringifyInput)
         Define.Field("fieldWithDefaultArgumentValue", String, "", [ Define.Input("input", Nullable String, Some "hello world") ], stringifyInput)
         Define.Field("fieldWithNestedInputObject", String, "", [ Define.Input("input", TestNestedInputObject, { na = None; nb = "hello world"}) ], stringifyInput)
-        Define.Field("fieldWithRecursiveInputObject", String, "", [ Define.Input("input", TestRecursiveInputObject, { ra = None; rb = "hello world"}) ], stringifyInput) 
+        Define.Field("fieldWithRecursiveInputObject", String, "", [ Define.Input("input", TestRecursiveInputObject, { ra = None; rb = "hello world"}) ], stringifyInput)
         Define.Field("fieldWithEnumInput", String, "", [ Define.Input("input", EnumTestType) ], stringifyInput)
         Define.Field("fieldWithNullableEnumInput", String, "", [ Define.Input("input", Nullable EnumTestType) ], stringifyInput)
         Define.Field("list", String, "", [ Define.Input("input", Nullable(ListOf (Nullable String))) ], stringifyInput)

--- a/tests/FSharp.Data.GraphQL.Tests/VariablesTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/VariablesTests.fs
@@ -140,7 +140,7 @@ let ``Execute handles objects and nullability using inline structs and doesn't u
     | _ -> fail "Expected Direct GQResponse"
 
 [<Fact>]
-let ``Execute handles objects and nullability using inline structs and proprely coerces complex scalar types`` () =
+let ``Execute handles objects and nullability using inline structs and properly coerces complex scalar types`` () =
     let ast = parse """{ fieldWithObjectInput(input: {c: "foo", d: "SerializedValue"}) }"""
     let actual = sync <| Executor(schema).AsyncExecute(ast)
     let expected = NameValueLookup.ofList [ "fieldWithObjectInput", upcast """{"a":null,"b":null,"c":"foo","d":"DeserializedValue","e":null}"""]
@@ -346,10 +346,10 @@ let ``Execute handles non-nullable scalars and passes along null for non-nullabl
     | _ -> fail "Expected Direct GQResponse"
 
 [<Fact>]
-let ``Execute handles nested input objects and nullability using inline structs and proprely coerces complex scalar types`` () =
+let ``Execute handles nested input objects and nullability using inline structs and properly coerces complex scalar types`` () =
     let ast = parse """{ fieldWithNestedInputObject(input: {na:{c:"c"},nb:"b"})}"""
     let actual = sync <| Executor(schema).AsyncExecute(ast)
-    let expected = NameValueLookup.ofList [ "fieldWithNestedInputObject", upcast """{"na":{"a":null,"b":null,"c":"c","d":null},"nb":"b"}""" ]
+    let expected = NameValueLookup.ofList [ "fieldWithNestedInputObject", upcast """{"na":{"a":null,"b":null,"c":"c","d":null,"e":null},"nb":"b"}""" ]
     match actual with
     | Direct(data, errors) ->
       empty errors
@@ -357,7 +357,7 @@ let ``Execute handles nested input objects and nullability using inline structs 
     | _ -> fail "Expected Direct GQResponse"
 
 [<Fact>]
-let ``Execute handles recursive input objects and nullability using inline structs and proprely coerces complex scalar types`` () =
+let ``Execute handles recursive input objects and nullability using inline structs and properly coerces complex scalar types`` () =
     let ast = parse """{ fieldWithRecursiveInputObject(input: {ra:{rb:"bb"},rb:"b"})}"""
     let actual = sync <| Executor(schema).AsyncExecute(ast)
     let expected = NameValueLookup.ofList [ "fieldWithRecursiveInputObject", upcast """{"ra":{"ra":null,"rb":"bb"},"rb":"b"}""" ]

--- a/tests/FSharp.Data.GraphQL.Tests/VariablesTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/VariablesTests.fs
@@ -53,6 +53,19 @@ let TestNestedInputObject =
         Define.Input("nb", String)
     ])
 
+type TestRecusiveInput = {
+    ra: TestRecusiveInput option
+    rb: string
+}
+let rec TestRecursiveInputObject =
+  Define.InputObject<TestRecusiveInput>(
+    name = "TestRecusiveInput",
+    fieldsFn =
+        fun () -> [
+            Define.Input("ra", Nullable TestRecursiveInputObject)
+            Define.Input("rb", String)]
+    )
+
 let stringifyArg name (ctx: ResolveFieldContext) () =
     let arg = ctx.TryArg name |> Option.toObj
     toJson arg
@@ -79,6 +92,7 @@ let TestType =
         Define.Field("fieldWithNonNullableStringInput", String, "", [ Define.Input("input", String) ], stringifyInput)
         Define.Field("fieldWithDefaultArgumentValue", String, "", [ Define.Input("input", Nullable String, Some "hello world") ], stringifyInput)
         Define.Field("fieldWithNestedInputObject", String, "", [ Define.Input("input", TestNestedInputObject, { na = None; nb = "hello world"}) ], stringifyInput)
+        Define.Field("fieldWithRecursiveInputObject", String, "", [ Define.Input("input", TestRecursiveInputObject, { ra = None; rb = "hello world"}) ], stringifyInput) 
         Define.Field("fieldWithEnumInput", String, "", [ Define.Input("input", EnumTestType) ], stringifyInput)
         Define.Field("fieldWithNullableEnumInput", String, "", [ Define.Input("input", Nullable EnumTestType) ], stringifyInput)
         Define.Field("list", String, "", [ Define.Input("input", Nullable(ListOf (Nullable String))) ], stringifyInput)
@@ -322,6 +336,28 @@ let ``Execute handles non-nullable scalars and passes along null for non-nullabl
     let ast = parse """{ fieldWithNonNullableStringInput }"""
     let actual = sync <| Executor(schema).AsyncExecute(ast)
     let expected = NameValueLookup.ofList [ "fieldWithNonNullableStringInput", upcast "null" ]
+    match actual with
+    | Direct(data, errors) ->
+      empty errors
+      data.["data"] |> equals (upcast expected)
+    | _ -> fail "Expected Direct GQResponse"
+
+[<Fact>]
+let ``Execute handles nested input objects and nullability using inline structs and proprely coerces complex scalar types`` () =
+    let ast = parse """{ fieldWithNestedInputObject(input: {na:{c:"c"},nb:"b"})}"""
+    let actual = sync <| Executor(schema).AsyncExecute(ast)
+    let expected = NameValueLookup.ofList [ "fieldWithNestedInputObject", upcast """{"na":{"a":null,"b":null,"c":"c","d":null},"nb":"b"}""" ]
+    match actual with
+    | Direct(data, errors) ->
+      empty errors
+      data.["data"] |> equals (upcast expected)
+    | _ -> fail "Expected Direct GQResponse"
+
+[<Fact>]
+let ``Execute handles recursive input objects and nullability using inline structs and proprely coerces complex scalar types`` () =
+    let ast = parse """{ fieldWithRecursiveInputObject(input: {ra:{rb:"bb"},rb:"b"})}"""
+    let actual = sync <| Executor(schema).AsyncExecute(ast)
+    let expected = NameValueLookup.ofList [ "fieldWithRecursiveInputObject", upcast """{"ra":{"ra":null,"rb":"bb"},"rb":"b"}""" ]
     match actual with
     | Direct(data, errors) ->
       empty errors


### PR DESCRIPTION
Using recursive definition of fields in the `InputObject` resulted in a null reference exception. The exception was triggered because the `ExecuteInput` on a field definition was not initialized. It was caused by not caching the field definitions correctly, resulting in uninitialized field definitions to be used.

In this PR, the function that is used to retrieve the definitions is wrapped inside a lazy, which makes sure that always the same field definitions are returned.

ps. it was required to update the dependencies because `MSBuild.StructuredLogger` was causing an issue when restoring the client project.