### PR TITLE
fix(376): rec func "go" was misintrepreting param "ms" (middlewares)

### DIFF
--- a/src/FSharp.Data.GraphQL.Server/Executor.fs
+++ b/src/FSharp.Data.GraphQL.Server/Executor.fs
@@ -74,9 +74,10 @@ type Executor<'Root>(schema: ISchema<'Root>, middlewares : IExecutorMiddleware s
                            (initialCtx : 'ctx)
                            (onComplete : 'ctx -> 'res)
                            : 'res =
-        let rec go ctx = function
+        let rec go ctx (middlewares: IExecutorMiddleware list) =
+            match middlewares with
             | [] -> onComplete ctx
-            | m : IExecutorMiddleware :: ms ->
+            | m :: ms ->
                 match (phaseSel m) with
                 | Some f -> f ctx (fun ctx' -> go ctx' ms)
                 | None -> go ctx ms

--- a/src/FSharp.Data.GraphQL.Server/Executor.fs
+++ b/src/FSharp.Data.GraphQL.Server/Executor.fs
@@ -76,7 +76,7 @@ type Executor<'Root>(schema: ISchema<'Root>, middlewares : IExecutorMiddleware s
                            : 'res =
         let rec go ctx = function
             | [] -> onComplete ctx
-            | m :: ms ->
+            | m : IExecutorMiddleware :: ms ->
                 match (phaseSel m) with
                 | Some f -> f ctx (fun ctx' -> go ctx' ms)
                 | None -> go ctx ms


### PR DESCRIPTION
 Issue found while trying to run the Star Wars API sample.
 Somehow, in the pattern matching branch "None -> go ctx ms", "go" was being
reevaluated to be a function whose ctx parameter is of type unit and the
'res type of the containing function runMiddlewares was being
reevaluated to be IExecutorMiddleware (something like a parameterless ExecutorMiddleware
fetcher), although ctx was clearly initially set to be a
SchemaCompileContext and 'res a "unit" because of the type of the
"compileSchema" function passed as parameter in a later function call.
 However, ms is always supposed to be a list of middlewares yet it was
being defined as a generic list, more specifically: the type definition was implicit. By adding
an explicit hint to the compiler in the code that "m" is an IExecutorMiddleware (and therefore "ms" a list thereof),
the compiler no longer had a misinterpretation issue with the recursive "go" function
and the Star Wars API sample now starts successfully.