### PR TITLE
Added `FieldDef<'Val, 'Res>` to support resolver changing middlewares

### DIFF
--- a/samples/chat-app/server/Schema.fs
+++ b/samples/chat-app/server/Schema.fs
@@ -147,7 +147,7 @@ module Schema =
         )
 
     let MemberType =
-        Define.Object<Member> (
+        Define.ObjectRec<Member> (
             name = nameof Member,
             description = "An organization member",
             isTypeOf = (fun o -> o :? Member),
@@ -166,7 +166,7 @@ module Schema =
         )
 
     let MeAsAMemberType =
-        Define.Object<MeAsAMember> (
+        Define.ObjectRec<MeAsAMember> (
             name = nameof MeAsAMember,
             description = "An organization member",
             isTypeOf = (fun o -> o :? MeAsAMember),
@@ -193,7 +193,7 @@ module Schema =
         )
 
     let ChatMemberType =
-        Define.Object<ChatMember> (
+        Define.ObjectRec<ChatMember> (
             name = nameof ChatMember,
             description = "A chat member is an organization member participating in a chat room",
             isTypeOf = (fun o -> o :? ChatMember),
@@ -213,7 +213,7 @@ module Schema =
         )
 
     let MeAsAChatMemberType =
-        Define.Object<MeAsAChatMember> (
+        Define.ObjectRec<MeAsAChatMember> (
             name = nameof MeAsAChatMember,
             description = "A chat member is an organization member participating in a chat room",
             isTypeOf = (fun o -> o :? MeAsAChatMember),
@@ -241,7 +241,7 @@ module Schema =
         )
 
     let ChatRoomStatsType =
-        Define.Object<ChatRoom> (
+        Define.ObjectRec<ChatRoom> (
             name = nameof ChatRoom,
             description = "A chat room as viewed from the outside",
             isTypeOf = (fun o -> o :? ChatRoom),
@@ -261,7 +261,7 @@ module Schema =
         )
 
     let ChatRoomDetailsType =
-        Define.Object<ChatRoomForMember> (
+        Define.ObjectRec<ChatRoomForMember> (
             name = nameof ChatRoomForMember,
             description = "A chat room as viewed by a chat room member",
             isTypeOf = (fun o -> o :? ChatRoomForMember),
@@ -292,7 +292,7 @@ module Schema =
         )
 
     let OrganizationStatsType =
-        Define.Object<Organization> (
+        Define.ObjectRec<Organization> (
             name = nameof Organization,
             description = "An organization as seen from the outside",
             isTypeOf = (fun o -> o :? Organization),
@@ -313,7 +313,7 @@ module Schema =
         )
 
     let OrganizationDetailsType =
-        Define.Object<OrganizationForMember> (
+        Define.ObjectRec<OrganizationForMember> (
             name = nameof OrganizationForMember,
             description = "An organization as seen by one of the organization's members",
             isTypeOf = (fun o -> o :? OrganizationForMember),
@@ -350,7 +350,7 @@ module Schema =
         )
 
     let aChatRoomMessageTypeWith description name =
-        Define.Object<ChatRoomMessage> (
+        Define.ObjectRec<ChatRoomMessage> (
             name = name,
             description = description,
             isTypeOf = (fun o -> o :? ChatRoomMessage),
@@ -395,8 +395,7 @@ module Schema =
             name = name,
             description = description,
             isTypeOf = (fun o -> o :? unit),
-            fieldsFn =
-                fun () -> [
+            fields = [
                     Define.Field ("doNotUse", BooleanType, "this is just to satify the expected structure of this type", (fun _ _ -> true))
                 ]
         )
@@ -406,8 +405,7 @@ module Schema =
             name = name,
             description = description,
             isTypeOf = (fun o -> o :? MessageId),
-            fieldsFn =
-                (fun () -> [
+            fields = [
                     Define.Field (
                         "messageId",
                         GuidType,
@@ -416,7 +414,7 @@ module Schema =
                             match x with
                             | MessageId theId -> theId
                     )
-                ])
+                ]
         )
 
     let aChatRoomEventForMemberIdAndName description name =
@@ -424,8 +422,7 @@ module Schema =
             name = name,
             description = description,
             isTypeOf = (fun o -> o :? (MemberId * string)),
-            fieldsFn =
-                (fun () -> [
+            fields = [
                     Define.Field (
                         "memberId",
                         GuidType,
@@ -435,7 +432,7 @@ module Schema =
                             | MemberId theId -> theId
                     )
                     Define.Field ("memberName", StringType, "this is the member's name", (fun _ (_ : MemberId, name : string) -> name))
-                ])
+                ]
         )
 
     let newMessageDef =
@@ -478,7 +475,7 @@ module Schema =
         )
 
     let ChatRoomEventType =
-        Define.Object<ChatRoomEvent> (
+        Define.ObjectRec<ChatRoomEvent> (
             name = nameof ChatRoomEvent,
             description = "Something that happened in the chat room, like a new message sent",
             isTypeOf = (fun o -> o :? ChatRoomEvent),
@@ -831,8 +828,7 @@ module Schema =
             name = "Root",
             description = "contains general request information",
             isTypeOf = (fun o -> o :? Root),
-            fieldsFn =
-                fun () -> [
+            fields = [
                     Define.Field ("requestId", StringType, "The request's unique ID.", (fun _ (r : Root) -> r.RequestId))
                 ]
         )

--- a/samples/star-wars-api/Schema.fs
+++ b/samples/star-wars-api/Schema.fs
@@ -155,7 +155,7 @@ module Schema =
         )
 
     and HumanType : ObjectDef<Human> =
-        Define.Object<Human> (
+        Define.ObjectRec<Human> (
             name = "Human",
             description = "A humanoid creature in the Star Wars universe.",
             isTypeOf = (fun o -> o :? Human),
@@ -210,7 +210,7 @@ module Schema =
         )
 
     and DroidType =
-        Define.Object<Droid> (
+        Define.ObjectRec<Droid> (
             name = "Droid",
             description = "A mechanical creature in the Star Wars universe.",
             isTypeOf = (fun o -> o :? Droid),
@@ -235,15 +235,15 @@ module Schema =
             name = "Planet",
             description = "A planet in the Star Wars universe.",
             isTypeOf = (fun o -> o :? Planet),
-            fieldsFn =
-                fun () ->
-                    [ Define.Field ("id", StringType, "The id of the planet", (fun _ p -> p.Id))
-                      Define.Field ("name", Nullable StringType, "The name of the planet.", (fun _ p -> p.Name))
-                      Define.Field ("isMoon", Nullable BooleanType, "Is that a moon?", (fun _ p -> p.IsMoon)) ]
+            fields = [
+                Define.Field ("id", StringType, "The id of the planet", (fun _ p -> p.Id))
+                Define.Field ("name", Nullable StringType, "The name of the planet.", (fun _ p -> p.Name))
+                Define.Field ("isMoon", Nullable BooleanType, "Is that a moon?", (fun _ p -> p.IsMoon))
+            ]
         )
 
     and RootType =
-        Define.Object<Root> (
+        Define.ObjectRec<Root> (
             name = "Root",
             description = "The Root type to be passed to all our resolvers.",
             isTypeOf = (fun o -> o :? Root),
@@ -281,7 +281,7 @@ module Schema =
         Define.Object<Root> (
             name = "Mutation",
             fields =
-                [ Define.Field (
+                [ Define.Field(
                       "setMoon",
                       Nullable PlanetType,
                       "Defines if a planet is actually a moon or not.",
@@ -293,7 +293,8 @@ module Schema =
                               schemaConfig.SubscriptionProvider.Publish<Planet> "watchMoon" x
                               schemaConfig.LiveFieldSubscriptionProvider.Publish<Planet> "Planet" "isMoon" x
                               x)
-                  ) ]
+                  )
+                ]
         )
 
     let schema : ISchema<Root> = upcast Schema (Query, Mutation, Subscription, schemaConfig)

--- a/src/FSharp.Data.GraphQL.Server.Middleware/MiddlewareDefinitions.fs
+++ b/src/FSharp.Data.GraphQL.Server.Middleware/MiddlewareDefinitions.fs
@@ -4,9 +4,9 @@ open FsToolkit.ErrorHandling
 open FSharp.Data.GraphQL
 open FSharp.Data.GraphQL.Types.Patterns
 open FSharp.Data.GraphQL.Types
-open FSharp.Data.GraphQL.Execution
 
 type internal QueryWeightMiddleware(threshold : float, reportToMetadata : bool) =
+
     let middleware (threshold : float) (ctx : ExecutionContext) (next : ExecutionContext -> AsyncVal<GQLExecutionResult>) =
         let measureThreshold (threshold : float) (fields : ExecutionInfo list) =
             let getWeight f =
@@ -56,6 +56,7 @@ type internal QueryWeightMiddleware(threshold : float, reportToMetadata : bool) 
         if pass
         then next ctx
         else error ctx
+
     interface IExecutorMiddleware with
         member _.CompileSchema = None
         member _.PostCompileSchema = None
@@ -63,6 +64,7 @@ type internal QueryWeightMiddleware(threshold : float, reportToMetadata : bool) 
         member _.ExecuteOperationAsync = Some (middleware threshold)
 
 type internal ObjectListFilterMiddleware<'ObjectType, 'ListType>(reportToMetadata : bool) =
+
     let compileMiddleware (ctx : SchemaCompileContext) (next : SchemaCompileContext -> unit) =
         let modifyFields (object : ObjectDef<'ObjectType>) (fields : FieldDef<'ObjectType> seq) =
             let args = [ Define.Input("filter", Nullable ObjectListFilter) ]
@@ -78,6 +80,7 @@ type internal ObjectListFilterMiddleware<'ObjectType, 'ListType>(reportToMetadat
             |> Seq.cast<NamedDef>
         ctx.TypeMap.AddTypes(modifiedTypes, overwrite = true)
         next ctx
+
     let reportMiddleware (ctx : ExecutionContext) (next : ExecutionContext -> AsyncVal<GQLExecutionResult>) =
         let rec collectArgs (acc : (string * ObjectListFilter) list) (fields : ExecutionInfo list) =
             let fieldArgs field =
@@ -133,6 +136,7 @@ type internal ObjectListFilterMiddleware<'ObjectType, 'ListType>(reportToMetadat
 type IdentityNameResolver = ObjectDef -> string
 
 type internal LiveQueryMiddleware(identityNameResolver : IdentityNameResolver) =
+
     let middleware (ctx : SchemaCompileContext) (next : SchemaCompileContext -> unit) =
         let identity (identityName : string) (x : obj) =
             x.GetType().GetProperty(identityName).GetValue(x)
@@ -165,6 +169,7 @@ type internal LiveQueryMiddleware(identityNameResolver : IdentityNameResolver) =
             if not (ctx.Schema.LiveFieldSubscriptionProvider.IsRegistered x.TypeName x.FieldName)
             then ctx.Schema.LiveFieldSubscriptionProvider.Register x)
         next ctx
+
     interface IExecutorMiddleware with
         member _.CompileSchema = Some middleware
         member _.PostCompileSchema = None

--- a/src/FSharp.Data.GraphQL.Server.Middleware/TypeSystemExtensions.fs
+++ b/src/FSharp.Data.GraphQL.Server.Middleware/TypeSystemExtensions.fs
@@ -5,22 +5,24 @@ open FSharp.Data.GraphQL.Types
 /// Contains extensions for the type system.
 [<AutoOpen>]
 module TypeSystemExtensions =
+
     type FieldDef<'Val> with
+
         /// <summary>
         /// Creates a new field definition based on the existing one, containing
         /// the existing metadata information, plus a new entry used to calculate the query
         /// weight by the QueryWeightMiddleware.
         /// </summary>
         /// <param name="weight">A float value representing the weight that this field have on the query.</param>
-        member this.WithQueryWeight(weight : float) : FieldDef<'Val> =
-            this.WithMetadata(this.Metadata.Add("queryWeight", weight))
+        member this.WithQueryWeight (weight : float) : FieldDef<'Val> = this.WithMetadata (this.Metadata.Add ("queryWeight", weight))
 
     type ResolveFieldContext with
+
         /// <summary>
         /// Gets the filter argument value for this field, if it does have one.
         /// Field argument is defined by the ObjectFilterMiddleware.
         /// </summary>
         member this.Filter =
-            match this.Args.TryFind("filter") with
+            match this.Args.TryFind ("filter") with
             | Some (:? ObjectListFilter as f) -> Some f
             | _ -> None

--- a/src/FSharp.Data.GraphQL.Server.Relay/FSharp.Data.GraphQL.Server.Relay.fsproj
+++ b/src/FSharp.Data.GraphQL.Server.Relay/FSharp.Data.GraphQL.Server.Relay.fsproj
@@ -20,5 +20,4 @@
     <PackageReference Condition="$(IsNuGet) != ''" Include="FSharp.Data.GraphQL.Shared" VersionOverride="$(Version)" />
     <PackageReference Condition="$(IsNuGet) != ''" Include="FSharp.Data.GraphQL.Server" VersionOverride="$(Version)" />
   </ItemGroup>
-
 </Project>

--- a/src/FSharp.Data.GraphQL.Shared/Introspection.fs
+++ b/src/FSharp.Data.GraphQL.Shared/Introspection.fs
@@ -10,26 +10,30 @@ open FSharp.Data.GraphQL.Extensions
 open System.Reflection
 
 let internal getFieldValue name o =
-    let property = o.GetType().GetTypeInfo().GetDeclaredProperty(name, ignoreCase=true)
-    if isNull property then null else property.GetValue(o, null)
+    let property = o.GetType().GetTypeInfo().GetDeclaredProperty (name, ignoreCase = true)
+    if isNull property then
+        null
+    else
+        property.GetValue (o, null)
 
 /// GraphQL enum describing kind of the GraphQL type definition.
 /// Can be one of: SCALAR, OBJECT, INTERFACE, UNION, ENUM, LIST,
 /// NON_NULL or INPUT_OBJECT.
 let __TypeKind =
-  Define.Enum(
-    name = "__TypeKind",
-    description = "An enum describing what kind of type a given __Type is.",
-    options = [
-        Define.EnumValue("SCALAR", TypeKind.SCALAR, "Indicates this type is a scalar.")
-        Define.EnumValue("OBJECT", TypeKind.OBJECT, "Indicates this type is an object. `fields` and `interfaces` are valid fields.")
-        Define.EnumValue("INTERFACE", TypeKind.INTERFACE, "Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.")
-        Define.EnumValue("UNION", TypeKind.UNION, "Indicates this type is a union. `possibleTypes` is a valid field.")
-        Define.EnumValue("ENUM", TypeKind.ENUM, "Indicates this type is an enum. `enumValues` is a valid field.")
-        Define.EnumValue("INPUT_OBJECT", TypeKind.INPUT_OBJECT, "Indicates this type is an input object. `inputFields` is a valid field.")
-        Define.EnumValue("LIST", TypeKind.LIST, "Indicates this type is a list. `ofType` is a valid field.")
-        Define.EnumValue("NON_NULL", TypeKind.NON_NULL, "Indicates this type is a non-null. `ofType` is a valid field.")
-    ])
+    Define.Enum (
+        name = "__TypeKind",
+        description = "An enum describing what kind of type a given __Type is.",
+        options = [
+            Define.EnumValue ("SCALAR", TypeKind.SCALAR, "Indicates this type is a scalar.")
+            Define.EnumValue ("OBJECT", TypeKind.OBJECT, "Indicates this type is an object. `fields` and `interfaces` are valid fields.")
+            Define.EnumValue ("INTERFACE", TypeKind.INTERFACE, "Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.")
+            Define.EnumValue ("UNION", TypeKind.UNION, "Indicates this type is a union. `possibleTypes` is a valid field.")
+            Define.EnumValue ("ENUM", TypeKind.ENUM, "Indicates this type is an enum. `enumValues` is a valid field.")
+            Define.EnumValue ("INPUT_OBJECT", TypeKind.INPUT_OBJECT, "Indicates this type is an input object. `inputFields` is a valid field.")
+            Define.EnumValue ("LIST", TypeKind.LIST, "Indicates this type is a list. `ofType` is a valid field.")
+            Define.EnumValue ("NON_NULL", TypeKind.NON_NULL, "Indicates this type is a non-null. `ofType` is a valid field.")
+        ]
+    )
 
 /// GraphQL enum describing kind of location for a particular directive
 /// to be used in. Can be one of: QUERY, MUTATION, SUBSCRIPTION, FIELD,
@@ -39,29 +43,35 @@ let __TypeKind =
 /// INTERFACE, UNION, ENUM, ENUM_VALUE, INPUT_OBJECT or
 /// INPUT_FIELD_DEFINITION.
 let __DirectiveLocation =
-  Define.Enum(
-    name = "__DirectiveLocation",
-    description = "A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies.",
-    options = [
-        Define.EnumValue("QUERY", DirectiveLocation.QUERY, "Location adjacent to a query operation.")
-        Define.EnumValue("MUTATION", DirectiveLocation.MUTATION, "Location adjacent to a mutation operation.")
-        Define.EnumValue("SUBSCRIPTION", DirectiveLocation.SUBSCRIPTION, "Location adjacent to a subscription operation.")
-        Define.EnumValue("FIELD", DirectiveLocation.FIELD, "Location adjacent to a field.")
-        Define.EnumValue("FRAGMENT_DEFINITION", DirectiveLocation.FRAGMENT_DEFINITION, "Location adjacent to a fragment definition.")
-        Define.EnumValue("FRAGMENT_SPREAD", DirectiveLocation.FRAGMENT_SPREAD, "Location adjacent to a fragment spread.")
-        Define.EnumValue("INLINE_FRAGMENT", DirectiveLocation.INLINE_FRAGMENT, "Location adjacent to an inline fragment.")
-        Define.EnumValue("SCHEMA", DirectiveLocation.SCHEMA, "Location adjacent to a schema IDL definition.")
-        Define.EnumValue("SCALAR", DirectiveLocation.SCALAR, "Location adjacent to a scalar IDL definition.")
-        Define.EnumValue("OBJECT", DirectiveLocation.OBJECT, "Location adjacent to an object IDL definition.")
-        Define.EnumValue("FIELD_DEFINITION", DirectiveLocation.FIELD_DEFINITION, "Location adjacent to a field IDL definition.")
-        Define.EnumValue("ARGUMENT_DEFINITION", DirectiveLocation.ARGUMENT_DEFINITION, "Location adjacent to a field argument IDL definition.")
-        Define.EnumValue("INTERFACE", DirectiveLocation.INTERFACE, "Location adjacent to an interface IDL definition.")
-        Define.EnumValue("UNION", DirectiveLocation.UNION, "Location adjacent to an union IDL definition.")
-        Define.EnumValue("ENUM", DirectiveLocation.ENUM, "Location adjacent to an enum IDL definition.")
-        Define.EnumValue("ENUM_VALUE", DirectiveLocation.ENUM_VALUE, "Location adjacent to an enum value definition.")
-        Define.EnumValue("INPUT_OBJECT", DirectiveLocation.INPUT_OBJECT, "Location adjacent to an input object IDL definition.")
-        Define.EnumValue("INPUT_FIELD_DEFINITION", DirectiveLocation.INPUT_FIELD_DEFINITION, "Location adjacent to an input object field IDL definition.")
-    ])
+    Define.Enum (
+        name = "__DirectiveLocation",
+        description =
+            "A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies.",
+        options = [
+            Define.EnumValue ("QUERY", DirectiveLocation.QUERY, "Location adjacent to a query operation.")
+            Define.EnumValue ("MUTATION", DirectiveLocation.MUTATION, "Location adjacent to a mutation operation.")
+            Define.EnumValue ("SUBSCRIPTION", DirectiveLocation.SUBSCRIPTION, "Location adjacent to a subscription operation.")
+            Define.EnumValue ("FIELD", DirectiveLocation.FIELD, "Location adjacent to a field.")
+            Define.EnumValue ("FRAGMENT_DEFINITION", DirectiveLocation.FRAGMENT_DEFINITION, "Location adjacent to a fragment definition.")
+            Define.EnumValue ("FRAGMENT_SPREAD", DirectiveLocation.FRAGMENT_SPREAD, "Location adjacent to a fragment spread.")
+            Define.EnumValue ("INLINE_FRAGMENT", DirectiveLocation.INLINE_FRAGMENT, "Location adjacent to an inline fragment.")
+            Define.EnumValue ("SCHEMA", DirectiveLocation.SCHEMA, "Location adjacent to a schema IDL definition.")
+            Define.EnumValue ("SCALAR", DirectiveLocation.SCALAR, "Location adjacent to a scalar IDL definition.")
+            Define.EnumValue ("OBJECT", DirectiveLocation.OBJECT, "Location adjacent to an object IDL definition.")
+            Define.EnumValue ("FIELD_DEFINITION", DirectiveLocation.FIELD_DEFINITION, "Location adjacent to a field IDL definition.")
+            Define.EnumValue ("ARGUMENT_DEFINITION", DirectiveLocation.ARGUMENT_DEFINITION, "Location adjacent to a field argument IDL definition.")
+            Define.EnumValue ("INTERFACE", DirectiveLocation.INTERFACE, "Location adjacent to an interface IDL definition.")
+            Define.EnumValue ("UNION", DirectiveLocation.UNION, "Location adjacent to an union IDL definition.")
+            Define.EnumValue ("ENUM", DirectiveLocation.ENUM, "Location adjacent to an enum IDL definition.")
+            Define.EnumValue ("ENUM_VALUE", DirectiveLocation.ENUM_VALUE, "Location adjacent to an enum value definition.")
+            Define.EnumValue ("INPUT_OBJECT", DirectiveLocation.INPUT_OBJECT, "Location adjacent to an input object IDL definition.")
+            Define.EnumValue (
+                "INPUT_FIELD_DEFINITION",
+                DirectiveLocation.INPUT_FIELD_DEFINITION,
+                "Location adjacent to an input object field IDL definition."
+            )
+        ]
+    )
 
 let inline private findIntrospected (ctx: ResolveFieldContext) name = ctx.Schema.Introspected.Types |> Seq.find (fun x -> x.Name = name)
 
@@ -73,101 +83,138 @@ let inline private findIntrospected (ctx: ResolveFieldContext) name = ctx.Schema
 /// the fields they describe. Abstract types, Union and Interface, provide
 /// the Object types possible at runtime. List and NonNull types compose other types.
 let rec __Type =
-  Define.Object<IntrospectionTypeRef>(
-    name = "__Type",
-    description = """The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum. Depending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.""",
-    fieldsFn = fun () ->
-    [
-        Define.Field("kind", __TypeKind, fun _ t -> t.Kind)
-        Define.Field("name", Nullable StringType, resolve = fun _ t -> t.Name)
-        Define.Field("description", Nullable StringType, resolve = fun _ t -> t.Description)
-        Define.Field("fields", Nullable (ListOf __Field),
-            args = [Define.Input("includeDeprecated", BooleanType, false) ],
-            resolve = fun ctx t ->
-                match t.Name with
-                | None -> None
-                | Some name ->
-                    let found = findIntrospected ctx name
-                    match ctx.TryArg "includeDeprecated" with
-                    | Some true ->  found.Fields |> Option.map Array.toSeq
-                    | _ -> found.Fields |> Option.map (fun x -> upcast Array.filter (fun f -> not f.IsDeprecated) x))
-        Define.Field("interfaces", Nullable (ListOf __Type), resolve = fun ctx t ->
-            match t.Name with
-            | None -> None
-            | Some name ->
-                let found = findIntrospected ctx name
-                found.Interfaces |> Option.map Array.toSeq )
-        Define.Field("possibleTypes", Nullable (ListOf __Type), resolve = fun ctx t ->
-            match t.Name with
-            | None -> None
-            | Some name ->
-                let found = findIntrospected ctx name
-                found.PossibleTypes |> Option.map Array.toSeq)
-        Define.Field("enumValues", Nullable (ListOf __EnumValue),
-            args = [Define.Input("includeDeprecated", BooleanType, false) ], resolve = fun ctx t ->
-            match t.Name with
-            | None -> None
-            | Some name ->
-                let found = findIntrospected ctx name
-                match ctx.TryArg "includeDeprecated" with
-                | None | Some false -> found.EnumValues |> Option.map Array.toSeq
-                | Some true -> found.EnumValues |> Option.map (fun x -> upcast  (x |> Array.filter (fun f -> not f.IsDeprecated))))
-        Define.Field("inputFields", Nullable (ListOf __InputValue), resolve = fun ctx t ->
-            match t.Name with
-            | None -> None
-            | Some name ->
-                let found = findIntrospected ctx name
-                found.InputFields |> Option.map Array.toSeq)
-        Define.Field("ofType", Nullable __Type, resolve = fun _ t -> t.OfType)
-    ])
+    Define.ObjectRec<IntrospectionTypeRef> (
+        name = "__Type",
+        description =
+            """The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum. Depending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.""",
+        fieldsFn =
+            fun () -> [
+                Define.Field ("kind", __TypeKind, (fun _ t -> t.Kind))
+                Define.Field ("name", Nullable StringType, resolve = (fun _ t -> t.Name))
+                Define.Field ("description", Nullable StringType, resolve = (fun _ t -> t.Description))
+                Define.Field (
+                    "fields",
+                    Nullable (ListOf __Field),
+                    args = [ Define.Input ("includeDeprecated", BooleanType, false) ],
+                    resolve =
+                        fun ctx t ->
+                            match t.Name with
+                            | None -> None
+                            | Some name ->
+                                let found = findIntrospected ctx name
+                                match ctx.TryArg "includeDeprecated" with
+                                | Some true -> found.Fields |> Option.map Array.toSeq
+                                | _ ->
+                                    found.Fields
+                                    |> Option.map (fun x -> upcast Array.filter (fun f -> not f.IsDeprecated) x)
+                )
+                Define.Field (
+                    "interfaces",
+                    Nullable (ListOf __Type),
+                    resolve =
+                        fun ctx t ->
+                            match t.Name with
+                            | None -> None
+                            | Some name ->
+                                let found = findIntrospected ctx name
+                                found.Interfaces |> Option.map Array.toSeq
+                )
+                Define.Field (
+                    "possibleTypes",
+                    Nullable (ListOf __Type),
+                    resolve =
+                        fun ctx t ->
+                            match t.Name with
+                            | None -> None
+                            | Some name ->
+                                let found = findIntrospected ctx name
+                                found.PossibleTypes |> Option.map Array.toSeq
+                )
+                Define.Field (
+                    "enumValues",
+                    Nullable (ListOf __EnumValue),
+                    args = [ Define.Input ("includeDeprecated", BooleanType, false) ],
+                    resolve =
+                        fun ctx t ->
+                            match t.Name with
+                            | None -> None
+                            | Some name ->
+                                let found = findIntrospected ctx name
+                                match ctx.TryArg "includeDeprecated" with
+                                | None
+                                | Some false -> found.EnumValues |> Option.map Array.toSeq
+                                | Some true ->
+                                    found.EnumValues
+                                    |> Option.map (fun x -> upcast (x |> Array.filter (fun f -> not f.IsDeprecated)))
+                )
+                Define.Field (
+                    "inputFields",
+                    Nullable (ListOf __InputValue),
+                    resolve =
+                        fun ctx t ->
+                            match t.Name with
+                            | None -> None
+                            | Some name ->
+                                let found = findIntrospected ctx name
+                                found.InputFields |> Option.map Array.toSeq
+                )
+                Define.Field ("ofType", Nullable __Type, resolve = (fun _ t -> t.OfType))
+            ]
+    )
 
 /// Arguments provided to Fields or Directives and the input fields of an
 /// InputObject are represented as Input Values which describe their type
 /// and optionally a default value.
 and __InputValue =
-  Define.Object<IntrospectionInputVal>(
-    name = "__InputValue",
-    description = "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.",
-    fieldsFn = fun () ->
-    [
-        Define.Field("name", StringType, resolve = fun _ f -> f.Name)
-        Define.Field("description", Nullable StringType, resolve = fun _ f -> f.Description)
-        Define.Field("type", __Type, resolve = fun _ f -> f.Type)
-        Define.Field("defaultValue", Nullable StringType, fun _ f -> f.DefaultValue)
-    ])
+    Define.ObjectRec<IntrospectionInputVal> (
+        name = "__InputValue",
+        description =
+            "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.",
+        fieldsFn =
+            fun () -> [
+                Define.Field ("name", StringType, resolve = (fun _ f -> f.Name))
+                Define.Field ("description", Nullable StringType, resolve = (fun _ f -> f.Description))
+                Define.Field ("type", __Type, resolve = (fun _ f -> f.Type))
+                Define.Field ("defaultValue", Nullable StringType, (fun _ f -> f.DefaultValue))
+            ]
+    )
 
 /// Object and Interface types are described by a list of Fields, each of
 /// which has a name, potentially a list of arguments, and a return type.
 and __Field =
-  Define.Object<IntrospectionField>(
-    name = "__Field",
-    description = "Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.",
-    fieldsFn = fun () ->
-    [
-        Define.Field("name", StringType, fun _ f -> f.Name)
-        Define.Field("description", Nullable StringType, fun _ f -> f.Description)
-        Define.Field("args", ListOf __InputValue, fun _ f -> f.Args)
-        Define.Field("type", __Type, fun _ f -> f.Type)
-        Define.Field("isDeprecated", BooleanType, resolve = fun _ f -> f.IsDeprecated)
-        Define.Field("deprecationReason", Nullable StringType, fun _ f -> f.DeprecationReason)
-    ])
+    Define.ObjectRec<IntrospectionField> (
+        name = "__Field",
+        description =
+            "Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.",
+        fieldsFn =
+            fun () -> [
+                Define.Field ("name", StringType, (fun _ f -> f.Name))
+                Define.Field ("description", Nullable StringType, (fun _ f -> f.Description))
+                Define.Field ("args", ListOf __InputValue, (fun _ f -> f.Args))
+                Define.Field ("type", __Type, (fun _ f -> f.Type))
+                Define.Field ("isDeprecated", BooleanType, resolve = (fun _ f -> f.IsDeprecated))
+                Define.Field ("deprecationReason", Nullable StringType, (fun _ f -> f.DeprecationReason))
+            ]
+    )
 
 /// One possible value for a given Enum. Enum values are unique values,
 /// not a placeholder for a string or numeric value. However an Enum value
 /// is returned in a JSON response as a string.
 and __EnumValue =
-  Define.Object<IntrospectionEnumVal>(
-    name = "__EnumValue",
-    description = "One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.",
-    fieldsFn = fun () ->
-    [
-        Define.Field("name", StringType, resolve = fun _ e -> e.Name)
-        Define.Field("description", Nullable StringType, resolve = fun _ e -> e.Description)
-        Define.Field("isDeprecated", BooleanType, resolve = fun _ e -> Option.isSome e.DeprecationReason)
-        Define.Field("deprecationReason", Nullable StringType, resolve = fun _ e -> e.DeprecationReason)
-    ])
+    Define.ObjectRec<IntrospectionEnumVal> (
+        name = "__EnumValue",
+        description =
+            "One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.",
+        fieldsFn =
+            fun () -> [
+                Define.Field ("name", StringType, resolve = (fun _ e -> e.Name))
+                Define.Field ("description", Nullable StringType, resolve = (fun _ e -> e.Description))
+                Define.Field ("isDeprecated", BooleanType, resolve = (fun _ e -> Option.isSome e.DeprecationReason))
+                Define.Field ("deprecationReason", Nullable StringType, resolve = (fun _ e -> e.DeprecationReason))
+            ]
+    )
 
-and private oneOf (compared: DirectiveLocation []) (comparand: DirectiveLocation) =
+and private oneOf (compared : DirectiveLocation[]) (comparand : DirectiveLocation) =
     let c = int comparand
     compared |> Array.exists (fun cc -> c &&& (int cc) <> 0)
 
@@ -177,32 +224,88 @@ and private oneOf (compared: DirectiveLocation []) (comparand: DirectiveLocation
 /// arguments will not suffice, such as conditionally including or skipping a field.
 /// Directives provide this by describing additional information to the executor.
 and __Directive =
-  Define.Object<IntrospectionDirective>(
-    name = "__Directive",
-    description = """A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document. In some cases, you need to provide options to alter GraphQL’s execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.""",
-    fieldsFn = fun () ->
-    [
-        Define.Field("name", StringType, resolve = fun _ directive -> directive.Name)
-        Define.Field("description", Nullable StringType, resolve = fun _ directive -> directive.Description)
-        Define.Field("locations", ListOf __DirectiveLocation, resolve = fun _ directive -> directive.Locations)
-        Define.Field("args", ListOf __InputValue, resolve = fun _ directive -> directive.Args)
-        Define.Field("onOperation", BooleanType, resolve = fun _ d -> d.Locations |> Seq.exists (oneOf [| DirectiveLocation.QUERY; DirectiveLocation.MUTATION; DirectiveLocation.SUBSCRIPTION |]))
-        Define.Field("onFragment", BooleanType, resolve = fun _ d -> d.Locations |> Seq.exists (oneOf [| DirectiveLocation.FRAGMENT_SPREAD; DirectiveLocation.INLINE_FRAGMENT; DirectiveLocation.FRAGMENT_DEFINITION |]))
-        Define.Field("onField", BooleanType, resolve = fun _ d -> d.Locations |> Seq.exists (oneOf [| DirectiveLocation.FIELD |]))
-    ])
+    Define.ObjectRec<IntrospectionDirective> (
+        name = "__Directive",
+        description =
+            """A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document. In some cases, you need to provide options to alter GraphQL’s execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.""",
+        fieldsFn =
+            fun () -> [
+                Define.Field ("name", StringType, resolve = (fun _ directive -> directive.Name))
+                Define.Field ("description", Nullable StringType, resolve = (fun _ directive -> directive.Description))
+                Define.Field ("locations", ListOf __DirectiveLocation, resolve = (fun _ directive -> directive.Locations))
+                Define.Field ("args", ListOf __InputValue, resolve = (fun _ directive -> directive.Args))
+                Define.Field (
+                    "onOperation",
+                    BooleanType,
+                    resolve =
+                        fun _ d ->
+                            d.Locations
+                            |> Seq.exists (oneOf [| DirectiveLocation.QUERY; DirectiveLocation.MUTATION; DirectiveLocation.SUBSCRIPTION |])
+                )
+                Define.Field (
+                    "onFragment",
+                    BooleanType,
+                    resolve =
+                        fun _ d ->
+                            d.Locations
+                            |> Seq.exists (
+                                oneOf [|
+                                    DirectiveLocation.FRAGMENT_SPREAD
+                                    DirectiveLocation.INLINE_FRAGMENT
+                                    DirectiveLocation.FRAGMENT_DEFINITION
+                                |]
+                            )
+                )
+                Define.Field (
+                    "onField",
+                    BooleanType,
+                    resolve =
+                        fun _ d ->
+                            d.Locations
+                            |> Seq.exists (oneOf [| DirectiveLocation.FIELD |])
+                )
+            ]
+    )
 
 /// GraphQL object defining capabilities of GraphQL server. It exposes
 /// all available types and directives on the server, as well as the
 /// entry points for query, mutation, and subscription operations.
 and __Schema =
-  Define.Object<IntrospectionSchema>(
-    name = "__Schema",
-    description = "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.",
-    fieldsFn = fun () ->
-    [
-        Define.Field("types", ListOf __Type, description = "A list of all types supported by this server.", resolve = fun _ schema -> schema.Types |> Array.map IntrospectionTypeRef.Named)
-        Define.Field("queryType", __Type, description = "The type that query operations will be rooted at.", resolve = fun _ schema -> schema.QueryType)
-        Define.Field("mutationType", Nullable __Type, description = "If this server supports mutation, the type that mutation operations will be rooted at.", resolve = fun _ schema -> schema.MutationType)
-        Define.Field("subscriptionType", Nullable __Type, description = "If this server support subscription, the type that subscription operations will be rooted at.", resolve = fun _ schema -> schema.SubscriptionType)
-        Define.Field("directives", ListOf __Directive, description = "A list of all directives supported by this server.", resolve = fun _  schema -> schema.Directives)
-    ])
+    Define.ObjectRec<IntrospectionSchema> (
+        name = "__Schema",
+        description =
+            "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.",
+        fieldsFn =
+            fun () -> [
+                Define.Field (
+                    "types",
+                    ListOf __Type,
+                    description = "A list of all types supported by this server.",
+                    resolve = fun _ schema -> schema.Types |> Array.map IntrospectionTypeRef.Named
+                )
+                Define.Field (
+                    "queryType",
+                    __Type,
+                    description = "The type that query operations will be rooted at.",
+                    resolve = fun _ schema -> schema.QueryType
+                )
+                Define.Field (
+                    "mutationType",
+                    Nullable __Type,
+                    description = "If this server supports mutation, the type that mutation operations will be rooted at.",
+                    resolve = fun _ schema -> schema.MutationType
+                )
+                Define.Field (
+                    "subscriptionType",
+                    Nullable __Type,
+                    description = "If this server support subscription, the type that subscription operations will be rooted at.",
+                    resolve = fun _ schema -> schema.SubscriptionType
+                )
+                Define.Field (
+                    "directives",
+                    ListOf __Directive,
+                    description = "A list of all directives supported by this server.",
+                    resolve = fun _ schema -> schema.Directives
+                )
+            ]
+    )

--- a/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
+++ b/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
@@ -968,22 +968,26 @@ and FieldDef<'Val> =
         inherit FieldDef
     end
 
-and [<CustomEquality; NoComparison>] internal FieldDefinition<'Val, 'Res> = {
-    /// Name of the field.
-    Name : string
-    /// Optional field description.
-    Description : string option
-    /// Field's GraphQL type definition.
-    TypeDef : OutputDef<'Res>
-    /// Field resolution function.
-    Resolve : Resolve
-    /// Field's arguments list.
-    Args : InputFieldDef[]
-    /// Optional field deprecation warning.
-    DeprecationReason : string option
-    /// Field metadata definition.
-    Metadata : Metadata
-} with
+and FieldDef<'Val, 'Res> =
+    interface
+        inherit FieldDef<'Val>
+    end
+
+and [<CustomEquality; NoComparison>] internal FieldDefinition<'Val, 'Res> =
+    { /// Name of the field.
+      Name : string
+      /// Optional field description.
+      Description : string option
+      /// Field's GraphQL type definition.
+      TypeDef : OutputDef<'Res>
+      /// Field resolution function.
+      Resolve : Resolve
+      /// Field's arguments list.
+      Args : InputFieldDef []
+      /// Optional field deprecation warning.
+      DeprecationReason : string option
+      /// Field metadata definition.
+      Metadata : Metadata }
 
     interface FieldDef with
         member x.Name = x.Name
@@ -994,7 +998,7 @@ and [<CustomEquality; NoComparison>] internal FieldDefinition<'Val, 'Res> = {
         member x.Resolve = x.Resolve
         member x.Metadata = x.Metadata
 
-    interface FieldDef<'Val>
+    interface FieldDef<'Val, 'Res>
 
     interface IEquatable<FieldDef> with
         member x.Equals f =
@@ -1741,8 +1745,8 @@ and [<CustomEquality; NoComparison>] SubscriptionFieldDefinition<'Root, 'Input, 
     interface SubscriptionFieldDef with
         member x.OutputTypeDef = x.OutputTypeDef :> OutputDef
         member x.TagsResolver = x.TagsResolver
-    interface FieldDef<'Root>
-    member x.TypeDef = x.RootTypeDef
+    interface FieldDef<'Root, 'Output>
+        member x.TypeDef = x.RootTypeDef
     interface SubscriptionFieldDef<'Root, 'Input, 'Output>
     interface IEquatable<FieldDef> with
         member x.Equals f =

--- a/tests/FSharp.Data.GraphQL.Benchmarks/AsyncSchema.fs
+++ b/tests/FSharp.Data.GraphQL.Benchmarks/AsyncSchema.fs
@@ -9,53 +9,75 @@ open FSharp.Data.GraphQL.Server.Middleware
 
 [<RequireQualifiedAccess>]
 module AsyncSchemaDefinition =
-  let humans =
-      [ { Id = "1000"
-          Name = Some "Luke Skywalker"
-          Friends = [ "1002"; "1003" ]
-          HomePlanet = Some "Tatooine" }
-        { Id = "1001"
-          Name = Some "Darth Vader"
-          Friends = [ "1004" ]
-          HomePlanet = Some "Tatooine" }
-        { Id = "1002"
-          Name = Some "Han Solo"
-          Friends = [ "1000"; "1003" ]
-          HomePlanet = None }
-        { Id = "1003"
-          Name = Some "Leia Organa"
-          Friends = [ "1000"; "1002" ]
-          HomePlanet = Some "Alderaan" }
-        { Id = "1004"
-          Name = Some "Wilhuff Tarkin"
-          Friends = [ "1001" ]
-          HomePlanet = None } ]
+    let humans = [
+        {
+            Id = "1000"
+            Name = Some "Luke Skywalker"
+            Friends = [ "1002"; "1003" ]
+            HomePlanet = Some "Tatooine"
+        }
+        {
+            Id = "1001"
+            Name = Some "Darth Vader"
+            Friends = [ "1004" ]
+            HomePlanet = Some "Tatooine"
+        }
+        {
+            Id = "1002"
+            Name = Some "Han Solo"
+            Friends = [ "1000"; "1003" ]
+            HomePlanet = None
+        }
+        {
+            Id = "1003"
+            Name = Some "Leia Organa"
+            Friends = [ "1000"; "1002" ]
+            HomePlanet = Some "Alderaan"
+        }
+        {
+            Id = "1004"
+            Name = Some "Wilhuff Tarkin"
+            Friends = [ "1001" ]
+            HomePlanet = None
+        }
+    ]
 
-  let getPerson id = humans |> List.tryFind (fun h -> h.Id = id)
+    let getPerson id = humans |> List.tryFind (fun h -> h.Id = id)
 
-  let delay value = async {
-          do Thread.Sleep(10)
-          return value
-      }
+    let delay value = async {
+        do Thread.Sleep (10)
+        return value
+    }
 
-  let rec Person =
-      Define.Object(name = "Person", isTypeOf = (fun o -> o :? Person),
-                    fieldsFn = fun () ->
-                        [ Define.AsyncField("id", StringType, resolve = fun _ person -> delay person.Id)
-                          Define.AsyncField("name", Nullable StringType, resolve = fun _ person -> delay person.Name)
-                          Define.AsyncField("friends", Nullable(ListOf(Nullable Person)),
-                                       resolve = fun _ person ->
-                                           person.Friends
-                                           |> List.map getPerson
-                                           |> List.toSeq
-                                           |> Some
-                                           |> delay).WithQueryWeight(1.0)
-                          Define.Field("homePlanet", StringType) ])
+    let rec Person =
+        Define.ObjectRec (
+            name = "Person",
+            isTypeOf = (fun o -> o :? Person),
+            fieldsFn =
+                fun () -> [
+                    Define.AsyncField ("id", StringType, resolve = (fun _ person -> delay person.Id))
+                    Define.AsyncField ("name", Nullable StringType, resolve = (fun _ person -> delay person.Name))
+                    Define.Field ("homePlanet", StringType)
+                    Define
+                        .AsyncField(
+                            "friends",
+                            Nullable (ListOf (Nullable Person)),
+                            resolve = fun _ person -> person.Friends |> List.map getPerson |> List.toSeq |> Some |> delay
+                        )
+                        .WithQueryWeight (1.0)
+                ]
+        )
 
-  let Query =
-      Define.Object
-          (name = "Query",
-           fields = [ Define.Field
-                          ("hero", Nullable Person, "Retrieves a person by provided id", [ Define.Input("id", StringType) ],
-                           fun ctx () -> getPerson (ctx.Arg("id"))) ])
-
+    let Query =
+        Define.Object (
+            name = "Query",
+            fields = [
+                Define.Field (
+                    "hero",
+                    Nullable Person,
+                    "Retrieves a person by provided id",
+                    [ Define.Input ("id", StringType) ],
+                    fun ctx () -> getPerson (ctx.Arg "id")
+                )
+            ]
+        )

--- a/tests/FSharp.Data.GraphQL.Benchmarks/Schema.fs
+++ b/tests/FSharp.Data.GraphQL.Benchmarks/Schema.fs
@@ -5,72 +5,99 @@ namespace FSharp.Data.GraphQL.Benchmarks
 open FSharp.Data.GraphQL.Types
 open FSharp.Data.GraphQL.Server.Middleware
 
-type Person =
-    { Id : string
-      Name : string option
-      Friends : string list
-      HomePlanet : string option }
+type Person = {
+    Id : string
+    Name : string option
+    Friends : string list
+    HomePlanet : string option
+}
 
 module SchemaDefinition =
-  let humans =
-      [ { Id = "1000"
-          Name = Some "Luke Skywalker"
-          Friends = [ "1002"; "1003" ]
-          HomePlanet = Some "Tatooine" }
-        { Id = "1001"
-          Name = Some "Darth Vader"
-          Friends = [ "1004" ]
-          HomePlanet = Some "Tatooine" }
-        { Id = "1002"
-          Name = Some "Han Solo"
-          Friends = [ "1000"; "1003" ]
-          HomePlanet = None }
-        { Id = "1003"
-          Name = Some "Leia Organa"
-          Friends = [ "1000"; "1002" ]
-          HomePlanet = Some "Alderaan" }
-        { Id = "1004"
-          Name = Some "Wilhuff Tarkin"
-          Friends = [ "1001" ]
-          HomePlanet = None } ]
+    let humans = [
+        {
+            Id = "1000"
+            Name = Some "Luke Skywalker"
+            Friends = [ "1002"; "1003" ]
+            HomePlanet = Some "Tatooine"
+        }
+        {
+            Id = "1001"
+            Name = Some "Darth Vader"
+            Friends = [ "1004" ]
+            HomePlanet = Some "Tatooine"
+        }
+        {
+            Id = "1002"
+            Name = Some "Han Solo"
+            Friends = [ "1000"; "1003" ]
+            HomePlanet = None
+        }
+        {
+            Id = "1003"
+            Name = Some "Leia Organa"
+            Friends = [ "1000"; "1002" ]
+            HomePlanet = Some "Alderaan"
+        }
+        {
+            Id = "1004"
+            Name = Some "Wilhuff Tarkin"
+            Friends = [ "1001" ]
+            HomePlanet = None
+        }
+    ]
 
-  let getPerson id = humans |> List.tryFind (fun h -> h.Id = id)
+    let getPerson id = humans |> List.tryFind (fun h -> h.Id = id)
 
-  let rec Person =
-      Define.Object(name = "Person", isTypeOf = (fun o -> o :? Person),
-                    fieldsFn = fun () ->
-                        [ Define.Field("id", StringType, resolve = fun _ person -> person.Id)
-                          Define.Field("name", Nullable StringType, resolve = fun _ person -> person.Name)
-                          Define.Field("friends", Nullable(ListOf(Nullable Person)),
-                                       resolve = fun _ person ->
-                                           person.Friends
-                                           |> List.map getPerson
-                                           |> List.toSeq
-                                           |> Some).WithQueryWeight(1.0)
-                          Define.Field("homePlanet", StringType) ])
+    let rec Person =
+        Define.ObjectRec (
+            name = "Person",
+            isTypeOf = (fun o -> o :? Person),
+            fieldsFn =
+                fun () -> [
+                    Define.Field ("id", StringType, resolve = (fun _ person -> person.Id))
+                    Define.Field ("name", Nullable StringType, resolve = (fun _ person -> person.Name))
+                    Define.Field ("homePlanet", StringType)
+                    Define.Field(
+                            "friends",
+                            Nullable (ListOf (Nullable Person)),
+                            resolve = fun _ person -> person.Friends |> List.map getPerson |> List.toSeq |> Some
+                        )
+                        .WithQueryWeight (1.0)
+                ]
+        )
 
-  let Query =
-      Define.Object
-          (name = "Query",
-           fields = [ Define.Field
-                          ("hero", Nullable Person, "Retrieves a person by provided id", [ Define.Input("id", StringType) ],
-                           fun ctx () -> getPerson (ctx.Arg("id"))) ])
+    let Query =
+        Define.Object (
+            name = "Query",
+            fields = [
+                Define.Field (
+                    "hero",
+                    Nullable Person,
+                    "Retrieves a person by provided id",
+                    [ Define.Input ("id", StringType) ],
+                    fun ctx () -> getPerson (ctx.Arg ("id"))
+                )
+            ]
+        )
 
 module QueryStrings =
 
-    let simple = """{
+    let simple =
+        """{
         hero(id: "1000") {
             id
         }
     }"""
-    let flat = """{
+    let flat =
+        """{
         hero(id: "1000") {
             id,
             name,
             homePlanet
         }
     }"""
-    let nested = """{
+    let nested =
+        """{
         hero(id: "1000") {
             id,
             name,
@@ -88,7 +115,8 @@ module QueryStrings =
             }
         }
     }"""
-    let filtered = """{
+    let filtered =
+        """{
         hero(id: "1000") {
             id,
             name,

--- a/tests/FSharp.Data.GraphQL.Tests/AbstractionTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/AbstractionTests.fs
@@ -44,7 +44,7 @@ let resolvePet =
 
 let schemaWithInterface =
     lazy
-        let PetType = Define.Interface ("Pet", (fun () -> [ Define.Field ("name", StringType) ]))
+        let PetType = Define.InterfaceRec ("Pet", (fun () -> [ Define.Field ("name", StringType) ]))
 
         let DogType =
             Define.Object<Dog> (
@@ -69,7 +69,7 @@ let schemaWithInterface =
         let schema =
             Schema (
                 query =
-                    Define.Object (
+                    Define.ObjectRec (
                         "Query",
                         fun () ->
                             [ Define.Field (
@@ -239,7 +239,7 @@ let schemaWithUnion =
         let schema =
             Schema (
                 query =
-                    Define.Object (
+                    Define.ObjectRec (
                         "Query",
                         fun () ->
                             [ Define.Field (

--- a/tests/FSharp.Data.GraphQL.Tests/AspNetCore/TestSchema.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/AspNetCore/TestSchema.fs
@@ -148,7 +148,7 @@ module TestSchema =
         )
 
     and HumanType : ObjectDef<Human> =
-        Define.Object<Human> (
+        Define.ObjectRec<Human> (
             name = "Human",
             description = "A humanoid creature in the Star Wars universe.",
             isTypeOf = (fun o -> o :? Human),
@@ -168,7 +168,7 @@ module TestSchema =
         )
 
     and DroidType =
-        Define.Object<Droid> (
+        Define.ObjectRec<Droid> (
             name = "Droid",
             description = "A mechanical creature in the Star Wars universe.",
             isTypeOf = (fun o -> o :? Droid),
@@ -188,7 +188,7 @@ module TestSchema =
         )
 
     and PlanetType =
-        Define.Object<Planet> (
+        Define.ObjectRec<Planet> (
             name = "Planet",
             description = "A planet in the Star Wars universe.",
             isTypeOf = (fun o -> o :? Planet),
@@ -201,7 +201,7 @@ module TestSchema =
         )
 
     and RootType =
-        Define.Object<Root> (
+        Define.ObjectRec<Root> (
             name = "Root",
             description = "The Root type to be passed to all our resolvers.",
             isTypeOf = (fun o -> o :? Root),

--- a/tests/FSharp.Data.GraphQL.Tests/DeferredTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/DeferredTests.fs
@@ -141,7 +141,7 @@ let UnionType =
             | B _ -> upcast BType))
 
 let rec InnerDataType =
-    Define.Object<InnerTestSubject>(
+    Define.ObjectRec<InnerTestSubject>(
         name = "InnerData",
         fieldsFn = fun () ->
         [
@@ -150,17 +150,17 @@ let rec InnerDataType =
         ])
 
 let AsyncDataType =
-    Define.Object<AsyncTestSubject>(
+    Define.ObjectRec<AsyncTestSubject>(
         name = "AsyncData",
         fieldsFn = fun () -> [ Define.AsyncField("value", Nullable StringType, (fun _ d -> d.value )) ])
 
 let NonNullAsyncDataType =
-    Define.Object<NonNullAsyncTestSubject>(
+    Define.ObjectRec<NonNullAsyncTestSubject>(
         name = "NonNullAsyncData",
         fieldsFn = fun () -> [ Define.AsyncField("value", StringType, (fun _ d -> d.value )) ])
 
 let DataType =
-    Define.Object<TestSubject>(
+    Define.ObjectRec<TestSubject>(
         name = "Data",
         fieldsFn = fun () ->
         [
@@ -231,7 +231,7 @@ let data = {
    }
 
 let Query =
-    Define.Object<TestSubject>(
+    Define.ObjectRec<TestSubject>(
         name = "Query",
         fieldsFn = fun () ->
         [

--- a/tests/FSharp.Data.GraphQL.Tests/ExecutionTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/ExecutionTests.fs
@@ -113,7 +113,7 @@ let ``Execution handles basic tasks: executes arbitrary code`` () =
                 Define.Field("c", (ListOf (Nullable StringType)), (fun _ dt -> dt.c))
             ])
     let rec DataType =
-      Define.Object<TestSubject>(
+      Define.ObjectRec<TestSubject>(
           "DataType",
           fieldsFn = fun () ->
           [
@@ -153,7 +153,7 @@ let ``Execution handles basic tasks: merges parallel fragments`` () =
         }"""
 
     let rec Type =
-      Define.Object(
+      Define.ObjectRec(
         name = "Type",
         fieldsFn = fun () ->
         [

--- a/tests/FSharp.Data.GraphQL.Tests/ExecutorMiddlewareTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/ExecutorMiddlewareTests.fs
@@ -23,7 +23,7 @@ let data =
       c = "Cookie" }
 
 let DataType =
-    Define.Object<TestSubject>(
+    Define.ObjectRec<TestSubject>(
         "Data",
         fieldsFn = fun () ->
         [
@@ -33,7 +33,7 @@ let DataType =
             Define.Field("d", BooleanType, "Returns its argument", [ Define.Input("input", BooleanType) ], fun ctx _ -> ctx.Arg<bool> "input")
         ])
 let Query =
-    Define.Object<TestSubject>(
+    Define.ObjectRec<TestSubject>(
         "Query",
         fieldsFn = fun () -> [ Define.Field("testData", DataType, (fun _ _ -> data)) ] )
 

--- a/tests/FSharp.Data.GraphQL.Tests/MiddlewareTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/MiddlewareTests.fs
@@ -53,7 +53,7 @@ let executor =
             resolveValue = (fun u -> match u with A a -> box a | B b -> box b),
             resolveType = (fun u -> match u with A _ -> upcast AType | B _ -> upcast BType))
     and AType =
-        Define.Object<A>(
+        Define.ObjectRec<A>(
             name = "A",
             isTypeOf = (fun o -> o :? A),
             fieldsFn = fun () ->
@@ -63,7 +63,7 @@ let executor =
                     resolve = fun _ (a : A) -> a.subjects |> List.map getSubject |> List.toSeq |> Some)
                     .WithQueryWeight(1.0) ])
     and BType =
-        Define.Object<B>(
+        Define.ObjectRec<B>(
             name = "B",
             isTypeOf = (fun o -> o :? B),
             fieldsFn = fun () ->

--- a/tests/FSharp.Data.GraphQL.Tests/PlanningTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/PlanningTests.fs
@@ -37,13 +37,14 @@ let animals =
         species = "Dog" } ]
 
 let rec Person =
-    Define.Object(name = "Person",
-                  fieldsFn = (fun () ->
-                  [ Define.Field("firstName", StringType, fun _ person -> person.firstName)
-                    Define.Field("lastName", StringType, fun _ person -> person.lastName)
-                    Define.Field("age", IntType, fun _ person -> person.age)
-                    Define.Field("name", StringType, fun _ person -> person.firstName + " " + person.lastName)
-                    Define.Field("friends", ListOf Person, fun _ _ -> []) ]), interfaces = [ INamed ])
+    Define.ObjectRec(
+        name = "Person",
+        fieldsFn = (fun () ->
+            [ Define.Field("firstName", StringType, fun _ person -> person.firstName)
+              Define.Field("lastName", StringType, fun _ person -> person.lastName)
+              Define.Field("age", IntType, fun _ person -> person.age)
+              Define.Field("name", StringType, fun _ person -> person.firstName + " " + person.lastName)
+              Define.Field("friends", ListOf Person, fun _ _ -> []) ]), interfaces = [ INamed ])
 
 and Animal =
     Define.Object(name = "Animal",
@@ -53,10 +54,11 @@ and Animal =
 and INamed = Define.Interface<obj>("INamed", [ Define.Field("name", StringType) ])
 
 and UNamed =
-    Define.Union("UNamed", [ Person; Animal ],
-                 function
-                 | Animal a -> box a
-                 | Person p -> upcast p)
+    Define.Union(
+        "UNamed", [ Person; Animal ],
+        function
+        | Animal a -> box a
+        | Person p -> upcast p)
 
 [<Fact>]
 let ``Planning must retain correct types for leafs``() =

--- a/tests/FSharp.Data.GraphQL.Tests/PropertyTrackerTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/PropertyTrackerTests.fs
@@ -22,7 +22,7 @@ let ben = { Id = 2; FirstName = "Ben"; LastName = "Adams"; Friends = [ john ] }
 let at22 = { Id = 3; Number = "AT22"; Function = "combat wombat" }
 
 let rec Person =
-    Define.Object<Person> (
+    Define.ObjectRec<Person>(
         name = "Person",
         interfaces = [ Node ],
         fieldsFn =
@@ -71,7 +71,7 @@ let rec Person =
             ]
     )
 and Droid =
-    Define.Object<Droid> (
+    Define.ObjectRec<Droid>(
         name = "Droid",
         interfaces = [ Node ],
         fieldsFn =

--- a/tests/FSharp.Data.GraphQL.Tests/SubscriptionTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/SubscriptionTests.fs
@@ -14,7 +14,7 @@ type Root =
     { ClientId : string }
 
 let ValueType =
-    Define.Object<Value>(
+    Define.ObjectRec<Value>(
         name = "Value",
         fieldsFn = fun () ->
         [
@@ -23,7 +23,7 @@ let ValueType =
         ])
 
 let RootType =
-    Define.Object<Root>(
+    Define.ObjectRec<Root>(
         name = "Query",
         description = "Root object",
         isTypeOf = (fun o -> o :? Root),
@@ -36,7 +36,7 @@ let getValue id =
     values |> Seq.tryFind (fun x -> x.Id = id)
 
 let Query =
-    Define.Object<Root>(
+    Define.ObjectRec<Root>(
         name = "Query",
         fieldsFn = fun () -> [ Define.Field("values", ListOf ValueType, (fun _ _ -> values)) ] )
 

--- a/tests/FSharp.Data.GraphQL.Tests/Variables and Inputs/InputObjectValidatorTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/Variables and Inputs/InputObjectValidatorTests.fs
@@ -95,7 +95,7 @@ let schema =
     let schema =
         Schema (
             query =
-                Define.Object (
+                Define.ObjectRec (
                     "Query",
                     fun () ->
                         [ Define.Field (

--- a/tests/FSharp.Data.GraphQL.Tests/Variables and Inputs/InputRecordTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/Variables and Inputs/InputRecordTests.fs
@@ -69,7 +69,7 @@ let schema =
     let schema =
         Schema (
             query =
-                Define.Object (
+                Define.ObjectRec (
                     "Query",
                     fun () ->
                         [ Define.Field (

--- a/tests/FSharp.Data.GraphQL.Tests/Variables and Inputs/InputScalarAndAutoFieldScalarTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/Variables and Inputs/InputScalarAndAutoFieldScalarTests.fs
@@ -85,7 +85,7 @@ let ``Object Nullable to Nullable Type`` =
 let ``Schema can be created for unmatched input nullable fields on record`` () =
     Schema (
         query =
-            Define.Object (
+            Define.ObjectRec (
                 "Query",
                 fun () ->
                     [ Define.Field (
@@ -102,7 +102,7 @@ let ``Schema cannot be created for unmatched input nullable fields on record`` (
     Assert.Throws<InvalidInputTypeException> (fun () ->
         Schema (
             query =
-                Define.Object (
+                Define.ObjectRec (
                     "Query",
                     fun () ->
                         [ Define.Field (
@@ -119,7 +119,7 @@ let ``Schema cannot be created for unmatched input nullable fields on record`` (
 let ``Schema can be created for matched input nullable fields on class`` () =
     Schema (
         query =
-            Define.Object (
+            Define.ObjectRec (
                 "Query",
                 fun () ->
                     [ Define.Field (
@@ -136,7 +136,7 @@ let ``Schema cannot be created for unmatched input nullable fields on class`` ()
     Assert.Throws<InvalidInputTypeException> (fun () ->
         Schema (
             query =
-                Define.Object (
+                Define.ObjectRec (
                     "Query",
                     fun () ->
                         [ Define.Field (
@@ -155,7 +155,7 @@ let schema =
         let schema =
             Schema<unit> (
                 query =
-                    Define.Object (
+                    Define.ObjectRec (
                         "Query",
                         fun () ->
                             [

--- a/tests/FSharp.Data.GraphQL.Tests/Variables and Inputs/OptionalsNormalizationTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/Variables and Inputs/OptionalsNormalizationTests.fs
@@ -172,7 +172,7 @@ let schema =
     let schema =
         Schema (
             query =
-                Define.Object (
+                Define.ObjectRec (
                     "Query",
                     fun () ->
                         [ Define.Field (


### PR DESCRIPTION
In order to call `Define.Field<'Val>(....).WithAuthorizationPolicy("policy")` I need to know not only `'Res` which is an object on which `FieldDef<'Res>` is defined but also a `'Val` which is a field type.
However when I introduced `FieldDef<'Val, 'Res>` F# cannot determine the override between `Define.Object` that gets a list of field and a labmda that return a list of fields. So I had to rename `Define.Object` overrie to `Define.ObjectRec` and `Define.Interface` override to `Define.ObjectRec`.
I have not renamed `Define.InputObject` as it accepts a parameter of list of another interface