### PR TITLE
Specify signature file for JsonValue

### DIFF
--- a/src/FSharp.Data.GraphQL.Client/FSharp.Data.GraphQL.Client.fsproj
+++ b/src/FSharp.Data.GraphQL.Client/FSharp.Data.GraphQL.Client.fsproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <Compile Include="MimeTypes.fs" />
     <Compile Include="TextConversions.fs" />
+    <Compile Include="JsonValue.fsi" />
     <Compile Include="JsonValue.fs" />
     <Compile Include="Extensions.fs" />
     <Compile Include="Schema.fs" />

--- a/src/FSharp.Data.GraphQL.Client/FSharp.Data.GraphQL.Client.fsproj
+++ b/src/FSharp.Data.GraphQL.Client/FSharp.Data.GraphQL.Client.fsproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <Compile Include="MimeTypes.fs" />
     <Compile Include="TextConversions.fs" />
+    <Compile Include="JsonValue.fsi" />
     <Compile Include="JsonValue.fs" />
     <Compile Include="Extensions.fs" />
     <Compile Include="Schema.fs" />

--- a/src/FSharp.Data.GraphQL.Client/JsonValue.fs
+++ b/src/FSharp.Data.GraphQL.Client/JsonValue.fs
@@ -40,9 +40,6 @@ type JsonValue =
   | Boolean of bool
   | Null
 
-  ///  <exclude />
-  [<EditorBrowsableAttribute(EditorBrowsableState.Never)>]
-  [<CompilerMessageAttribute("This property is intended for use in generated code only.", 10001, IsHidden=true, IsError=false)>]
   member x._Print =
     let str = x.ToString()
     if str.Length > 512 then str.Substring(0, 509) + "..."

--- a/src/FSharp.Data.GraphQL.Client/JsonValue.fsi
+++ b/src/FSharp.Data.GraphQL.Client/JsonValue.fsi
@@ -1,0 +1,51 @@
+namespace FSharp.Data.GraphQL.Client
+open System.ComponentModel
+    /// Specifies the formatting behaviour of JSON values.
+    [<RequireQualifiedAccess; Struct>]
+    type JsonSaveOptions =
+        | None = 0
+        | DisableFormatting = 1
+
+    /// Represents a JSON value. Large numbers that do not fit in the
+    /// Decimal type are represented using the Float case, while
+    /// smaller numbers are represented as decimals to avoid precision loss.
+    [<RequireQualifiedAccess; StructuredFormatDisplay ("{_Print}")>]
+    type JsonValue =
+        | Integer of int
+        | String of string
+        | Float of float
+        | Record of properties: (string * JsonValue)[]
+        | Array of elements: JsonValue[]
+        | Boolean of bool
+        | Null
+
+        static member
+          internal JsonStringEncodeTo: w: System.IO.TextWriter ->
+                                         value: string -> unit
+
+        /// Parses the specified JSON string.
+        static member Parse: text: string -> JsonValue
+
+        /// Attempts to parse the specified JSON string.
+        static member TryParse: text: string -> JsonValue option
+
+        override ToString: unit -> string
+
+        member ToString: saveOptions: JsonSaveOptions -> string
+
+        /// Serializes the JsonValue to the specified System.IO.TextWriter.
+        member
+          WriteTo: w: System.IO.TextWriter * saveOptions: JsonSaveOptions ->
+                     unit
+
+        ///  <exclude />
+        [<EditorBrowsableAttribute(EditorBrowsableState.Never);
+          CompilerMessageAttribute("This property is intended for use in generated code only.", 10001, IsHidden=true, IsError=false)>]
+        member _Print: string
+
+    type private JsonParser =
+
+        new: jsonText: string -> JsonParser
+
+        member Parse: unit -> JsonValue
+

--- a/src/FSharp.Data.GraphQL.Client/JsonValue.fsi
+++ b/src/FSharp.Data.GraphQL.Client/JsonValue.fsi
@@ -43,9 +43,3 @@ open System.ComponentModel
           CompilerMessageAttribute("This property is intended for use in generated code only.", 10001, IsHidden=true, IsError=false)>]
         member _Print: string
 
-    type private JsonParser =
-
-        new: jsonText: string -> JsonParser
-
-        member Parse: unit -> JsonValue
-


### PR DESCRIPTION
In order to make it easier to swap out the implementation, let us make it more obvious what is used from JsonValue
See #328