### PR TITLE
bugfix/issue-353-invalid-introspection

### DIFF
--- a/src/FSharp.Data.GraphQL.Client/Serialization.fs
+++ b/src/FSharp.Data.GraphQL.Client/Serialization.fs
@@ -62,7 +62,6 @@ module Serialization =
             | (Option et | et) ->
                 try Enum.Parse(et, s) |> downcastType t
                 with _ -> failwithf "Error parsing JSON value: %O is a Enum type, but parsing of value \"%s\" failed." t s
-            | _ -> failwithf "Error parsing JSON value: %O is not a enum type." t
         | _ -> failwithf "Error parsing JSON value: %O is not a string type." t
 
     let private downcastBoolean (t : Type) b =

--- a/src/FSharp.Data.GraphQL.Server/Schema.fs
+++ b/src/FSharp.Data.GraphQL.Server/Schema.fs
@@ -13,6 +13,7 @@ open System.Collections.Generic
 open System.Reactive.Linq
 open System.Reactive.Subjects
 open System.Text.Json
+open System.Text.Json.Serialization
 
 type private Channel = ISubject<obj>
 
@@ -135,7 +136,7 @@ type SchemaConfig =
                 | ex -> [{ new IGQLError with member _.Message = ex.Message }]
           SubscriptionProvider = SchemaConfig.DefaultSubscriptionProvider()
           LiveFieldSubscriptionProvider = SchemaConfig.DefaultLiveFieldSubscriptionProvider()
-          JsonOptions = JsonSerializerOptions.Default }
+          JsonOptions = JsonFSharpOptions.Default().ToJsonSerializerOptions() }
     /// <summary>
     /// Default SchemaConfig with buffered stream support.
     /// This config modifies the stream directive to have two optional arguments: 'interval' and 'preferredBatchSize'.

--- a/src/FSharp.Data.GraphQL.Shared/Helpers/Reflection.fs
+++ b/src/FSharp.Data.GraphQL.Shared/Helpers/Reflection.fs
@@ -11,7 +11,7 @@ open System.Collections.Immutable
 /// General helper functions and types.
 module Helpers =
 
-    /// Casts a System.Object to an option to a System.Object option.
+    /// Casts a System.Object to a System.Object option.
     let optionCast (value: obj) =
         if isNull value then None
         else


### PR DESCRIPTION
This is a fix for https://github.com/fsprojects/FSharp.Data.GraphQL/issues/353.

Currently the implementation does not generate a valid introspection query result when default values are specified. 

According to [the spec](https://spec.graphql.org/June2018/#sec-The-__InputValue-Type):

> `defaultValue` may return a String encoding (using the GraphQL language) of the default value used by this input value in the condition a value is not provided at runtime. If this input value has no default value, returns `null`.

Before the fix:

```diff
-                  "defaultValue": "this is the default value"
```

After the fix:

```diff
+                  "defaultValue": "\"this is the default value\""
```

This PR adds a `Serialize` method to all input type definitions (`InputDef`) that takes a .NET instance for that type definition and generates a GraphQL value:

```
        /// Serializes the associated .NET CLR type into a GQL value
        abstract member Serialize : obj -> Ast.Value
```

This is used to generate a valid string during introspection.

By default, a serializer is automatically generated using reflection, so there is no need for the user to do anything. However, there is the opportunity to pass a custom serializer for full control over the output. 