### PR TITLE
Fixed packaging and publishing NuGet packages

### DIFF
--- a/.github/workflows/publish_ci.yml
+++ b/.github/workflows/publish_ci.yml
@@ -45,7 +45,7 @@ jobs:
         dotnet pack --no-build --nologo --configuration Release /p:IsNuget=true -o ../../nuget
     - name: Publish FSharp.Data.GraphQL.Shared project to GitHub
       run: |
-        dotnet nuget push nuget/*Shared*.nupkg -s "github" -k ${{secrets.GITHUB_TOKEN}}
+        dotnet nuget push nuget/*Shared*.nupkg -s "github" -k ${{secrets.GITHUB_TOKEN}} --skip-duplicate
 
     - name: Pack FSharp.Data.GraphQL.Client project
       run: |
@@ -53,7 +53,7 @@ jobs:
         dotnet pack --no-build --nologo --configuration Release /p:IsNuget=true -o ../../nuget
     - name: Publish FSharp.Data.GraphQL.Client project to GitHub
       run: |
-        dotnet nuget push nuget/*Client*.nupkg -s "github" -k ${{secrets.GITHUB_TOKEN}}
+        dotnet nuget push nuget/*Client*.nupkg -s "github" -k ${{secrets.GITHUB_TOKEN}} --skip-duplicate
 
     - name: Pack FSharp.Data.GraphQL.Server project
       run: |
@@ -61,7 +61,7 @@ jobs:
         dotnet pack --no-build --nologo --configuration Release /p:IsNuget=true -o ../../nuget
     - name: Publish FSharp.Data.GraphQL.Server project to GitHub
       run: |
-        dotnet nuget push nuget/*Server*.nupkg -s "github" -k ${{secrets.GITHUB_TOKEN}}
+        dotnet nuget push nuget/*Server*.nupkg -s "github" -k ${{secrets.GITHUB_TOKEN}} --skip-duplicate
 
     - name: Pack FSharp.Data.GraphQL.Server.Relay project
       run: |
@@ -69,7 +69,7 @@ jobs:
         dotnet pack --no-build --nologo --configuration Release /p:IsNuget=true -o ../../nuget
     - name: Publish FSharp.Data.GraphQL.Server.Relay project to GitHub
       run: |
-        dotnet nuget push nuget/*Server.Relay*.nupkg -s "github" -k ${{secrets.GITHUB_TOKEN}}
+        dotnet nuget push nuget/*Server.Relay*.nupkg -s "github" -k ${{secrets.GITHUB_TOKEN}} --skip-duplicate
 
     - name: Pack FSharp.Data.GraphQL.Server.Middleware project
       run: |
@@ -77,7 +77,7 @@ jobs:
         dotnet pack --nologo --configuration Release /p:IsNuget=true -o ../../nuget
     - name: Publish FSharp.Data.GraphQL.Server.Middleware project to GitHub
       run: |
-        dotnet nuget push nuget/*Server.Middleware*.nupkg -s "github" -k ${{secrets.GITHUB_TOKEN}}
+        dotnet nuget push nuget/*Server.Middleware*.nupkg -s "github" -k ${{secrets.GITHUB_TOKEN}} --skip-duplicate
 
     - name: Prepare the sample project to be packed as a project template
       run: |
@@ -91,5 +91,5 @@ jobs:
     - name: Publish FSharp.Data.GraphQL.ProjectTemplates project to GitHub
       run: |
         $path = "nuget/FSharp.Data.GraphQL.ProjectTemplates.$Env:VERSION.nupkg"
-        dotnet nuget push $path -s "github" -k ${{secrets.GITHUB_TOKEN}}
+        dotnet nuget push $path -s "github" -k ${{secrets.GITHUB_TOKEN}} --skip-duplicate
       shell: pwsh

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -44,7 +44,7 @@ jobs:
         dotnet pack --no-build --nologo --configuration Release /p:IsNuget=true -o ../../nuget
     - name: Publish FSharp.Data.GraphQL.Shared project to NuGet
       run: |
-        dotnet nuget push nuget/*Shared*.nupkg -k ${{secrets.NUGET_SECRET}}
+        dotnet nuget push nuget/*Shared*.nupkg -k ${{secrets.NUGET_SECRET}} --skip-duplicate
 
     - name: Pack FSharp.Data.GraphQL.Client project
       run: |
@@ -52,7 +52,7 @@ jobs:
         dotnet pack --no-build --nologo --configuration Release /p:IsNuget=true -o ../../nuget
     - name: Publish FSharp.Data.GraphQL.Client project to NuGet
       run: |
-        dotnet nuget push nuget/*Client*.nupkg -k ${{secrets.NUGET_SECRET}}
+        dotnet nuget push nuget/*Client*.nupkg -k ${{secrets.NUGET_SECRET}} --skip-duplicate
 
     - name: Pack FSharp.Data.GraphQL.Server project
       run: |
@@ -60,7 +60,7 @@ jobs:
         dotnet pack --no-build --nologo --configuration Release /p:IsNuget=true -o ../../nuget
     - name: Publish FSharp.Data.GraphQL.Server project to NuGet
       run: |
-        dotnet nuget push nuget/*Server*.nupkg -k ${{secrets.NUGET_SECRET}}
+        dotnet nuget push nuget/*Server*.nupkg -k ${{secrets.NUGET_SECRET}} --skip-duplicate
 
     - name: Pack FSharp.Data.GraphQL.Server.Relay project
       run: |
@@ -68,7 +68,7 @@ jobs:
         dotnet pack --no-build --nologo --configuration Release /p:IsNuget=true -o ../../nuget
     - name: Publish FSharp.Data.GraphQL.Server.Relay project to NuGet
       run: |
-        dotnet nuget push nuget/*Server.Relay*.nupkg -k ${{secrets.NUGET_SECRET}}
+        dotnet nuget push nuget/*Server.Relay*.nupkg -k ${{secrets.NUGET_SECRET}} --skip-duplicate
 
     - name: Pack FSharp.Data.GraphQL.Server.Middleware project
       run: |
@@ -76,7 +76,7 @@ jobs:
         dotnet pack --nologo --configuration Release /p:IsNuget=true -o ../../nuget
     - name: Publish FSharp.Data.GraphQL.Server.Middleware project to NuGet
       run: |
-        dotnet nuget push nuget/*Server.Middleware*.nupkg -k ${{secrets.NUGET_SECRET}}
+        dotnet nuget push nuget/*Server.Middleware*.nupkg -k ${{secrets.NUGET_SECRET}} --skip-duplicate
 
     - name: Prepare the sample project to be packed as a project template
       run: |
@@ -90,5 +90,5 @@ jobs:
     - name: Publish FSharp.Data.GraphQL.ProjectTemplates project to GitHub
       run: |
         $path = "nuget/FSharp.Data.GraphQL.ProjectTemplates.$Env:VERSION.nupkg"
-        dotnet nuget push $path -k ${{secrets.NUGET_SECRET}}
+        dotnet nuget push $path -k ${{secrets.NUGET_SECRET}} --skip-duplicate
       shell: pwsh

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -32,4 +32,4 @@ jobs:
       run: dotnet tool restore
 
     - name: Build and run integration tests
-      run: dotnet run --project build/Build.fsproj
+      run: dotnet run --project build/Build.fsproj --launch-profile BuildAndTest

--- a/build/Build.fsproj
+++ b/build/Build.fsproj
@@ -9,6 +9,7 @@
     <None Include="Properties\launchSettings.json" />
     <Compile Include="BinLog.fs" />
     <Compile Include="MSBuild.fs" />
+    <Compile Include="NuGet.fs" />
     <Compile Include="DotNet.fs" />
     <Compile Include="Helpers.fs" />
     <Compile Include="Program.fs" />

--- a/build/DotNet.fs
+++ b/build/DotNet.fs
@@ -27,7 +27,9 @@ module DotNet =
         if Environment.isUnix then
             Environment.environVar "HOME" @@ ".dotnet"
         else
-            Environment.environVar "LocalAppData" @@ "Microsoft" @@ "dotnet"
+            Environment.environVar "LocalAppData"
+            @@ "Microsoft"
+            @@ "dotnet"
 
     /// <summary>
     /// .NET Core SDK default install directory (set to default SDK installer paths
@@ -47,15 +49,14 @@ module DotNet =
     /// <param name="startDir">The directory to start search from</param>
     let internal tryGetSDKVersionFromGlobalJsonDir startDir : string option =
         let globalJsonPaths rootDir =
-            let rec loop (dir: DirectoryInfo) =
-                seq {
-                    match dir.GetFiles "global.json" with
-                    | [| json |] -> yield json
-                    | _ -> ()
+            let rec loop (dir : DirectoryInfo) = seq {
+                match dir.GetFiles "global.json" with
+                | [| json |] -> yield json
+                | _ -> ()
 
-                    if not (isNull dir.Parent) then
-                        yield! loop dir.Parent
-                }
+                if not (isNull dir.Parent) then
+                    yield! loop dir.Parent
+            }
 
             loop (DirectoryInfo rootDir)
 
@@ -65,11 +66,11 @@ module DotNet =
             try
                 let content = File.ReadAllText globalJson.FullName
                 let json = JObject.Parse content
-                let sdk = json.Item("sdk") :?> JObject
-                match sdk.Property("version") with
+                let sdk = json.Item ("sdk") :?> JObject
+                match sdk.Property ("version") with
                 | null -> None
                 | version ->
-                    let versionValue = version.Value.ToString()
+                    let versionValue = version.Value.ToString ()
                     let _ = Version.Parse (versionValue)
                     Some versionValue
             with exn ->
@@ -102,34 +103,33 @@ module DotNet =
     /// </summary>
     ///
     /// <param name="dotnetCliDir">the path to check else will probe system PATH</param>
-    let findPossibleDotnetCliPaths dotnetCliDir =
-        seq {
-            let fileName = if Environment.isUnix then "dotnet" else "dotnet.exe"
+    let findPossibleDotnetCliPaths dotnetCliDir = seq {
+        let fileName = if Environment.isUnix then "dotnet" else "dotnet.exe"
 
-            yield!
-                ProcessUtils.findFilesOnPath "dotnet"
-                |> Seq.filter File.Exists
-                |> Seq.filter (fun dotPath -> dotPath.EndsWith fileName)
+        yield!
+            ProcessUtils.findFilesOnPath "dotnet"
+            |> Seq.filter File.Exists
+            |> Seq.filter (fun dotPath -> dotPath.EndsWith fileName)
 
-            let userInstallDir = defaultUserInstallDir </> fileName
+        let userInstallDir = defaultUserInstallDir </> fileName
 
-            if File.exists userInstallDir then
-                yield userInstallDir
+        if File.exists userInstallDir then
+            yield userInstallDir
 
-            let systemInstallDir = defaultSystemInstallDir </> fileName
+        let systemInstallDir = defaultSystemInstallDir </> fileName
 
-            if File.exists systemInstallDir then
-                yield systemInstallDir
+        if File.exists systemInstallDir then
+            yield systemInstallDir
 
-            match dotnetCliDir with
-            | Some userSetPath ->
-                let defaultCliPath = userSetPath @@ fileName
+        match dotnetCliDir with
+        | Some userSetPath ->
+            let defaultCliPath = userSetPath @@ fileName
 
-                match File.Exists defaultCliPath with
-                | true -> yield defaultCliPath
-                | _ -> ()
-            | None -> ()
-        }
+            match File.Exists defaultCliPath with
+            | true -> yield defaultCliPath
+            | _ -> ()
+        | None -> ()
+    }
 
     /// <summary>
     /// Get .NET Core SDK download uri
@@ -137,53 +137,47 @@ module DotNet =
     let private getGenericDotNetCliInstallerUrl branch installerName =
         sprintf "https://raw.githubusercontent.com/dotnet/cli/%s/scripts/obtain/%s" branch installerName
 
-    let private getPowershellDotNetCliInstallerUrl branch =
-        getGenericDotNetCliInstallerUrl branch "dotnet-install.ps1"
+    let private getPowershellDotNetCliInstallerUrl branch = getGenericDotNetCliInstallerUrl branch "dotnet-install.ps1"
 
-    let private getBashDotNetCliInstallerUrl branch =
-        getGenericDotNetCliInstallerUrl branch "dotnet-install.sh"
+    let private getBashDotNetCliInstallerUrl branch = getGenericDotNetCliInstallerUrl branch "dotnet-install.sh"
 
 
     /// <summary>
     /// Download .NET Core SDK installer
     /// </summary>
-    let private downloadDotNetInstallerFromUrl (url: string) fileName =
+    let private downloadDotNetInstallerFromUrl (url : string) fileName =
         //let url = getDotNetCliInstallerUrl branch
-        let h = new System.Net.Http.HttpClient()
-        use f = File.Open(fileName, FileMode.Create)
-        h.GetStreamAsync(url).Result.CopyTo(f)
+        let h = new System.Net.Http.HttpClient ()
+        use f = File.Open (fileName, FileMode.Create)
+        h.GetStreamAsync(url).Result.CopyTo (f)
         //use outFile = File.Open(fileName, FileMode.Create)
         //installScript.ResponseStream.CopyTo(outFile)
         Trace.trace (sprintf "downloaded dotnet installer (%s) to %s" url fileName)
 
-    let private md5 (data: byte array) : string =
-        use md5 = MD5.Create()
+    let private md5 (data : byte array) : string =
+        use md5 = MD5.Create ()
 
-        (StringBuilder(), md5.ComputeHash(data))
-        ||> Array.fold (fun sb b -> sb.Append(b.ToString("x2")))
+        (StringBuilder (), md5.ComputeHash (data))
+        ||> Array.fold (fun sb b -> sb.Append (b.ToString ("x2")))
         |> string
 
 
     /// <summary>
     /// .NET Core SDK installer download options
     /// </summary>
-    type InstallerOptions =
-        {
-            /// Always download install script (otherwise install script is cached in temporary folder)
-            AlwaysDownload: bool
+    type InstallerOptions = {
+        /// Always download install script (otherwise install script is cached in temporary folder)
+        AlwaysDownload : bool
 
-            /// Download installer from this github branch
-            Branch: string
+        /// Download installer from this github branch
+        Branch : string
 
-            // Use the given directory to download the script into. If None the temp-dir is used
-            CustomDownloadDir: string option
-        }
+        // Use the given directory to download the script into. If None the temp-dir is used
+        CustomDownloadDir : string option
+    } with
 
         /// Parameter default values.
-        static member Default =
-            { AlwaysDownload = false
-              Branch = "master"
-              CustomDownloadDir = None }
+        static member Default = { AlwaysDownload = false; Branch = "master"; CustomDownloadDir = None }
 
     /// <summary>
     /// Download .NET Core SDK installer
@@ -201,18 +195,20 @@ module DotNet =
             else
                 getPowershellDotNetCliInstallerUrl
 
-        let scriptName =
-            sprintf "dotnet_install_%s.%s" (md5 (Encoding.ASCII.GetBytes(param.Branch))) ext
+        let scriptName = sprintf "dotnet_install_%s.%s" (md5 (Encoding.ASCII.GetBytes (param.Branch))) ext
 
         let tempDir =
             match param.CustomDownloadDir with
-            | None -> Path.GetTempPath()
+            | None -> Path.GetTempPath ()
             | Some d -> d
 
         let tempInstallerScript = tempDir @@ scriptName
 
         // maybe download installer script
-        if param.AlwaysDownload || not (File.Exists(tempInstallerScript)) then
+        if
+            param.AlwaysDownload
+            || not (File.Exists (tempInstallerScript))
+        then
             let url = getInstallerUrl param.Branch
             downloadDotNetInstallerFromUrl url tempInstallerScript
 
@@ -248,7 +244,7 @@ module DotNet =
         /// Most current release.
         let Current = Some "Current"
         /// Two-part version in X.Y format representing a specific release (for example, 2.0 or 1.0).
-        let Version major minor = Some(sprintf "%d.%d" major minor)
+        let Version major minor = Some (sprintf "%d.%d" major minor)
         /// Branch name. For example, release/2.0.0, release/2.0.0-preview2, or master (for nightly releases).
         let Branch branchName = Some branchName
 
@@ -257,185 +253,202 @@ module DotNet =
     /// </summary>
     [<NoComparison>]
     [<NoEquality>]
-    type CliInstallOptions =
-        {
-            /// Custom installer obtain (download) options
-            InstallerOptions: InstallerOptions -> InstallerOptions
+    type CliInstallOptions = {
+        /// Custom installer obtain (download) options
+        InstallerOptions : InstallerOptions -> InstallerOptions
 
-            /// <summary>
-            /// Specifies the source channel for the installation. The possible values are:
-            /// <list type="number">
-            /// <item>
-            /// <c>Current</c> - Most current release.
-            /// </item>
-            /// <item>
-            /// <c>LTS</c> - Long-Term Support channel (most current supported release).
-            /// </item>
-            /// <item>
-            /// Two-part version in <c>X.Y</c> format representing a specific release (for example, <c>2.0</c> or
-            /// <c>1.0</c>).
-            /// </item>
-            /// <item>
-            /// Branch name. For example, release/2.0.0, release/2.0.0-preview2, or master (for nightly releases).
-            /// </item>
-            /// </list>
-            /// The default value is <c>LTS</c>. For more information on .NET support channels, see the
-            /// .NET Support Policy page.
-            /// </summary>
-            /// <remarks>
-            /// Use the <c>CliChannel</c> module, for example <c>CliChannel.Current</c>
-            /// </remarks>
-            Channel: string option
+        /// <summary>
+        /// Specifies the source channel for the installation. The possible values are:
+        /// <list type="number">
+        /// <item>
+        /// <c>Current</c> - Most current release.
+        /// </item>
+        /// <item>
+        /// <c>LTS</c> - Long-Term Support channel (most current supported release).
+        /// </item>
+        /// <item>
+        /// Two-part version in <c>X.Y</c> format representing a specific release (for example, <c>2.0</c> or
+        /// <c>1.0</c>).
+        /// </item>
+        /// <item>
+        /// Branch name. For example, release/2.0.0, release/2.0.0-preview2, or master (for nightly releases).
+        /// </item>
+        /// </list>
+        /// The default value is <c>LTS</c>. For more information on .NET support channels, see the
+        /// .NET Support Policy page.
+        /// </summary>
+        /// <remarks>
+        /// Use the <c>CliChannel</c> module, for example <c>CliChannel.Current</c>
+        /// </remarks>
+        Channel : string option
 
-            /// .NET Core SDK version
-            Version: CliVersion
+        /// .NET Core SDK version
+        Version : CliVersion
 
-            /// Custom installation directory (for local build installation)
-            CustomInstallDir: string option
+        /// Custom installation directory (for local build installation)
+        CustomInstallDir : string option
 
-            /// Always download and run the installer, ignore potentially existing installations.
-            ForceInstall: bool
+        /// Always download and run the installer, ignore potentially existing installations.
+        ForceInstall : bool
 
-            /// Architecture
-            Architecture: CliArchitecture
+        /// Architecture
+        Architecture : CliArchitecture
 
-            /// Include symbols in the installation (Switch does not work yet. Symbols zip is not being uploaded yet)
-            DebugSymbols: bool
+        /// Include symbols in the installation (Switch does not work yet. Symbols zip is not being uploaded yet)
+        DebugSymbols : bool
 
-            /// If set it will not perform installation but instead display what command line to use
-            DryRun: bool
+        /// If set it will not perform installation but instead display what command line to use
+        DryRun : bool
 
-            /// Do not update path variable
-            NoPath: bool
+        /// Do not update path variable
+        NoPath : bool
 
-            /// Command working directory
-            WorkingDirectory: string
-        }
+        /// Command working directory
+        WorkingDirectory : string
+    } with
 
         /// Parameter default values.
-        static member Default =
-            { InstallerOptions = id
-              Channel = None
-              Version = Latest
-              CustomInstallDir = None
-              ForceInstall = false
-              Architecture = Auto
-              DebugSymbols = false
-              DryRun = false
-              NoPath = true
-              WorkingDirectory = "." }
+        static member Default = {
+            InstallerOptions = id
+            Channel = None
+            Version = Latest
+            CustomInstallDir = None
+            ForceInstall = false
+            Architecture = Auto
+            DebugSymbols = false
+            DryRun = false
+            NoPath = true
+            WorkingDirectory = "."
+        }
 
     /// <summary>
     /// The a list of well-known versions to install
     /// </summary>
     module Versions =
         /// .NET Core SDK install options preconfigured for preview2 tooling
-        let internal Preview2ToolingOptions options =
-            { options with
+        let internal Preview2ToolingOptions options = {
+            options with
                 InstallerOptions = (fun io -> { io with Branch = "v1.0.0-preview2" })
                 Channel = Some "preview"
-                Version = Version "1.0.0-preview2-003121" }
+                Version = Version "1.0.0-preview2-003121"
+        }
 
         /// .NET Core SDK install options preconfigured for preview4 tooling
-        let internal LatestPreview4ToolingOptions options =
-            { options with
+        let internal LatestPreview4ToolingOptions options = {
+            options with
                 InstallerOptions = (fun io -> { io with Branch = "rel/1.0.0-preview4" })
                 Channel = None
-                Version = Latest }
+                Version = Latest
+        }
 
         /// .NET Core SDK install options preconfigured for preview4 tooling
-        let internal Preview4_004233ToolingOptions options =
-            { options with
+        let internal Preview4_004233ToolingOptions options = {
+            options with
                 InstallerOptions = (fun io -> { io with Branch = "rel/1.0.0-preview4" })
                 Channel = None
-                Version = Version "1.0.0-preview4-004233" }
+                Version = Version "1.0.0-preview4-004233"
+        }
 
         /// .NET Core SDK install options preconfigured for preview4 tooling
-        let internal RC4_004771ToolingOptions options =
-            { options with
+        let internal RC4_004771ToolingOptions options = {
+            options with
                 InstallerOptions = (fun io -> { io with Branch = "rel/1.0.0-rc3" })
                 Channel = None
-                Version = Version "1.0.0-rc4-004771" }
+                Version = Version "1.0.0-rc4-004771"
+        }
 
         /// .NET Core SDK install options preconfigured for preview4 tooling, this is marketized as v1.0.1
         /// release of the .NET Core tools
-        let internal RC4_004973ToolingOptions options =
-            { options with
+        let internal RC4_004973ToolingOptions options = {
+            options with
                 InstallerOptions = (fun io -> { io with Branch = "rel/1.0.1" })
                 Channel = None
-                Version = Version "1.0.3-rc4-004973" }
+                Version = Version "1.0.3-rc4-004973"
+        }
 
-        let Release_1_0_4 options =
-            { options with
+        let Release_1_0_4 options = {
+            options with
                 InstallerOptions = (fun io -> { io with Branch = "release/2.0.0" })
                 Channel = None
-                Version = Version "1.0.4" }
+                Version = Version "1.0.4"
+        }
 
-        let Release_2_0_0 options =
-            { options with
+        let Release_2_0_0 options = {
+            options with
                 InstallerOptions = (fun io -> { io with Branch = "release/2.0.0" })
                 Channel = None
-                Version = Version "2.0.0" }
+                Version = Version "2.0.0"
+        }
 
-        let Release_2_0_3 options =
-            { options with
+        let Release_2_0_3 options = {
+            options with
                 InstallerOptions = (fun io -> { io with Branch = "release/2.0.0" })
                 Channel = None
-                Version = Version "2.0.3" }
+                Version = Version "2.0.3"
+        }
 
-        let Release_2_1_4 options =
-            { options with
+        let Release_2_1_4 options = {
+            options with
                 InstallerOptions = (fun io -> { io with Branch = "release/2.1" })
                 Channel = None
-                Version = Version "2.1.4" }
+                Version = Version "2.1.4"
+        }
 
-        let Release_2_1_300_RC1 option =
-            { option with
+        let Release_2_1_300_RC1 option = {
+            option with
                 InstallerOptions = (fun io -> { io with Branch = "release/2.1" })
                 Channel = None
-                Version = Version "2.1.300-rc1-008673" }
+                Version = Version "2.1.300-rc1-008673"
+        }
 
-        let Release_2_1_300 option =
-            { option with
+        let Release_2_1_300 option = {
+            option with
                 InstallerOptions = (fun io -> { io with Branch = "release/2.1" })
                 Channel = None
-                Version = Version "2.1.300" }
+                Version = Version "2.1.300"
+        }
 
-        let Release_2_1_301 option =
-            { option with
+        let Release_2_1_301 option = {
+            option with
                 InstallerOptions = (fun io -> { io with Branch = "release/2.1" })
                 Channel = None
-                Version = Version "2.1.301" }
+                Version = Version "2.1.301"
+        }
 
-        let Release_2_1_302 option =
-            { option with
+        let Release_2_1_302 option = {
+            option with
                 InstallerOptions = (fun io -> { io with Branch = "release/2.1" })
                 Channel = None
-                Version = Version "2.1.302" }
+                Version = Version "2.1.302"
+        }
 
-        let Release_2_1_400 option =
-            { option with
+        let Release_2_1_400 option = {
+            option with
                 InstallerOptions = (fun io -> { io with Branch = "release/2.1" })
                 Channel = None
-                Version = Version "2.1.400" }
+                Version = Version "2.1.400"
+        }
 
-        let Release_2_1_401 option =
-            { option with
+        let Release_2_1_401 option = {
+            option with
                 InstallerOptions = (fun io -> { io with Branch = "release/2.1" })
                 Channel = None
-                Version = Version "2.1.401" }
+                Version = Version "2.1.401"
+        }
 
-        let Release_2_1_402 option =
-            { option with
+        let Release_2_1_402 option = {
+            option with
                 InstallerOptions = (fun io -> { io with Branch = "release/2.1" })
                 Channel = None
-                Version = Version "2.1.402" }
+                Version = Version "2.1.402"
+        }
 
-        let FromGlobalJson option =
-            { option with
+        let FromGlobalJson option = {
+            option with
                 InstallerOptions = id
                 Channel = None
-                Version = CliVersion.GlobalJson }
+                Version = CliVersion.GlobalJson
+        }
 
     let private optionToParam option paramFormat =
         match option with
@@ -447,7 +460,7 @@ module DotNet =
         | true -> flagParam
         | false -> ""
 
-    let private buildDotNetCliInstallArgs (param: CliInstallOptions) =
+    let private buildDotNetCliInstallArgs (param : CliInstallOptions) =
         let versionParamValue =
             match param.Version with
             | Latest -> "latest"
@@ -490,44 +503,43 @@ module DotNet =
     /// <summary>
     /// dotnet cli command execution options
     /// </summary>
-    type Options =
-        {
-            /// DotNet cli executable path
-            DotNetCliPath: string
+    type Options = {
+        /// DotNet cli executable path
+        DotNetCliPath : string
 
-            /// Write a global.json with the given version (required to make SDK choose the correct version)
-            Version: string option
+        /// Write a global.json with the given version (required to make SDK choose the correct version)
+        Version : string option
 
-            /// Command working directory
-            WorkingDirectory: string
+        /// Command working directory
+        WorkingDirectory : string
 
-            /// Process timeout, kills the process after the specified time
-            Timeout: TimeSpan option
+        /// Process timeout, kills the process after the specified time
+        Timeout : TimeSpan option
 
-            /// Custom parameters
-            CustomParams: string option
+        /// Custom parameters
+        CustomParams : string option
 
-            /// Logging verbosity (<c>--verbosity</c>)
-            Verbosity: Verbosity option
+        /// Logging verbosity (<c>--verbosity</c>)
+        Verbosity : Verbosity option
 
-            /// Restore logging verbosity (<c>--diagnostics</c>)
-            Diagnostics: bool
+        /// Restore logging verbosity (<c>--diagnostics</c>)
+        Diagnostics : bool
 
-            /// If true the function will redirect the output of the called process (but will disable colors, false
-            /// by default)
-            RedirectOutput: bool
+        /// If true the function will redirect the output of the called process (but will disable colors, false
+        /// by default)
+        RedirectOutput : bool
 
-            /// If RedirectOutput is true this flag decides if FAKE emits the output into the standard output/error
-            /// otherwise the flag is ignored.
-            /// True by default.
-            PrintRedirectedOutput: bool
+        /// If RedirectOutput is true this flag decides if FAKE emits the output into the standard output/error
+        /// otherwise the flag is ignored.
+        /// True by default.
+        PrintRedirectedOutput : bool
 
-            /// Gets the environment variables that apply to this process and its child processes.
-            /// NOTE: Recommendation is to not use this Field, but instead use the helper function in the Proc module
-            /// (for example <c>Process.setEnvironmentVariable</c>)
-            /// NOTE: This field is ignored when UseShellExecute is true.
-            Environment: Map<string, string>
-        }
+        /// Gets the environment variables that apply to this process and its child processes.
+        /// NOTE: Recommendation is to not use this Field, but instead use the helper function in the Proc module
+        /// (for example <c>Process.setEnvironmentVariable</c>)
+        /// NOTE: This field is ignored when UseShellExecute is true.
+        Environment : Map<string, string>
+    } with
 
         /// <summary>
         /// Create a default setup for executing the <c>dotnet</c> command line.
@@ -535,8 +547,8 @@ module DotNet =
         /// installation. To overwrite this behavior set <c>DotNetCliPath</c> manually (for example to the first
         /// result of <c>ProcessUtils.findFilesOnPath "dotnet"</c>)
         /// </summary>
-        static member Create() =
-            { DotNetCliPath =
+        static member Create () = {
+            DotNetCliPath =
                 let version = tryGetSDKVersionFromGlobalJson ()
 
                 findPossibleDotnetCliPaths None
@@ -549,65 +561,56 @@ module DotNet =
                         |> Directory.Exists
                     | None -> true)
                 |> Option.defaultWith (fun () -> if Environment.isUnix then "dotnet" else "dotnet.exe")
-              WorkingDirectory = Directory.GetCurrentDirectory()
-              Timeout = None
-              CustomParams = None
-              Version = None
-              Verbosity = None
-              Diagnostics = false
-              RedirectOutput = false
-              PrintRedirectedOutput = true
-              Environment =
+            WorkingDirectory = Directory.GetCurrentDirectory ()
+            Timeout = None
+            CustomParams = None
+            Version = None
+            Verbosity = None
+            Diagnostics = false
+            RedirectOutput = false
+            PrintRedirectedOutput = true
+            Environment =
                 Process.createEnvironmentMap ()
                 |> Map.remove "MSBUILD_EXE_PATH"
                 |> Map.remove "MSBuildExtensionsPath"
                 |> Map.remove "MSBuildLoadMicrosoftTargetsReadOnly"
                 |> Map.remove "MSBuildSDKsPath"
-                |> Map.remove "DOTNET_HOST_PATH" }
+                |> Map.remove "DOTNET_HOST_PATH"
+        }
 
         /// Sets the current environment variables.
         member x.WithEnvironment map = { x with Environment = map }
 
         /// Sets a value indicating whether the output for the given process is redirected.
-        member x.WithRedirectOutput shouldRedirect =
-            { x with RedirectOutput = shouldRedirect }
+        member x.WithRedirectOutput shouldRedirect = { x with RedirectOutput = shouldRedirect }
 
         /// Sets a value indicating whether the redirected output should be printed to standard-output/error stream.
-        member x.WithPrintRedirectedOutput shouldPrint =
-            { x with PrintRedirectedOutput = shouldPrint }
+        member x.WithPrintRedirectedOutput shouldPrint = { x with PrintRedirectedOutput = shouldPrint }
 
         /// Changes the "Common" properties according to the given function
         member inline x.WithCommon f = f x
 
     module Options =
-        let inline lift (f: Options -> Options) (x: ^a) =
-            let inline withCommon s e =
-                (^a: (member WithCommon: (Options -> Options) -> ^a) (s, e))
+        let inline lift (f : Options -> Options) (x : ^a) =
+            let inline withCommon s e = (^a : (member WithCommon : (Options -> Options) -> ^a) (s, e))
 
             withCommon x f
 
         let inline withEnvironment map x = lift (fun o -> o.WithEnvironment map) x
 
-        let inline withRedirectOutput shouldRedirect x =
-            lift (fun o -> o.WithRedirectOutput shouldRedirect) x
+        let inline withRedirectOutput shouldRedirect x = lift (fun o -> o.WithRedirectOutput shouldRedirect) x
 
-        let inline withRedirectedOutput shouldPrint x =
-            lift (fun o -> o.WithPrintRedirectedOutput shouldPrint) x
+        let inline withRedirectedOutput shouldPrint x = lift (fun o -> o.WithPrintRedirectedOutput shouldPrint) x
 
-        let inline withWorkingDirectory wd x =
-            lift (fun o -> { o with WorkingDirectory = wd }) x
+        let inline withWorkingDirectory wd x = lift (fun o -> { o with WorkingDirectory = wd }) x
 
-        let inline withTimeout t x =
-            lift (fun o -> { o with Timeout = t }) x
+        let inline withTimeout t x = lift (fun o -> { o with Timeout = t }) x
 
-        let inline withDiagnostics diag x =
-            lift (fun o -> { o with Diagnostics = diag }) x
+        let inline withDiagnostics diag x = lift (fun o -> { o with Diagnostics = diag }) x
 
-        let inline withVerbosity verb x =
-            lift (fun o -> { o with Verbosity = verb }) x
+        let inline withVerbosity verb x = lift (fun o -> { o with Verbosity = verb }) x
 
-        let inline withCustomParams args x =
-            lift (fun o -> { o with CustomParams = args }) x
+        let inline withCustomParams args x = lift (fun o -> { o with CustomParams = args }) x
 
         /// Sets custom command-line arguments expressed as a sequence of strings.
         /// This function overwrites and gets overwritten by `withCustomParams`.
@@ -620,11 +623,9 @@ module DotNet =
                  | x -> Some x))
                 x
 
-        let inline withDotNetCliPath path x =
-            lift (fun o -> { o with DotNetCliPath = path }) x
+        let inline withDotNetCliPath path x = lift (fun o -> { o with DotNetCliPath = path }) x
 
-    let private argList2 name values =
-        values |> List.collect (fun v -> [ "--" + name; v ])
+    let private argList2 name values = values |> List.collect (fun v -> [ "--" + name; v ])
 
     let private argOption name value =
         match value with
@@ -633,23 +634,27 @@ module DotNet =
 
     let private argOptionExplicit name value = [ sprintf "--%s=%A" name value ]
 
-    let private buildCommonArgs (param: Options) =
-        [ defaultArg param.CustomParams "" |> Args.fromWindowsCommandLine |> Seq.toList
-          param.Verbosity
-          |> Option.toList
-          |> List.map (fun v -> v.ToString().ToLowerInvariant())
-          |> argList2 "verbosity" ]
+    let private buildCommonArgs (param : Options) =
+        [
+            defaultArg param.CustomParams ""
+            |> Args.fromWindowsCommandLine
+            |> Seq.toList
+            param.Verbosity
+            |> Option.toList
+            |> List.map (fun v -> v.ToString().ToLowerInvariant ())
+            |> argList2 "verbosity"
+        ]
         |> List.concat
         |> List.filter (not << String.IsNullOrEmpty)
 
-    let private buildSdkOptionsArgs (param: Options) =
+    let private buildSdkOptionsArgs (param : Options) =
         [ param.Diagnostics |> argOption "--diagnostics" ]
         |> List.concat
         |> List.filter (not << String.IsNullOrEmpty)
 
     let internal withGlobalJsonDispose workDir version =
         let globalJsonPath =
-            if (Path.GetFullPath workDir).StartsWith(Path.GetFullPath ".") then
+            if (Path.GetFullPath workDir).StartsWith (Path.GetFullPath ".") then
                 "global.json"
             else
                 workDir </> "global.json"
@@ -664,14 +669,15 @@ module DotNet =
                     false
                 else
                     let template = sprintf """{ "sdk": { "version": "%s" } }""" version
-                    File.WriteAllText(globalJsonPath, template)
+                    File.WriteAllText (globalJsonPath, template)
                     true
             | _ -> false
 
         { new IDisposable with
-            member x.Dispose() =
+            member x.Dispose () =
                 if writtenJson then
-                    File.delete globalJsonPath }
+                    File.delete globalJsonPath
+        }
 
     let internal withGlobalJson workDir version f =
         use d = withGlobalJsonDispose workDir version
@@ -681,10 +687,12 @@ module DotNet =
         let sdkOptions = buildSdkOptionsArgs options
         let commonOptions = buildCommonArgs options
 
-        [ sdkOptions
-          command // |> Args.fromWindowsCommandLine |> Seq.toList
-          commonOptions
-          args ] // |> Args.fromWindowsCommandLine |> Seq.toList ]
+        [
+            sdkOptions
+            command // |> Args.fromWindowsCommandLine |> Seq.toList
+            commonOptions
+            args
+        ] // |> Args.fromWindowsCommandLine |> Seq.toList ]
         |> List.concat
 
     [<RequireQualifiedAccess>]
@@ -692,21 +700,21 @@ module DotNet =
         | UsePreviousFile
         | ReplaceWith of string list
 
-    let internal runRaw (firstArg: FirstArgReplacement) options (c: CreateProcess<'a>) =
+    let internal runRaw (firstArg : FirstArgReplacement) options (c : CreateProcess<'a>) =
         //let timeout = TimeSpan.MaxValue
-        let results = System.Collections.Generic.List<ConsoleMessage>()
+        let results = System.Collections.Generic.List<ConsoleMessage> ()
 
         let errorF msg =
             if options.PrintRedirectedOutput then
                 Trace.traceError msg
 
-            results.Add(ConsoleMessage.CreateError msg)
+            results.Add (ConsoleMessage.CreateError msg)
 
         let messageF msg =
             if options.PrintRedirectedOutput then
                 Trace.trace msg
 
-            results.Add(ConsoleMessage.CreateOut msg)
+            results.Add (ConsoleMessage.CreateOut msg)
 
         let dir = Path.GetDirectoryName options.DotNetCliPath
         let oldPath = options |> Process.getEnvironmentVariable "PATH"
@@ -715,10 +723,12 @@ module DotNet =
             match firstArg with
             | FirstArgReplacement.UsePreviousFile -> Arguments.withPrefix [ c.Command.Executable ] c.Command.Arguments
             | FirstArgReplacement.ReplaceWith args ->
-                (Arguments.ofList args).ToStartInfo + " " + c.Command.Arguments.ToStartInfo
+                (Arguments.ofList args).ToStartInfo
+                + " "
+                + c.Command.Arguments.ToStartInfo
                 |> Arguments.OfStartInfo
 
-        let cmd = RawCommand(options.DotNetCliPath, newArgs)
+        let cmd = RawCommand (options.DotNetCliPath, newArgs)
 
         c
         |> CreateProcess.withCommand cmd
@@ -739,7 +749,7 @@ module DotNet =
             (fun _ -> withGlobalJsonDispose options.WorkingDirectory options.Version)
             (fun state p -> ())
             (fun prev state exitCode -> prev)
-            (fun s -> s.Dispose())
+            (fun s -> s.Dispose ())
         |> (if options.RedirectOutput then
                 CreateProcess.redirectOutputIfNotRedirected
                 >> CreateProcess.withOutputEventsNotNull messageF errorF
@@ -748,12 +758,12 @@ module DotNet =
         |> CreateProcess.map (fun prev -> prev, (results |> List.ofSeq))
 
     let internal run cmdArgs options : ProcessResult =
-        CreateProcess.fromCommand (Command.RawCommand(options.DotNetCliPath, Arguments.ofList (List.ofSeq cmdArgs)))
+        CreateProcess.fromCommand (Command.RawCommand (options.DotNetCliPath, Arguments.ofList (List.ofSeq cmdArgs)))
         |> runRaw (FirstArgReplacement.ReplaceWith []) options
         |> CreateProcess.map (fun (r, results) -> ProcessResult.New r.ExitCode results)
         |> Proc.run
 
-    let internal setOptions (buildOptions: Options -> Options) = buildOptions (Options.Create())
+    let internal setOptions (buildOptions : Options -> Options) = buildOptions (Options.Create ())
 
     /// <summary>
     /// Execute raw dotnet cli command
@@ -762,14 +772,11 @@ module DotNet =
     /// <param name="buildOptions">build common execution options</param>
     /// <param name="command">the sdk command to execute <c>test</c>, <c>new</c>, <c>build</c>, ...</param>
     /// <param name="args">command arguments</param>
-    let exec (buildOptions: Options -> Options) (command: string) (args: string) =
+    let exec (buildOptions : Options -> Options) (command : string) (args : string) =
         let options = setOptions buildOptions
 
         let cmdArgs =
-            buildCommand
-                (command |> Args.fromWindowsCommandLine |> Seq.toList)
-                (args |> Args.fromWindowsCommandLine |> Seq.toList)
-                options
+            buildCommand (command |> Args.fromWindowsCommandLine |> Seq.toList) (args |> Args.fromWindowsCommandLine |> Seq.toList) options
 
         run cmdArgs options
 
@@ -780,7 +787,7 @@ module DotNet =
     /// <param name="buildOptions">build common execution options</param>
     /// <param name="firstArg">the first argument (like t)</param>
     /// <param name="args">command arguments</param>
-    let prefixProcess (buildOptions: Options -> Options) (firstArgs: string list) (c: CreateProcess<'a>) =
+    let prefixProcess (buildOptions : Options -> Options) (firstArgs : string list) (c : CreateProcess<'a>) =
         let options = setOptions buildOptions
 
         c
@@ -794,7 +801,7 @@ module DotNet =
     /// </summary>
     ///
     /// <param name="install">The SDK to use (result of <c>DotNet.install</c>)</param>
-    let setupEnv (install: Options -> Options) =
+    let setupEnv (install : Options -> Options) =
         let options = setOptions install
         let dotnetTool = Path.GetFullPath options.DotNetCliPath
         let dotnetFolder = Path.GetDirectoryName dotnetTool
@@ -803,8 +810,7 @@ module DotNet =
         match currentPath with
         | null
         | "" -> Environment.setEnvironVar "PATH" dotnetFolder
-        | _ when not (currentPath.Contains dotnetFolder) ->
-            Environment.setEnvironVar "PATH" (dotnetFolder + string Path.PathSeparator + currentPath)
+        | _ when not (currentPath.Contains dotnetFolder) -> Environment.setEnvironVar "PATH" (dotnetFolder + string Path.PathSeparator + currentPath)
         | _ -> ()
 
         let currentDotNetRoot = Environment.environVar "DOTNET_ROOT"
@@ -814,11 +820,10 @@ module DotNet =
 #if !FX_NO_POSIX
                 // resolve potential symbolic link to the real location
                 // https://stackoverflow.com/questions/58326739/how-can-i-find-the-target-of-a-linux-symlink-in-c-sharp
-                Mono.Unix.UnixPath.GetRealPath(dotnetTool) |> Path.GetDirectoryName
+                Mono.Unix.UnixPath.GetRealPath (dotnetTool)
+                |> Path.GetDirectoryName
 #else
-                eprintf
-                    "Setting 'DOTNET_ROOT' to '%s' this might be wrong as we didn't follow the symlink. Please upgrade to netcore."
-                    dotnetFolder
+                eprintf "Setting 'DOTNET_ROOT' to '%s' this might be wrong as we didn't follow the symlink. Please upgrade to netcore." dotnetFolder
 
                 dotnetFolder
 #endif
@@ -834,26 +839,24 @@ module DotNet =
     /// <summary>
     /// dotnet --info command options
     /// </summary>
-    type InfoOptions =
-        {
-            /// Common tool options
-            Common: Options
-        }
+    type InfoOptions = {
+        /// Common tool options
+        Common : Options
+    } with
 
         /// Parameter default values.
-        static member Create() =
-            { Common = Options.Create().WithRedirectOutput(true).WithPrintRedirectedOutput(false) }
+        static member Create () = {
+            Common = Options.Create().WithRedirectOutput(true).WithPrintRedirectedOutput (false)
+        }
 
         /// Gets the current environment
         member x.Environment = x.Common.Environment
 
         /// Sets the current environment variables.
-        member x.WithEnvironment map =
-            { x with Common = { x.Common with Environment = map } }
+        member x.WithEnvironment map = { x with Common = { x.Common with Environment = map } }
 
         /// Sets a value indicating whether the output for the given process is redirected.
-        member x.WithRedirectOutput shouldRedirect =
-            { x with Common = x.Common.WithRedirectOutput shouldRedirect }
+        member x.WithRedirectOutput shouldRedirect = { x with Common = x.Common.WithRedirectOutput shouldRedirect }
 
         /// Changes the "Common" properties according to the given function
         member inline x.WithCommon f = { x with Common = f x.Common }
@@ -861,11 +864,10 @@ module DotNet =
     /// <summary>
     /// dotnet info result
     /// </summary>
-    type InfoResult =
-        {
-            /// Common tool options
-            RID: string
-        }
+    type InfoResult = {
+        /// Common tool options
+        RID : string
+    }
 
     /// <summary>
     /// Execute dotnet --info command
@@ -874,14 +876,14 @@ module DotNet =
     /// <param name="setParams">set info command parameters</param>
     let info setParams =
         use __ = Trace.traceTask "DotNet:info" "running dotnet --info"
-        let param = InfoOptions.Create() |> setParams
+        let param = InfoOptions.Create () |> setParams
         let args = "--info" // project (buildPackArgs param)
         let result = exec (fun _ -> param.Common) "" args
 
         let rawOutput =
             result.Results
             |> Seq.map (fun c -> sprintf "%s: %s" (if c.IsError then "stderr: " else "stdout: ") c.Message)
-            |> fun s -> String.Join("\n", s)
+            |> fun s -> String.Join ("\n", s)
 
         if not result.OK then
             failwithf "dotnet --info failed with code '%i': \n%s" result.ExitCode rawOutput
@@ -889,27 +891,25 @@ module DotNet =
         let rid =
             result.Messages
             |> Seq.tryFind (fun m -> m.Contains "RID:")
-            |> Option.map (fun line -> line.Split([| ':' |]).[1].Trim())
+            |> Option.map (fun line -> line.Split([| ':' |]).[1].Trim ())
 
         if rid.IsNone then
             failwithf "could not read rid from output: \n%s" rawOutput
 
-        __.MarkSuccess()
+        __.MarkSuccess ()
         { RID = rid.Value }
 
 
     /// <summary>
     /// dotnet --version command options
     /// </summary>
-    type VersionOptions =
-        {
-            /// Common tool options
-            Common: Options
-        }
+    type VersionOptions = {
+        /// Common tool options
+        Common : Options
+    } with
 
         /// Parameter default values.
-        static member Create() =
-            { Common = Options.Create().WithRedirectOutput true }
+        static member Create () = { Common = Options.Create().WithRedirectOutput true }
 
         /// Gets the current environment
         member x.Environment = x.Common.Environment
@@ -918,12 +918,10 @@ module DotNet =
         member inline x.WithCommon f = { x with Common = f x.Common }
 
         /// Sets the current environment variables.
-        member x.WithEnvironment map =
-            x.WithCommon(fun c -> { c with Environment = map })
+        member x.WithEnvironment map = x.WithCommon (fun c -> { c with Environment = map })
 
         /// Sets a value indicating whether the output for the given process is redirected.
-        member x.WithRedirectOutput shouldRedirect =
-            { x with Common = x.Common.WithRedirectOutput shouldRedirect }
+        member x.WithRedirectOutput shouldRedirect = { x with Common = x.Common.WithRedirectOutput shouldRedirect }
 
 
     /// <summary>
@@ -938,7 +936,7 @@ module DotNet =
     /// <param name="setParams">set version command parameters</param>
     let getVersion setParams =
         use __ = Trace.traceTask "DotNet:version" "running dotnet --version"
-        let param = VersionOptions.Create() |> setParams
+        let param = VersionOptions.Create () |> setParams
         let args = "--version"
         let result = exec (fun _ -> param.Common) "" args
 
@@ -948,9 +946,9 @@ module DotNet =
         let version = result.Messages |> String.separated "\n" |> String.trim
 
         if String.isNullOrWhiteSpace version then
-            failwithf "could not read version from output: \n%s" (String.Join("\n", result.Messages))
+            failwithf "could not read version from output: \n%s" (String.Join ("\n", result.Messages))
 
-        __.MarkSuccess()
+        __.MarkSuccess ()
         version
 
     /// <summary>
@@ -968,7 +966,7 @@ module DotNet =
             | Version version -> Some version, false
             | CliVersion.Coherent -> None, false
             | CliVersion.Latest -> None, false
-            | CliVersion.GlobalJson -> Some(getSDKVersionFromGlobalJson ()), true
+            | CliVersion.GlobalJson -> Some (getSDKVersionFromGlobalJson ()), true
 
         let dotnetInstallations =
             if param.ForceInstall then
@@ -986,11 +984,7 @@ module DotNet =
                     |> Seq.tryFind (fun dotnet ->
                         try
                             let result =
-                                getVersion (fun opt ->
-                                    opt.WithCommon(fun c ->
-                                        { c with
-                                            DotNetCliPath = dotnet
-                                            Version = None }))
+                                getVersion (fun opt -> opt.WithCommon (fun c -> { c with DotNetCliPath = dotnet; Version = None }))
 
                             result = version
                         with e ->
@@ -998,9 +992,7 @@ module DotNet =
                                 not (e.Message.Contains "dotnet --info failed with code")
                                 || not (e.Message.Contains "global.json")
                             then
-                                Trace.traceFAKE
-                                    "Retrieving version failed, assuming because it doesn't match global.json, error was: %O"
-                                    e
+                                Trace.traceFAKE "Retrieving version failed, assuming because it doesn't match global.json, error was: %O" e
 
                             false)),
                 passVersion
@@ -1012,21 +1004,17 @@ module DotNet =
         | Some dotnet, passVersion ->
             Trace.traceVerbose "Suitable dotnet installation found, skipping .NET SDK installer."
 
-            (fun opt ->
-                { opt with
-                    DotNetCliPath = dotnet
-                    Version = passVersion })
+            (fun opt -> { opt with DotNetCliPath = dotnet; Version = passVersion })
         | _ ->
 
             let passVersion = if fromGlobalJson then None else checkVersion
             let installScript = downloadInstaller param.InstallerOptions
 
             // check if existing processes exists:
-            let dotnetExe =
-                Path.Combine(dir, (if Environment.isUnix then "dotnet" else "dotnet.exe"))
+            let dotnetExe = Path.Combine (dir, (if Environment.isUnix then "dotnet" else "dotnet.exe"))
 
-            if Environment.isWindows && File.Exists(dotnetExe) then
-                System.Diagnostics.Process.GetProcesses()
+            if Environment.isWindows && File.Exists (dotnetExe) then
+                System.Diagnostics.Process.GetProcesses ()
                 |> Seq.filter (fun p ->
                     try
                         not p.HasExited
@@ -1034,7 +1022,7 @@ module DotNet =
                         false)
                 |> Seq.filter (fun p ->
                     try
-                        Path.GetFullPath(Process.getFileName p).ToLowerInvariant() = Path.GetFullPath(dotnetExe)
+                        Path.GetFullPath(Process.getFileName p).ToLowerInvariant () = Path.GetFullPath (dotnetExe)
                     with _ ->
                         false)
                 |> Seq.iter Process.kill
@@ -1059,9 +1047,7 @@ module DotNet =
                             |> Arguments.appendIf true "-NonInteractive"
                             // Note: The & is required when the script path contains spaces, see https://stackoverflow.com/questions/45760457/how-to-run-a-powershell-script-with-white-spaces-in-path-from-command-line
                             // powershell really is a waste of time
-                            |> Arguments.appendNotEmpty
-                                "-Command"
-                                (sprintf "& %s; if (-not $?) { exit -1 };" command.ToWindowsCommandLine)
+                            |> Arguments.appendNotEmpty "-Command" (sprintf "& %s; if (-not $?) { exit -1 };" command.ToWindowsCommandLine)
 
                         args, "powershell"
 
@@ -1077,85 +1063,81 @@ module DotNet =
                 // force download new installer script
                 Trace.traceError ".NET Core SDK install failed, trying to re-download installer..."
 
-                downloadInstaller (param.InstallerOptions >> (fun o -> { o with AlwaysDownload = true }))
+                downloadInstaller (
+                    param.InstallerOptions
+                    >> (fun o -> { o with AlwaysDownload = true })
+                )
                 |> ignore
 
                 failwithf ".NET Core SDK install failed with code %i" exitCode
 
-            let exe = dir @@ (if Environment.isUnix then "dotnet" else "dotnet.exe")
+            let exe =
+                dir
+                @@ (if Environment.isUnix then "dotnet" else "dotnet.exe")
             Trace.tracefn ".NET Core SDK installed to %s" exe
 
-            (fun opt ->
-                { opt with
-                    DotNetCliPath = exe
-                    Version = passVersion })
+            (fun opt -> { opt with DotNetCliPath = exe; Version = passVersion })
 
     /// <summary>
     /// dotnet restore command options
     /// </summary>
-    type MSBuildOptions =
-        {
-            /// Common tool options
-            Common: Options
+    type MSBuildOptions = {
+        /// Common tool options
+        Common : Options
 
-            /// MSBuild parameters
-            MSBuildParams: MSBuild.CliArguments
-        }
+        /// MSBuild parameters
+        MSBuildParams : MSBuild.CliArguments
+    } with
 
         /// Parameter default values.
-        static member Create() =
-            { Common = Options.Create()
-              MSBuildParams = MSBuild.CliArguments.Create() }
+        static member Create () = { Common = Options.Create (); MSBuildParams = MSBuild.CliArguments.Create () }
 
         /// Gets the current environment
         member x.Environment = x.Common.Environment
 
         /// Sets the current environment variables.
-        member x.WithEnvironment map =
-            { x with Common = { x.Common with Environment = map } }
+        member x.WithEnvironment map = { x with Common = { x.Common with Environment = map } }
 
         /// Sets a value indicating whether the output for the given process is redirected.
-        member x.WithRedirectOutput shouldRedirect =
-            { x with Common = x.Common.WithRedirectOutput shouldRedirect }
+        member x.WithRedirectOutput shouldRedirect = { x with Common = x.Common.WithRedirectOutput shouldRedirect }
 
         /// Changes the "Common" properties according to the given function
         member inline x.WithCommon f = { x with Common = f x.Common }
 
         /// Changes the "MSBuildParams" properties according to the given function
-        member inline x.WithMSBuildParams f =
-            { x with MSBuildParams = f x.MSBuildParams }
+        member inline x.WithMSBuildParams f = { x with MSBuildParams = f x.MSBuildParams }
 
-    let internal addBinaryLogger disableFakeBinLog args (common: Options) =
+    let internal addBinaryLogger disableFakeBinLog args (common : Options) =
         // used for detection
         let callMsBuildExe args =
             let result =
                 exec
-                    (fun _ ->
-                        { RedirectOutput = true
-                          PrintRedirectedOutput = true
-                          DotNetCliPath = common.DotNetCliPath
-                          Version = common.Version
-                          Environment = common.Environment
-                          WorkingDirectory = common.WorkingDirectory
-                          Timeout = None
-                          CustomParams = None
-                          Verbosity = None
-                          Diagnostics = false })
+                    (fun _ -> {
+                        RedirectOutput = true
+                        PrintRedirectedOutput = true
+                        DotNetCliPath = common.DotNetCliPath
+                        Version = common.Version
+                        Environment = common.Environment
+                        WorkingDirectory = common.WorkingDirectory
+                        Timeout = None
+                        CustomParams = None
+                        Verbosity = None
+                        Diagnostics = false
+                    })
                     "msbuild"
                     args
 
             if not result.OK then
                 failwithf "msbuild failed with exit code '%d'" result.ExitCode
 
-            String.Join("\n", result.Messages)
+            String.Join ("\n", result.Messages)
 
         MSBuild.addBinaryLogger (common.DotNetCliPath + " msbuild") callMsBuildExe args disableFakeBinLog
 
     let internal execWithBinLog project common command args msBuildArgs =
         let argString = MSBuild.fromCliArguments msBuildArgs
 
-        let binLogPath, args =
-            addBinaryLogger msBuildArgs.DisableInternalBinLog (args + " " + argString) common
+        let binLogPath, args = addBinaryLogger msBuildArgs.DisableInternalBinLog (args + " " + argString) common
 
         let result = exec (fun _ -> common) command args
         MSBuild.handleAfterRun (sprintf "dotnet %s" command) binLogPath result.ExitCode project
@@ -1163,8 +1145,7 @@ module DotNet =
     let internal tryExecWithBinLog project common command args msBuildArgs =
         let argString = MSBuild.fromCliArguments msBuildArgs
 
-        let binLogPath, args =
-            addBinaryLogger msBuildArgs.DisableInternalBinLog (args + " " + argString) common
+        let binLogPath, args = addBinaryLogger msBuildArgs.DisableInternalBinLog (args + " " + argString) common
 
         let result = exec (fun _ -> common) command args
 
@@ -1172,7 +1153,7 @@ module DotNet =
             MSBuild.handleAfterRun (sprintf "dotnet %s" command) binLogPath result.ExitCode project
             Choice1Of2 result
         with e ->
-            Choice2Of2(e, result)
+            Choice2Of2 (e, result)
 
     /// <summary>
     /// Runs a MSBuild project
@@ -1206,17 +1187,17 @@ module DotNet =
     let msbuild setParams project =
         use __ = Trace.traceTask "DotNet:msbuild" project
 
-        let param = MSBuildOptions.Create() |> setParams
+        let param = MSBuildOptions.Create () |> setParams
         let args = [ project ]
         let args = Args.toWindowsCommandLine args
         execWithBinLog project param.Common "msbuild" args param.MSBuildParams
-        __.MarkSuccess()
+        __.MarkSuccess ()
 
     // TODO: Make this API public? change return code?
     let internal msbuildWithResult setParams project =
         //use __ = Trace.traceTask "DotNet:msbuild" project
 
-        let param = MSBuildOptions.Create() |> setParams
+        let param = MSBuildOptions.Create () |> setParams
         let args = [ project ]
         let args = Args.toWindowsCommandLine args
         let r = tryExecWithBinLog project param.Common "msbuild" args param.MSBuildParams
@@ -1227,71 +1208,72 @@ module DotNet =
     /// <summary>
     /// dotnet restore command options
     /// </summary>
-    type RestoreOptions =
-        {
-            /// Common tool options
-            Common: Options
+    type RestoreOptions = {
+        /// Common tool options
+        Common : Options
 
-            /// The runtime to restore for (seems added in RC4). Maybe a bug, but works.
-            Runtime: string option
+        /// The runtime to restore for (seems added in RC4). Maybe a bug, but works.
+        Runtime : string option
 
-            /// Nuget feeds to search updates in. Use default if empty.
-            Sources: string list
+        /// Nuget feeds to search updates in. Use default if empty.
+        Sources : string list
 
-            /// Directory to install packages in (<c>--packages</c>).
-            Packages: string list
+        /// Directory to install packages in (<c>--packages</c>).
+        Packages : string list
 
-            /// Path to the nuget configuration file (<c>nuget.config</c>).
-            ConfigFile: string option
+        /// Path to the nuget configuration file (<c>nuget.config</c>).
+        ConfigFile : string option
 
-            /// No cache flag (<c>--no-cache</c>)
-            NoCache: bool
+        /// No cache flag (<c>--no-cache</c>)
+        NoCache : bool
 
-            /// Only warning failed sources if there are packages meeting version requirement
-            /// (<c>--ignore-failed-sources</c>)
-            IgnoreFailedSources: bool
+        /// Only warning failed sources if there are packages meeting version requirement
+        /// (<c>--ignore-failed-sources</c>)
+        IgnoreFailedSources : bool
 
-            /// Disables restoring multiple projects in parallel (<c>--disable-parallel</c>)
-            DisableParallel: bool
+        /// Disables restoring multiple projects in parallel (<c>--disable-parallel</c>)
+        DisableParallel : bool
 
-            /// Other msbuild specific parameters
-            MSBuildParams: MSBuild.CliArguments
-        }
+        /// Other msbuild specific parameters
+        MSBuildParams : MSBuild.CliArguments
+    } with
 
         /// Parameter default values.
-        static member Create() =
-            { Common = Options.Create()
-              Sources = []
-              Runtime = None
-              Packages = []
-              ConfigFile = None
-              NoCache = false
-              IgnoreFailedSources = false
-              DisableParallel = false
-              MSBuildParams = MSBuild.CliArguments.Create() }
+        static member Create () = {
+            Common = Options.Create ()
+            Sources = []
+            Runtime = None
+            Packages = []
+            ConfigFile = None
+            NoCache = false
+            IgnoreFailedSources = false
+            DisableParallel = false
+            MSBuildParams = MSBuild.CliArguments.Create ()
+        }
 
         /// Gets the current environment
         member x.Environment = x.Common.Environment
 
         /// Sets the current environment variables.
-        member x.WithEnvironment map =
-            { x with Common = { x.Common with Environment = map } }
+        member x.WithEnvironment map = { x with Common = { x.Common with Environment = map } }
 
         /// Sets a value indicating whether the output for the given process is redirected.
-        member x.WithRedirectOutput shouldRedirect =
-            { x with Common = x.Common.WithRedirectOutput shouldRedirect }
+        member x.WithRedirectOutput shouldRedirect = { x with Common = x.Common.WithRedirectOutput shouldRedirect }
 
         /// Changes the "Common" properties according to the given function
         member inline x.WithCommon f = { x with Common = f x.Common }
 
-    let private buildRestoreArgs (param: RestoreOptions) =
-        [ param.Sources |> argList2 "source"
-          param.Packages |> argList2 "packages"
-          param.ConfigFile |> Option.toList |> argList2 "configfile"
-          param.NoCache |> argOption "no-cache"
-          param.Runtime |> Option.toList |> argList2 "runtime"
-          param.IgnoreFailedSources |> argOption "ignore-failed-sources"
-          param.DisableParallel |> argOption "disable-parallel" ]
+    let private buildRestoreArgs (param : RestoreOptions) =
+        [
+            param.Sources |> argList2 "source"
+            param.Packages |> argList2 "packages"
+            param.ConfigFile |> Option.toList |> argList2 "configfile"
+            param.NoCache |> argOption "no-cache"
+            param.Runtime |> Option.toList |> argList2 "runtime"
+            param.IgnoreFailedSources
+            |> argOption "ignore-failed-sources"
+            param.DisableParallel |> argOption "disable-parallel"
+        ]
         |> List.concat
         |> List.filter (not << String.IsNullOrEmpty)
 
@@ -1304,10 +1286,10 @@ module DotNet =
     /// <param name="project">project to restore packages</param>
     let restore setParams project =
         use __ = Trace.traceTask "DotNet:restore" project
-        let param = RestoreOptions.Create() |> setParams
+        let param = RestoreOptions.Create () |> setParams
         let args = Args.toWindowsCommandLine (project :: buildRestoreArgs param)
         execWithBinLog project param.Common "restore" args param.MSBuildParams
-        __.MarkSuccess()
+        __.MarkSuccess ()
 
     /// build configuration
     type BuildConfiguration =
@@ -1316,7 +1298,7 @@ module DotNet =
         | Custom of string
 
         /// Convert the build configuration to a string that can be passed to the .NET CLI
-        override this.ToString() =
+        override this.ToString () =
             match this with
             | Debug -> "Debug"
             | Release -> "Release"
@@ -1328,95 +1310,98 @@ module DotNet =
     [<RequireQualifiedAccess>]
     module BuildConfiguration =
         /// Parse a build configuration string
-        let fromString (s: string) =
-            match s.ToLowerInvariant() with
+        let fromString (s : string) =
+            match s.ToLowerInvariant () with
             | "debug" -> Debug
             | "release" -> Release
             | _ -> Custom s
 
         /// Get the build configuration from an environment variable with the given name or returns
         /// the default if not value was set
-        let fromEnvironVarOrDefault (name: string) (defaultValue: BuildConfiguration) =
+        let fromEnvironVarOrDefault (name : string) (defaultValue : BuildConfiguration) =
             match Environment.environVarOrNone name with
             | Some config -> fromString config
             | None -> defaultValue
 
-    let private buildConfigurationArg (param: BuildConfiguration) =
-        argList2 "configuration" [ param.ToString() ]
+    let private buildConfigurationArg (param : BuildConfiguration) = argList2 "configuration" [ param.ToString () ]
 
     /// <summary>
     /// dotnet pack command options
     /// </summary>
-    type PackOptions =
-        {
-            /// Common tool options
-            Common: Options
+    type PackOptions = {
+        /// Common tool options
+        Common : Options
 
-            /// Pack configuration (<c>--configuration</c>)
-            Configuration: BuildConfiguration
+        /// Pack configuration (<c>--configuration</c>)
+        Configuration : BuildConfiguration
 
-            /// Version suffix to use
-            VersionSuffix: string option
+        /// Version suffix to use
+        VersionSuffix : string option
 
-            /// Build base path (<c>--build-base-path</c>)
-            BuildBasePath: string option
+        /// Build base path (<c>--build-base-path</c>)
+        BuildBasePath : string option
 
-            /// Output path (<c>--output</c>)
-            OutputPath: string option
+        /// Output path (<c>--output</c>)
+        OutputPath : string option
 
-            /// Don't show copyright messages. (<c>--nologo</c>)
-            NoLogo: bool
+        /// Don't show copyright messages. (<c>--nologo</c>)
+        NoLogo : bool
 
-            /// No build flag (<c>--no-build</c>)
-            NoBuild: bool
+        /// No build flag (<c>--no-build</c>)
+        NoBuild : bool
 
-            /// Doesn't execute an implicit restore when running the command. (<c>--no-restore</c>)
-            NoRestore: bool
+        /// Doesn't execute an implicit restore when running the command. (<c>--no-restore</c>)
+        NoRestore : bool
 
-            /// Other msbuild specific parameters
-            MSBuildParams: MSBuild.CliArguments
+        /// Other msbuild specific parameters
+        MSBuildParams : MSBuild.CliArguments
 
-            /// Includes the debug symbols NuGet packages in addition to the regular NuGet packages in the output
-            /// directory (<c>--include-symbols</c>)
-            IncludeSymbols: bool
-        }
+        /// Includes the debug symbols NuGet packages in addition to the regular NuGet packages in the output
+        /// directory (<c>--include-symbols</c>)
+        IncludeSymbols : bool
+    } with
 
         /// Parameter default values.
-        static member Create() =
-            { Common = Options.Create()
-              Configuration = Release
-              VersionSuffix = None
-              BuildBasePath = None
-              OutputPath = None
-              NoLogo = false
-              NoBuild = false
-              NoRestore = false
-              MSBuildParams = MSBuild.CliArguments.Create()
-              IncludeSymbols = false }
+        static member Create () = {
+            Common = Options.Create ()
+            Configuration = Release
+            VersionSuffix = None
+            BuildBasePath = None
+            OutputPath = None
+            NoLogo = false
+            NoBuild = false
+            NoRestore = false
+            MSBuildParams = MSBuild.CliArguments.Create ()
+            IncludeSymbols = false
+        }
 
         /// Gets the current environment
         member x.Environment = x.Common.Environment
 
         /// Sets the current environment variables.
-        member x.WithEnvironment map =
-            { x with Common = { x.Common with Environment = map } }
+        member x.WithEnvironment map = { x with Common = { x.Common with Environment = map } }
 
         /// Sets a value indicating whether the output for the given process is redirected.
-        member x.WithRedirectOutput shouldRedirect =
-            { x with Common = x.Common.WithRedirectOutput shouldRedirect }
+        member x.WithRedirectOutput shouldRedirect = { x with Common = x.Common.WithRedirectOutput shouldRedirect }
 
         /// Changes the "Common" properties according to the given function
         member inline x.WithCommon f = { x with Common = f x.Common }
 
-    let private buildPackArgs (param: PackOptions) =
-        [ buildConfigurationArg param.Configuration
-          param.VersionSuffix |> Option.toList |> argList2 "version-suffix"
-          param.BuildBasePath |> Option.toList |> argList2 "build-base-path"
-          param.OutputPath |> Option.toList |> argList2 "output"
-          param.NoLogo |> argOption "nologo"
-          param.NoBuild |> argOption "no-build"
-          param.NoRestore |> argOption "no-restore"
-          param.IncludeSymbols |> argOption "include-symbols" ]
+    let private buildPackArgs (param : PackOptions) =
+        [
+            buildConfigurationArg param.Configuration
+            param.VersionSuffix
+            |> Option.toList
+            |> argList2 "version-suffix"
+            param.BuildBasePath
+            |> Option.toList
+            |> argList2 "build-base-path"
+            param.OutputPath |> Option.toList |> argList2 "output"
+            param.NoLogo |> argOption "nologo"
+            param.NoBuild |> argOption "no-build"
+            param.NoRestore |> argOption "no-restore"
+            param.IncludeSymbols |> argOption "include-symbols"
+        ]
         |> List.concat
         |> List.filter (not << String.IsNullOrEmpty)
 
@@ -1441,111 +1426,120 @@ module DotNet =
     /// </example>
     let pack setParams project =
         use __ = Trace.traceTask "DotNet:pack" project
-        let param = PackOptions.Create() |> setParams
+        let param = PackOptions.Create () |> setParams
         let args = Args.toWindowsCommandLine (project :: buildPackArgs param)
         execWithBinLog project param.Common "pack" args param.MSBuildParams
-        __.MarkSuccess()
+        __.MarkSuccess ()
 
     /// <summary>
     /// dotnet publish command options
     /// </summary>
-    type PublishOptions =
-        {
-            /// Common tool options
-            Common: Options
+    type PublishOptions = {
+        /// Common tool options
+        Common : Options
 
-            /// Pack configuration (<c>--configuration</c>)
-            Configuration: BuildConfiguration
+        /// Pack configuration (<c>--configuration</c>)
+        Configuration : BuildConfiguration
 
-            /// Target framework to compile for (<c>--framework</c>)
-            Framework: string option
+        /// Target framework to compile for (<c>--framework</c>)
+        Framework : string option
 
-            /// Target runtime to publish for (<c>--runtime</c>)
-            Runtime: string option
+        /// Target runtime to publish for (<c>--runtime</c>)
+        Runtime : string option
 
-            /// Build base path (<c>--build-base-path</c>)
-            BuildBasePath: string option
+        /// Build base path (<c>--build-base-path</c>)
+        BuildBasePath : string option
 
-            /// Output path (<c>--output</c>)
-            OutputPath: string option
+        /// Output path (<c>--output</c>)
+        OutputPath : string option
 
-            /// Defines what <c>*</c> should be replaced with in version field in project.json
-            /// (<c>--version-suffix</c>)
-            VersionSuffix: string option
+        /// Defines what <c>*</c> should be replaced with in version field in project.json
+        /// (<c>--version-suffix</c>)
+        VersionSuffix : string option
 
-            /// Specifies one or several target manifests to use to trim the set of packages published with the app.
-            /// The manifest file is part of the output of the dotnet store command.
-            /// This option is available starting with .NET Core 2.0 SDK. (<c>--manifest</c>)
-            Manifest: string list option
+        /// Specifies one or several target manifests to use to trim the set of packages published with the app.
+        /// The manifest file is part of the output of the dotnet store command.
+        /// This option is available starting with .NET Core 2.0 SDK. (<c>--manifest</c>)
+        Manifest : string list option
 
-            /// Publish the .NET Core runtime with your application so the runtime doesn't need to be installed on
-            /// the target machine. The default is 'true' if a runtime identifier is specified.
-            /// (<c>--self-contained</c>)
-            SelfContained: bool option
+        /// Publish the .NET Core runtime with your application so the runtime doesn't need to be installed on
+        /// the target machine. The default is 'true' if a runtime identifier is specified.
+        /// (<c>--self-contained</c>)
+        SelfContained : bool option
 
-            /// Don't show copyright messages. (<c>--nologo</c>)
-            NoLogo: bool
+        /// Don't show copyright messages. (<c>--nologo</c>)
+        NoLogo : bool
 
-            /// No build flag (<c>--no-build</c>)
-            NoBuild: bool
+        /// No build flag (<c>--no-build</c>)
+        NoBuild : bool
 
-            /// Doesn't execute an implicit restore when running the command. (<c>--no-restore</c>)
-            NoRestore: bool
+        /// Doesn't execute an implicit restore when running the command. (<c>--no-restore</c>)
+        NoRestore : bool
 
-            /// Force all dependencies to be resolved even if the last restore was successful.
-            /// This is equivalent to deleting project.assets.json. (<c>--force</c>)
-            Force: bool option
+        /// Force all dependencies to be resolved even if the last restore was successful.
+        /// This is equivalent to deleting project.assets.json. (<c>--force</c>)
+        Force : bool option
 
-            /// Other msbuild specific parameters
-            MSBuildParams: MSBuild.CliArguments
-        }
+        /// Other msbuild specific parameters
+        MSBuildParams : MSBuild.CliArguments
+    } with
 
         /// Parameter default values.
-        static member Create() =
-            { Common = Options.Create()
-              Configuration = Release
-              Framework = None
-              Runtime = None
-              BuildBasePath = None
-              OutputPath = None
-              VersionSuffix = None
-              NoLogo = false
-              NoBuild = false
-              NoRestore = false
-              Force = None
-              SelfContained = None
-              Manifest = None
-              MSBuildParams = MSBuild.CliArguments.Create() }
+        static member Create () = {
+            Common = Options.Create ()
+            Configuration = Release
+            Framework = None
+            Runtime = None
+            BuildBasePath = None
+            OutputPath = None
+            VersionSuffix = None
+            NoLogo = false
+            NoBuild = false
+            NoRestore = false
+            Force = None
+            SelfContained = None
+            Manifest = None
+            MSBuildParams = MSBuild.CliArguments.Create ()
+        }
 
         /// Gets the current environment
         member x.Environment = x.Common.Environment
 
         /// Sets the current environment variables.
-        member x.WithEnvironment map =
-            { x with Common = { x.Common with Environment = map } }
+        member x.WithEnvironment map = { x with Common = { x.Common with Environment = map } }
 
         /// Sets a value indicating whether the output for the given process is redirected.
-        member x.WithRedirectOutput shouldRedirect =
-            { x with Common = x.Common.WithRedirectOutput shouldRedirect }
+        member x.WithRedirectOutput shouldRedirect = { x with Common = x.Common.WithRedirectOutput shouldRedirect }
 
         /// Changes the "Common" properties according to the given function
         member inline x.WithCommon f = { x with Common = f x.Common }
 
-    let internal buildPublishArgs (param: PublishOptions) =
-        [ buildConfigurationArg param.Configuration
-          param.Framework |> Option.toList |> argList2 "framework"
-          param.Runtime |> Option.toList |> argList2 "runtime"
-          param.BuildBasePath |> Option.toList |> argList2 "build-base-path"
-          param.OutputPath |> Option.toList |> argList2 "output"
-          param.VersionSuffix |> Option.toList |> argList2 "version-suffix"
-          param.Manifest |> Option.toList |> List.collect id |> argList2 "manifest"
-          param.NoLogo |> argOption "nologo"
-          param.NoBuild |> argOption "no-build"
-          param.NoRestore |> argOption "no-restore"
-          param.SelfContained
-          |> Option.map (argOptionExplicit "self-contained")
-          |> Option.defaultValue []
-          param.Force |> Option.map (argOption "force") |> Option.defaultValue [] ]
+    let internal buildPublishArgs (param : PublishOptions) =
+        [
+            buildConfigurationArg param.Configuration
+            param.Framework |> Option.toList |> argList2 "framework"
+            param.Runtime |> Option.toList |> argList2 "runtime"
+            param.BuildBasePath
+            |> Option.toList
+            |> argList2 "build-base-path"
+            param.OutputPath |> Option.toList |> argList2 "output"
+            param.VersionSuffix
+            |> Option.toList
+            |> argList2 "version-suffix"
+            param.Manifest
+            |> Option.toList
+            |> List.collect id
+            |> argList2 "manifest"
+            param.NoLogo |> argOption "nologo"
+            param.NoBuild |> argOption "no-build"
+            param.NoRestore |> argOption "no-restore"
+            param.SelfContained
+            |> Option.map (argOptionExplicit "self-contained")
+            |> Option.defaultValue []
+            param.Force
+            |> Option.map (argOption "force")
+            |> Option.defaultValue []
+        ]
         |> List.concat
         |> List.filter (not << String.IsNullOrEmpty)
 
@@ -1558,84 +1552,86 @@ module DotNet =
     /// <param name="project">project to publish</param>
     let publish setParams project =
         use __ = Trace.traceTask "DotNet:publish" project
-        let param = PublishOptions.Create() |> setParams
+        let param = PublishOptions.Create () |> setParams
         let args = Args.toWindowsCommandLine (project :: buildPublishArgs param)
         execWithBinLog project param.Common "publish" args param.MSBuildParams
-        __.MarkSuccess()
+        __.MarkSuccess ()
 
     /// <summary>
     /// dotnet build command options
     /// </summary>
-    type BuildOptions =
-        {
-            /// Common tool options
-            Common: Options
+    type BuildOptions = {
+        /// Common tool options
+        Common : Options
 
-            /// Pack configuration (<c>--configuration</c>)
-            Configuration: BuildConfiguration
+        /// Pack configuration (<c>--configuration</c>)
+        Configuration : BuildConfiguration
 
-            /// Target framework to compile for (<c>--framework</c>)
-            Framework: string option
+        /// Target framework to compile for (<c>--framework</c>)
+        Framework : string option
 
-            /// Target runtime to publish for (<c>--runtime</c>)
-            Runtime: string option
+        /// Target runtime to publish for (<c>--runtime</c>)
+        Runtime : string option
 
-            /// Build base path (<c>--build-base-path</c>)
-            BuildBasePath: string option
+        /// Build base path (<c>--build-base-path</c>)
+        BuildBasePath : string option
 
-            /// Output path (<c>--output</c>)
-            OutputPath: string option
+        /// Output path (<c>--output</c>)
+        OutputPath : string option
 
-            /// Native flag (<c>--native</c>)
-            Native: bool
+        /// Native flag (<c>--native</c>)
+        Native : bool
 
-            /// Don't show copyright messages. (<c>--nologo</c>)
-            NoLogo: bool
+        /// Don't show copyright messages. (<c>--nologo</c>)
+        NoLogo : bool
 
-            /// Doesn't execute an implicit restore during build. (<c>--no-restore</c>)
-            NoRestore: bool
+        /// Doesn't execute an implicit restore during build. (<c>--no-restore</c>)
+        NoRestore : bool
 
-            /// Other msbuild specific parameters
-            MSBuildParams: MSBuild.CliArguments
-        }
+        /// Other msbuild specific parameters
+        MSBuildParams : MSBuild.CliArguments
+    } with
 
         /// Parameter default values.
-        static member Create() =
-            { Common = Options.Create()
-              Configuration = Release
-              Framework = None
-              Runtime = None
-              BuildBasePath = None
-              OutputPath = None
-              Native = false
-              NoLogo = false
-              NoRestore = false
-              MSBuildParams = MSBuild.CliArguments.Create() }
+        static member Create () = {
+            Common = Options.Create ()
+            Configuration = Release
+            Framework = None
+            Runtime = None
+            BuildBasePath = None
+            OutputPath = None
+            Native = false
+            NoLogo = false
+            NoRestore = false
+            MSBuildParams = MSBuild.CliArguments.Create ()
+        }
 
         /// Gets the current environment
         member x.Environment = x.Common.Environment
 
         /// Sets the current environment variables.
-        member x.WithEnvironment map =
-            { x with Common = { x.Common with Environment = map } }
+        member x.WithEnvironment map = { x with Common = { x.Common with Environment = map } }
 
         /// Sets a value indicating whether the output for the given process is redirected.
-        member x.WithRedirectOutput shouldRedirect =
-            { x with Common = x.Common.WithRedirectOutput shouldRedirect }
+        member x.WithRedirectOutput shouldRedirect = { x with Common = x.Common.WithRedirectOutput shouldRedirect }
 
         /// Changes the "Common" properties according to the given function
         member inline x.WithCommon f = { x with Common = f x.Common }
 
 
-    let private buildBuildArgs (param: BuildOptions) =
-        [ buildConfigurationArg param.Configuration
-          param.Framework |> Option.toList |> argList2 "framework"
-          param.Runtime |> Option.toList |> argList2 "runtime"
-          param.BuildBasePath |> Option.toList |> argList2 "build-base-path"
-          param.OutputPath |> Option.toList |> argList2 "output"
-          param.Native |> argOption "native"
-          param.NoLogo |> argOption "nologo"
-          param.NoRestore |> argOption "no-restore" ]
+    let private buildBuildArgs (param : BuildOptions) =
+        [
+            buildConfigurationArg param.Configuration
+            param.Framework |> Option.toList |> argList2 "framework"
+            param.Runtime |> Option.toList |> argList2 "runtime"
+            param.BuildBasePath
+            |> Option.toList
+            |> argList2 "build-base-path"
+            param.OutputPath |> Option.toList |> argList2 "output"
+            param.Native |> argOption "native"
+            param.NoLogo |> argOption "nologo"
+            param.NoRestore |> argOption "no-restore"
+        ]
         |> List.concat
         |> List.filter (not << String.IsNullOrEmpty)
 
@@ -1648,145 +1644,149 @@ module DotNet =
     /// <param name="project">project to compile</param>
     let build setParams project =
         use __ = Trace.traceTask "DotNet:build" project
-        let param = BuildOptions.Create() |> setParams
+        let param = BuildOptions.Create () |> setParams
         let args = Args.toWindowsCommandLine (project :: buildBuildArgs param)
         execWithBinLog project param.Common "build" args param.MSBuildParams
-        __.MarkSuccess()
+        __.MarkSuccess ()
 
     /// <summary>
     /// dotnet test command options
     /// </summary>
-    type TestOptions =
-        {
-            /// Common tool options
-            Common: Options
+    type TestOptions = {
+        /// Common tool options
+        Common : Options
 
-            /// Settings to use when running tests (<c>--settings</c>)
-            Settings: string option
+        /// Settings to use when running tests (<c>--settings</c>)
+        Settings : string option
 
-            /// Lists discovered tests (<c>--list-tests</c>)
-            ListTests: bool
+        /// Lists discovered tests (<c>--list-tests</c>)
+        ListTests : bool
 
-            /// Run tests that match the given expression. (<c>--filter</c>)
-            /// Examples:
-            /// <list type="number">
-            /// <item>
-            /// Run tests with priority set to 1: <c>--filter "Priority = 1"</c>
-            /// </item>
-            /// <item>
-            /// Run a test with the specified full name:
-            /// <c>--filter "FullyQualifiedName=Namespace.ClassName.MethodName"</c>
-            /// </item>
-            /// <item>
-            /// Run tests that contain the specified name: <c>--filter "FullyQualifiedName~Namespace.Class"</c>
-            /// </item>
-            /// <item>
-            /// More info on filtering support: https://aka.ms/vstest-filtering
-            /// </item>
-            /// </list>
-            Filter: string option
+        /// Run tests that match the given expression. (<c>--filter</c>)
+        /// Examples:
+        /// <list type="number">
+        /// <item>
+        /// Run tests with priority set to 1: <c>--filter "Priority = 1"</c>
+        /// </item>
+        /// <item>
+        /// Run a test with the specified full name:
+        /// <c>--filter "FullyQualifiedName=Namespace.ClassName.MethodName"</c>
+        /// </item>
+        /// <item>
+        /// Run tests that contain the specified name: <c>--filter "FullyQualifiedName~Namespace.Class"</c>
+        /// </item>
+        /// <item>
+        /// More info on filtering support: https://aka.ms/vstest-filtering
+        /// </item>
+        /// </list>
+        Filter : string option
 
-            /// Use custom adapters from the given path in the test run. (<c>--test-adapter-path</c>)
-            TestAdapterPath: string option
+        /// Use custom adapters from the given path in the test run. (<c>--test-adapter-path</c>)
+        TestAdapterPath : string option
 
-            /// Specify a logger for test results. (<c>--logger</c>)
-            Logger: string option
+        /// Specify a logger for test results. (<c>--logger</c>)
+        Logger : string option
 
-            ///Configuration to use for building the project.  Default for most projects is  "Debug".
-            /// (<c>--configuration</c>)
-            Configuration: BuildConfiguration
+        ///Configuration to use for building the project.  Default for most projects is  "Debug".
+        /// (<c>--configuration</c>)
+        Configuration : BuildConfiguration
 
-            /// Target framework to publish for. The target framework has to be specified in the project file.
-            /// (<c>--framework</c>)
-            Framework: string option
+        /// Target framework to publish for. The target framework has to be specified in the project file.
+        /// (<c>--framework</c>)
+        Framework : string option
 
-            ///  Directory in which to find the binaries to be run (<c>--output</c>)
-            Output: string option
+        ///  Directory in which to find the binaries to be run (<c>--output</c>)
+        Output : string option
 
-            /// Enable verbose logs for test platform. Logs are written to the provided file. (<c>--diag</c>)
-            Diag: string option
+        /// Enable verbose logs for test platform. Logs are written to the provided file. (<c>--diag</c>)
+        Diag : string option
 
-            /// Don't show copyright messages. (<c>--nologo</c>)
-            NoLogo: bool
+        /// Don't show copyright messages. (<c>--nologo</c>)
+        NoLogo : bool
 
-            ///  Do not build project before testing. (<c>--no-build</c>)
-            NoBuild: bool
+        ///  Do not build project before testing. (<c>--no-build</c>)
+        NoBuild : bool
 
-            /// The directory where the test results are going to be placed. The specified directory will be created
-            /// if it does not exist. (<c>--results-directory</c>)
-            ResultsDirectory: string option
+        /// The directory where the test results are going to be placed. The specified directory will be created
+        /// if it does not exist. (<c>--results-directory</c>)
+        ResultsDirectory : string option
 
-            /// Enables data collector for the test run. More info here : https://aka.ms/vstest-collect
-            /// (<c>--collect</c>)
-            Collect: string option
+        /// Enables data collector for the test run. More info here : https://aka.ms/vstest-collect
+        /// (<c>--collect</c>)
+        Collect : string option
 
-            ///  Does not do an implicit restore when executing the command. (<c>--no-restore</c>)
-            NoRestore: bool
+        ///  Does not do an implicit restore when executing the command. (<c>--no-restore</c>)
+        NoRestore : bool
 
-            /// Arguments to pass run settings configurations through commandline. Arguments may be specified as
-            /// name-value pair of the form <c>[name]=[value]</c> after <c>"-- "</c>. Note the space after <c>--</c>.
-            RunSettingsArguments: string option
+        /// Arguments to pass run settings configurations through commandline. Arguments may be specified as
+        /// name-value pair of the form <c>[name]=[value]</c> after <c>"-- "</c>. Note the space after <c>--</c>.
+        RunSettingsArguments : string option
 
-            /// Runs the tests in blame mode. This option is helpful in isolating the problematic tests causing test
-            /// host to crash. It creates an output file in the current directory as Sequence.xml that captures the
-            /// order of tests execution before the crash.  (<c>--blame</c>)
-            Blame: bool
+        /// Runs the tests in blame mode. This option is helpful in isolating the problematic tests causing test
+        /// host to crash. It creates an output file in the current directory as Sequence.xml that captures the
+        /// order of tests execution before the crash.  (<c>--blame</c>)
+        Blame : bool
 
-            /// Other msbuild specific parameters
-            MSBuildParams: MSBuild.CliArguments
-        }
+        /// Other msbuild specific parameters
+        MSBuildParams : MSBuild.CliArguments
+    } with
 
         /// Parameter default values.
-        static member Create() =
-            { Common = Options.Create()
-              Settings = None
-              ListTests = false
-              Filter = None
-              TestAdapterPath = None
-              Logger = None
-              Configuration = BuildConfiguration.Debug
-              Framework = None
-              Output = None
-              Diag = None
-              NoLogo = false
-              NoBuild = false
-              ResultsDirectory = None
-              Collect = None
-              NoRestore = false
-              RunSettingsArguments = None
-              Blame = false
-              MSBuildParams = MSBuild.CliArguments.Create() }
+        static member Create () = {
+            Common = Options.Create ()
+            Settings = None
+            ListTests = false
+            Filter = None
+            TestAdapterPath = None
+            Logger = None
+            Configuration = BuildConfiguration.Debug
+            Framework = None
+            Output = None
+            Diag = None
+            NoLogo = false
+            NoBuild = false
+            ResultsDirectory = None
+            Collect = None
+            NoRestore = false
+            RunSettingsArguments = None
+            Blame = false
+            MSBuildParams = MSBuild.CliArguments.Create ()
+        }
 
         /// Gets the current environment
         member x.Environment = x.Common.Environment
 
         /// Sets the current environment variables.
-        member x.WithEnvironment map =
-            { x with Common = { x.Common with Environment = map } }
+        member x.WithEnvironment map = { x with Common = { x.Common with Environment = map } }
 
         /// Sets a value indicating whether the output for the given process is redirected.
-        member x.WithRedirectOutput shouldRedirect =
-            { x with Common = x.Common.WithRedirectOutput shouldRedirect }
+        member x.WithRedirectOutput shouldRedirect = { x with Common = x.Common.WithRedirectOutput shouldRedirect }
 
         /// Changes the "Common" properties according to the given function
         member inline x.WithCommon f = { x with Common = f x.Common }
 
-    let private buildTestArgs (param: TestOptions) =
-        [ param.Settings |> Option.toList |> argList2 "settings"
-          param.ListTests |> argOption "list-tests"
-          param.Filter |> Option.toList |> argList2 "filter"
-          param.TestAdapterPath |> Option.toList |> argList2 "test-adapter-path"
-          param.Logger |> Option.toList |> argList2 "logger"
-          buildConfigurationArg param.Configuration
-          param.Framework |> Option.toList |> argList2 "framework"
-          param.Output |> Option.toList |> argList2 "output"
-          param.Diag |> Option.toList |> argList2 "diag"
-          param.NoLogo |> argOption "nologo"
-          param.NoBuild |> argOption "no-build"
-          param.ResultsDirectory |> Option.toList |> argList2 "results-directory"
-          param.Collect |> Option.toList |> argList2 "collect"
-          param.NoRestore |> argOption "no-restore"
-          param.Blame |> argOption "blame" ]
+    let private buildTestArgs (param : TestOptions) =
+        [
+            param.Settings |> Option.toList |> argList2 "settings"
+            param.ListTests |> argOption "list-tests"
+            param.Filter |> Option.toList |> argList2 "filter"
+            param.TestAdapterPath
+            |> Option.toList
+            |> argList2 "test-adapter-path"
+            param.Logger |> Option.toList |> argList2 "logger"
+            buildConfigurationArg param.Configuration
+            param.Framework |> Option.toList |> argList2 "framework"
+            param.Output |> Option.toList |> argList2 "output"
+            param.Diag |> Option.toList |> argList2 "diag"
+            param.NoLogo |> argOption "nologo"
+            param.NoBuild |> argOption "no-build"
+            param.ResultsDirectory
+            |> Option.toList
+            |> argList2 "results-directory"
+            param.Collect |> Option.toList |> argList2 "collect"
+            param.NoRestore |> argOption "no-restore"
+            param.Blame |> argOption "blame"
+        ]
         |> List.concat
         |> List.filter (not << String.IsNullOrEmpty)
 
@@ -1799,39 +1799,49 @@ module DotNet =
     /// <param name="project">project to test</param>
     let test setParams project =
         use __ = Trace.traceTask "DotNet:test" project
-        let param = TestOptions.Create() |> setParams
+        let param = TestOptions.Create () |> setParams
         let args = Args.toWindowsCommandLine (project :: buildTestArgs param)
         execWithBinLog project param.Common "test" args param.MSBuildParams
-        __.MarkSuccess()
+        __.MarkSuccess ()
 
-    let internal buildNugetPushArgs (param: NuGet.NuGetPushParams) =
-        [ param.DisableBuffering |> argOption "disable-buffering"
-          param.ApiKey |> Option.toList |> argList2 "api-key"
-          param.NoSymbols |> argOption "no-symbols"
-          param.NoServiceEndpoint |> argOption "no-service-endpoint"
-          param.Source |> Option.toList |> argList2 "source"
-          param.SymbolApiKey |> Option.toList |> argList2 "symbol-api-key"
-          param.SymbolSource |> Option.toList |> argList2 "symbol-source"
-          param.Timeout
-          |> Option.map (fun t -> t.TotalSeconds |> int |> string)
-          |> Option.toList
-          |> argList2 "timeout" ]
+    let internal buildNugetPushArgs (param : NuGet.NuGetPushParams) =
+        [
+            param.DisableBuffering |> argOption "disable-buffering"
+            param.SkipDuplicate |> argOption "skip-duplicate"
+            param.ApiKey |> Option.toList |> argList2 "api-key"
+            param.NoSymbols |> argOption "no-symbols"
+            param.NoServiceEndpoint |> argOption "no-service-endpoint"
+            param.Source |> Option.toList |> argList2 "source"
+            param.SymbolApiKey
+            |> Option.toList
+            |> argList2 "symbol-api-key"
+            param.SymbolSource
+            |> Option.toList
+            |> argList2 "symbol-source"
+            param.Timeout
+            |> Option.map (fun t -> t.TotalSeconds |> int |> string)
+            |> Option.toList
+            |> argList2 "timeout"
+        ]
         |> List.concat
         |> List.filter (not << String.IsNullOrEmpty)
 
     /// <summary>
     /// nuget push parameters for <c>dotnet nuget push</c>
     /// </summary>
-    type NuGetPushOptions =
-        { Common: Options
-          PushParams: NuGet.NuGetPushParams }
+    type NuGetPushOptions = {
+        Common : Options
+        PushParams : NuGet.NuGetPushParams
+    } with
 
-        static member Create() =
-            { Common = Options.Create()
-              PushParams = NuGet.NuGetPushParams.Create() }
+        static member Create () = {
+            Common = Options.Create ()
+            PushParams = NuGet.NuGetPushParams.Create ()
+        }
 
-        member this.WithCommon(common: Options) = { this with Common = common }
-        member this.WithPushParams(options: NuGet.NuGetPushParams) = { this with PushParams = options }
+        /// Changes the "Common" properties according to the given function
+        member inline x.WithCommon f = { x with Common = f x.Common }
+        member this.WithPushParams (pushParams : NuGet.NuGetPushParams) = { this with PushParams = pushParams }
 
     /// <summary>
     /// Execute dotnet nuget push command
@@ -1858,7 +1868,7 @@ module DotNet =
     /// </example>
     let rec nugetPush setParams nupkg =
         use __ = Trace.traceTask "DotNet:nuget:push" nupkg
-        let param = NuGetPushOptions.Create() |> setParams
+        let param = NuGetPushOptions.Create () |> setParams
         let pushParams = param.PushParams
 
         pushParams.ApiKey
@@ -1871,7 +1881,7 @@ module DotNet =
         let result = exec (fun _ -> param.Common) "nuget push" args
 
         if result.OK then
-            __.MarkSuccess()
+            __.MarkSuccess ()
         elif pushParams.PushTrials > 0 then
             nugetPush (fun _ -> param.WithPushParams { pushParams with PushTrials = pushParams.PushTrials - 1 }) nupkg
         else
@@ -1884,7 +1894,7 @@ module DotNet =
         | VisualBasic
 
         /// Convert the list option to string representation
-        override this.ToString() =
+        override this.ToString () =
             match this with
             | FSharp -> "F#"
             | CSharp -> "C#"
@@ -1893,90 +1903,96 @@ module DotNet =
     /// <summary>
     /// dotnet new command options
     /// </summary>
-    type NewOptions =
-        {
-            /// Common tool options
-            Common: Options
+    type NewOptions = {
+        /// Common tool options
+        Common : Options
 
-            // Displays a summary of what would happen if the given command line were run if it would result in a
-            // template creation.
-            DryRun: bool
+        // Displays a summary of what would happen if the given command line were run if it would result in a
+        // template creation.
+        DryRun : bool
 
-            // Forces content to be generated even if it would change existing files.
-            Force: bool
+        // Forces content to be generated even if it would change existing files.
+        Force : bool
 
-            // Filters templates based on language and specifies the language of the template to create.
-            Language: NewLanguage
+        // Filters templates based on language and specifies the language of the template to create.
+        Language : NewLanguage
 
-            // The name for the created output. If no name is specified, the name of the current directory is used.
-            Name: string option
+        // The name for the created output. If no name is specified, the name of the current directory is used.
+        Name : string option
 
-            // Disables checking for template package updates when instantiating a template.
-            NoUpdateCheck: bool
+        // Disables checking for template package updates when instantiating a template.
+        NoUpdateCheck : bool
 
-            // Location to place the generated output. The default is the current directory.
-            Output: string option
-        }
+        // Location to place the generated output. The default is the current directory.
+        Output : string option
+    } with
 
         /// Parameter default values.
-        static member Create() =
-            { Common = Options.Create()
-              DryRun = false
-              Force = false
-              Language = NewLanguage.FSharp
-              Name = None
-              NoUpdateCheck = false
-              Output = None }
+        static member Create () = {
+            Common = Options.Create ()
+            DryRun = false
+            Force = false
+            Language = NewLanguage.FSharp
+            Name = None
+            NoUpdateCheck = false
+            Output = None
+        }
 
     /// <summary>
     /// dotnet new --install options
     /// </summary>
-    type TemplateInstallOptions =
-        {
-            /// Common tool options
-            Common: Options
-            Install: string
-            NugetSource: string option
-        }
+    type TemplateInstallOptions = {
+        /// Common tool options
+        Common : Options
+        Install : string
+        NugetSource : string option
+    } with
 
         /// Parameter default values.
-        static member Create(packageOrSourceName) =
-            { Common = Options.Create()
-              Install = packageOrSourceName
-              NugetSource = None }
+        static member Create (packageOrSourceName) = {
+            Common = Options.Create ()
+            Install = packageOrSourceName
+            NugetSource = None
+        }
 
     /// <summary>
     /// dotnet new --install options
     /// </summary>
-    type TemplateUninstallOptions =
-        {
-            /// Common tool options
-            Common: Options
-            Uninstall: string
-        }
+    type TemplateUninstallOptions = {
+        /// Common tool options
+        Common : Options
+        Uninstall : string
+    } with
 
         /// Parameter default values.
-        static member Create(packageOrSourceName) =
-            { Common = { Options.Create() with RedirectOutput = true }
-              Uninstall = packageOrSourceName }
+        static member Create (packageOrSourceName) = {
+            Common = { Options.Create () with RedirectOutput = true }
+            Uninstall = packageOrSourceName
+        }
 
-    let internal buildNewArgs (param: NewOptions) =
-        [ param.DryRun |> argOption "dry-run"
-          param.Force |> argOption "force"
-          argList2 "language" [ param.Language.ToString() ]
-          param.Name |> Option.toList |> argList2 "name"
-          param.NoUpdateCheck |> argOption "no-update-check"
-          param.Output |> Option.toList |> argList2 "output" ]
+    let internal buildNewArgs (param : NewOptions) =
+        [
+            param.DryRun |> argOption "dry-run"
+            param.Force |> argOption "force"
+            argList2 "language" [ param.Language.ToString () ]
+            param.Name |> Option.toList |> argList2 "name"
+            param.NoUpdateCheck |> argOption "no-update-check"
+            param.Output |> Option.toList |> argList2 "output"
+        ]
         |> List.concat
         |> List.filter (not << String.IsNullOrEmpty)
 
-    let internal buildTemplateInstallArgs (param: TemplateInstallOptions) =
-        [ argList2 "install" [ param.Install ]
-          param.NugetSource |> Option.toList |> argList2 "nuget-source" ]
+    let internal buildTemplateInstallArgs (param : TemplateInstallOptions) =
+        [
+            argList2 "install" [ param.Install ]
+            param.NugetSource
+            |> Option.toList
+            |> argList2 "nuget-source"
+        ]
         |> List.concat
         |> List.filter (not << String.IsNullOrEmpty)
 
-    let internal buildTemplateUninstallArgs (param: TemplateUninstallOptions) =
+    let internal buildTemplateUninstallArgs (param : TemplateUninstallOptions) =
         [ argList2 "uninstall" [ param.Uninstall ] ]
         |> List.concat
         |> List.filter (not << String.IsNullOrEmpty)
@@ -1989,14 +2005,14 @@ module DotNet =
     /// <param name="setParams">set version command parameters</param>
     let newFromTemplate templateName setParams =
         use __ = Trace.traceTask "DotNet:new" "dotnet new command"
-        let param = NewOptions.Create() |> setParams
+        let param = NewOptions.Create () |> setParams
         let args = Args.toWindowsCommandLine (buildNewArgs param)
         let result = exec (fun _ -> param.Common) $"new {templateName}" args
 
         if not result.OK then
             failwithf $"dotnet new failed with code %i{result.ExitCode}"
 
-        __.MarkSuccess()
+        __.MarkSuccess ()
 
     /// <summary>
     /// Execute dotnet new <c>--install &lt;PATH|NUGET_ID&gt;</c> command to install a new template
@@ -2006,14 +2022,14 @@ module DotNet =
     /// <param name="setParams">set version command parameters</param>
     let installTemplate templateName setParams =
         use __ = Trace.traceTask "DotNet:new" "dotnet new --install command"
-        let param = TemplateInstallOptions.Create(templateName) |> setParams
+        let param = TemplateInstallOptions.Create (templateName) |> setParams
         let args = Args.toWindowsCommandLine (buildTemplateInstallArgs param)
         let result = exec (fun _ -> param.Common) "new" args
 
         if not result.OK then
             failwithf $"dotnet new --install failed with code %i{result.ExitCode}"
 
-        __.MarkSuccess()
+        __.MarkSuccess ()
 
     /// <summary>
     /// Execute dotnet new <c>--uninstall &lt;PATH|NUGET_ID&gt;</c> command to uninstall a new template
@@ -2023,7 +2039,7 @@ module DotNet =
     /// <param name="setParams">set version command parameters</param>
     let uninstallTemplate templateName =
         use __ = Trace.traceTask "DotNet:new" "dotnet new --uninstall command"
-        let param = TemplateUninstallOptions.Create(templateName)
+        let param = TemplateUninstallOptions.Create (templateName)
         let args = Args.toWindowsCommandLine (buildTemplateUninstallArgs param)
         let result = exec (fun _ -> param.Common) "new" args
 
@@ -2032,8 +2048,7 @@ module DotNet =
         // completed with success
         let templateIsNotFoundToUninstall =
             result.Results
-            |> List.exists (fun (result: ConsoleMessage) ->
-                result.Message.Contains $"The template package '{templateName}' is not found.")
+            |> List.exists (fun (result : ConsoleMessage) -> result.Message.Contains $"The template package '{templateName}' is not found.")
 
         let success = (result.ExitCode = 0) || templateIsNotFoundToUninstall
 
@@ -2041,4 +2056,4 @@ module DotNet =
         | true -> ()
         | false -> failwithf $"dotnet new --uninstall failed with code %i{result.ExitCode}"
 
-        __.MarkSuccess()
+        __.MarkSuccess ()

--- a/build/MSBuild.fs
+++ b/build/MSBuild.fs
@@ -1,4 +1,4 @@
-﻿namespace Fake.DotNet
+namespace Fake.DotNet
 
 open System
 open System.IO
@@ -18,12 +18,12 @@ type MSBuildProject = XDocument
 /// An exception type to signal build errors.
 /// </summary>
 exception MSBuildException of string * list<string> with
-    override x.ToString() =
-        x.Data0.ToString()
+    override x.ToString () =
+        x.Data0.ToString ()
         + Environment.NewLine
         + (String.separated Environment.NewLine x.Data1)
 
-type MSBuildEntry = { Version: string; Paths: string list }
+type MSBuildEntry = { Version : string; Paths : string list }
 
 /// MSBuild verbosity option
 type MSBuildVerbosity =
@@ -80,19 +80,21 @@ type MSBuildLogParameter =
 /// <summary>
 /// A type for MSBuild configuration
 /// </summary>
-type MSBuildFileLoggerConfig =
-    { Number: int
-      Filename: string option
-      Verbosity: MSBuildVerbosity option
-      Parameters: MSBuildLogParameter list option }
+type MSBuildFileLoggerConfig = {
+    Number : int
+    Filename : string option
+    Verbosity : MSBuildVerbosity option
+    Parameters : MSBuildLogParameter list option
+}
 
 /// <summary>
 /// A type for MSBuild distributed logger configuration
 /// </summary>
-type MSBuildDistributedLoggerConfig =
-    { ClassName: string option
-      AssemblyPath: string
-      Parameters: (string * string) list option }
+type MSBuildDistributedLoggerConfig = {
+    ClassName : string option
+    AssemblyPath : string
+    Parameters : (string * string) list option
+}
 
 type MSBuildLoggerConfig = MSBuildDistributedLoggerConfig
 
@@ -105,19 +107,20 @@ module private MSBuildExeFromVsWhere =
         |> List.map (fun vs -> vs.InstallationPath)
 
     let private getAllMsBuildPaths vsPath =
-        let msBuildDir = Path.Combine(vsPath, "MSBuild")
+        let msBuildDir = Path.Combine (vsPath, "MSBuild")
 
-        if Directory.Exists(msBuildDir) then
-            Directory.EnumerateDirectories(msBuildDir)
-            |> Seq.map (fun dir -> Path.Combine(dir, "Bin", "MSBuild.exe"))
+        if Directory.Exists (msBuildDir) then
+            Directory.EnumerateDirectories (msBuildDir)
+            |> Seq.map (fun dir -> Path.Combine (dir, "Bin", "MSBuild.exe"))
             |> Seq.choose (fun exe ->
-                if File.Exists(exe) then
-                    let v = FileVersionInfo.GetVersionInfo(exe)
+                if File.Exists (exe) then
+                    let v = FileVersionInfo.GetVersionInfo (exe)
 
-                    Some
-                        {| IsPreRelease = v.IsPreRelease
-                           FileMajorPart = v.FileMajorPart
-                           Path = Path.GetDirectoryName(exe) |}
+                    Some {|
+                        IsPreRelease = v.IsPreRelease
+                        FileMajorPart = v.FileMajorPart
+                        Path = Path.GetDirectoryName (exe)
+                    |}
                 else
                     None)
             |> List.ofSeq
@@ -131,56 +134,66 @@ module private MSBuildExeFromVsWhere =
              |> List.sortBy (fun x -> x.IsPreRelease)
              |> List.groupBy (fun x -> x.FileMajorPart)
              |> List.sortByDescending fst
-             |> List.map (fun (v, dirs) ->
-                 { Version = sprintf "%d.0" v
-                   Paths = dirs |> List.map (fun x -> x.Path) }))
+             |> List.map (fun (v, dirs) -> { Version = sprintf "%d.0" v; Paths = dirs |> List.map (fun x -> x.Path) }))
 
     let getOrdered () : MSBuildEntry list = all.Value
 
 module private MSBuildExe =
-    let knownMSBuildEntries =
-        [ { Version = "17.0"
-            Paths =
-              [ @"\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin"
+    let knownMSBuildEntries = [
+        {
+            Version = "17.0"
+            Paths = [
+                @"\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin"
                 @"\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin"
                 @"\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin"
                 @"\MSBuild\Current\Bin"
-                @"\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin" ] }
-          { Version = "16.0"
-            Paths =
-              [ @"\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin"
+                @"\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin"
+            ]
+        }
+        {
+            Version = "16.0"
+            Paths = [
+                @"\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin"
                 @"\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin"
                 @"\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin"
                 @"\MSBuild\Current\Bin"
-                @"\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin" ] }
-          { Version = "15.0"
-            Paths =
-              [ @"\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin"
+                @"\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin"
+            ]
+        }
+        {
+            Version = "15.0"
+            Paths = [
+                @"\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin"
                 @"\Microsoft Visual Studio\2017\Professional\MSBuild\15.0\Bin"
                 @"\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin"
                 @"\MSBuild\15.0\Bin"
-                @"\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin" ] }
-          { Version = "14.0"
-            Paths = [ @"\MSBuild\14.0\Bin" ] }
-          { Version = "12.0"
-            Paths = [ @"\MSBuild\12.0\Bin"; @"\MSBuild\12.0\Bin\amd64" ] } ]
+                @"\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin"
+            ]
+        }
+        { Version = "14.0"; Paths = [ @"\MSBuild\14.0\Bin" ] }
+        {
+            Version = "12.0"
+            Paths = [ @"\MSBuild\12.0\Bin"; @"\MSBuild\12.0\Bin\amd64" ]
+        }
+    ]
 
-    let oldMSBuildLocations =
-        [ @"c:\Windows\Microsoft.NET\Framework\v4.0.30319\"
-          @"c:\Windows\Microsoft.NET\Framework\v4.0.30128\"
-          @"c:\Windows\Microsoft.NET\Framework\v3.5\" ]
+    let oldMSBuildLocations = [
+        @"c:\Windows\Microsoft.NET\Framework\v4.0.30319\"
+        @"c:\Windows\Microsoft.NET\Framework\v4.0.30128\"
+        @"c:\Windows\Microsoft.NET\Framework\v3.5\"
+    ]
 
-    let private toDict items =
-        items |> Seq.map (fun f -> f.Version, f.Paths) |> Map.ofSeq
+    let private toDict items = items |> Seq.map (fun f -> f.Version, f.Paths) |> Map.ofSeq
 
     let private getAllKnownPaths =
-        (knownMSBuildEntries |> List.collect (fun m -> m.Paths)) @ oldMSBuildLocations
+        (knownMSBuildEntries |> List.collect (fun m -> m.Paths))
+        @ oldMSBuildLocations
 
     /// <summary>
     /// Versions of Mono prior to this one have faulty implementations of MSBuild
     /// NOTE: in System.Version 5.0 &gt;= 5.0.0.0 is false while 5.0.0.0 &gt;= 5.0 is true...
     /// </summary>
-    let monoVersionToUseMSBuildOn = Version("5.0")
+    let monoVersionToUseMSBuildOn = Version ("5.0")
 
     /// <summary>
     /// Tries to detect the right version of MSBuild.
@@ -270,19 +283,23 @@ module private MSBuildExe =
         let foundExe =
             match Environment.isUnix, preferMSBuildOnNetCore || preferMSBuildOnMono with
             | true, true ->
-                let sources =
-                    [ msbuildEnvironVar |> Option.map (exactPathOrBinaryOnPath "msbuild")
-                      msbuildEnvironVar |> Option.bind which
-                      which "msbuild"
-                      which "xbuild" ]
+                let sources = [
+                    msbuildEnvironVar
+                    |> Option.map (exactPathOrBinaryOnPath "msbuild")
+                    msbuildEnvironVar |> Option.bind which
+                    which "msbuild"
+                    which "xbuild"
+                ]
 
                 defaultArg (sources |> List.choose id |> List.tryHead) "msbuild"
             | true, _ ->
-                let sources =
-                    [ msbuildEnvironVar |> Option.map (exactPathOrBinaryOnPath "xbuild")
-                      msbuildEnvironVar |> Option.bind which
-                      which "xbuild"
-                      which "msbuild" ]
+                let sources = [
+                    msbuildEnvironVar
+                    |> Option.map (exactPathOrBinaryOnPath "xbuild")
+                    msbuildEnvironVar |> Option.bind which
+                    which "xbuild"
+                    which "msbuild"
+                ]
 
                 defaultArg (sources |> List.choose id |> List.tryHead) "xbuild"
             | false, _ ->
@@ -291,10 +308,7 @@ module private MSBuildExe =
 #if !FX_NO_SYSTEM_CONFIGURATION
                     if
                         "true"
-                            .Equals(
-                                System.Configuration.ConfigurationManager.AppSettings.["IgnoreMSBuild"],
-                                StringComparison.OrdinalIgnoreCase
-                            )
+                            .Equals (System.Configuration.ConfigurationManager.AppSettings.["IgnoreMSBuild"], StringComparison.OrdinalIgnoreCase)
                     then
                         Some ""
                     else
@@ -307,7 +321,8 @@ module private MSBuildExe =
                     // with VS 2022 Visual Studio can also be installed in "Program Files" instead of "Program Files (x86)"
                     // so we need to search both paths for every version of Visual Studio
                     let withProgramFiles paths =
-                        (paths |> List.map ((@@) Fake.Core.Environment.ProgramFilesX86))
+                        (paths
+                         |> List.map ((@@) Fake.Core.Environment.ProgramFilesX86))
                         @ (paths |> List.map ((@@) Fake.Core.Environment.ProgramFiles))
 
                     let vsVersionPaths =
@@ -319,7 +334,8 @@ module private MSBuildExe =
                         with
                         | Some x -> x |> withProgramFiles
                         | None ->
-                            (knownMSBuildEntries |> List.collect (fun x -> x.Paths |> withProgramFiles))
+                            (knownMSBuildEntries
+                             |> List.collect (fun x -> x.Paths |> withProgramFiles))
                             @ oldMSBuildLocations
 
                     let vsWhereVersionPaths =
@@ -332,11 +348,13 @@ module private MSBuildExe =
 
                     ProcessUtils.tryFindFile fullList "MSBuild.exe"
 
-                let sources =
-                    [ msbuildEnvironVar |> Option.map (exactPathOrBinaryOnPath "MSBuild.exe")
-                      msbuildEnvironVar |> Option.bind which
-                      configIgnoreMSBuild
-                      findOnVSPathsThenSystemPath ]
+                let sources = [
+                    msbuildEnvironVar
+                    |> Option.map (exactPathOrBinaryOnPath "MSBuild.exe")
+                    msbuildEnvironVar |> Option.bind which
+                    configIgnoreMSBuild
+                    findOnVSPathsThenSystemPath
+                ]
 
                 defaultArg (sources |> List.choose id |> List.tryHead) "MSBuild.exe"
 
@@ -362,19 +380,136 @@ module private MSBuildExe =
 /// A type for MSBuild task parameters
 /// Please see <a href="https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2015/msbuild/msbuild-command-line-reference?view=vs-2015">MSBuild command line reference</a>
 /// </summary>
-type MSBuildParams =
-    {
-        /// Set the MSBuild executable to use. Defaults to the latest installed MSBuild.
-        ToolPath: string
+type MSBuildParams = {
+    /// Set the MSBuild executable to use. Defaults to the latest installed MSBuild.
+    ToolPath : string
 
-        /// The working directory to execute MSBuild in
-        WorkingDirectory: string
+    /// The working directory to execute MSBuild in
+    WorkingDirectory : string
 
+    /// The list of targets to use
+    Targets : string list
+
+    /// The list of properties to pass to MSBuild
+    Properties : (string * string) list
+
+    /// <summary>
+    /// corresponds to the msbuild option <c>/m</c>:
+    /// <list type="number">
+    /// <item>
+    /// <c>None</c> will omit the option.
+    /// </item>
+    /// <item>
+    /// <c>Some None</c> will emit <c>/m</c>.
+    /// </item>
+    /// <item>
+    /// <c>Some 2</c> will emit <c>/m:2</c>.
+    /// </item>
+    /// </list>
+    /// </summary>
+    MaxCpuCount : int option option
+
+    /// Execute a restore before executing the targets (<c>/restore</c> flag)
+    DoRestore : bool
+
+    /// Don't display the startup banner or the copyright message.
+    NoLogo : bool
+
+    /// Enable or disable the re-use of MSBuild nodes. You can specify the following values
+    NodeReuse : bool
+
+    /// mark if to restore the packages or not
+    RestorePackagesFlag : bool
+
+    /// Specifies the version of the Toolset to use to build the project
+    ToolsVersion : string option
+
+    /// Specifies the amount of information to display in the build log. Each logger displays events based on
+    /// the verbosity level that you set for that logger
+    Verbosity : MSBuildVerbosity option
+
+    /// Disable the default console logger, and don't log events to the console.
+    NoConsoleLogger : bool
+
+    /// The list of warnings to treat as errors
+    WarnAsError : string list option
+
+    /// The list of warning to ignore
+    NoWarn : string list option
+
+    /// corresponds to the msbuild option <c>/consoleloggerparameters</c>
+    ConsoleLogParameters : MSBuildLogParameter list
+
+    /// Fake attaches a binlog-logger in order to report errors and warnings. You can disable this behavior
+    /// with this flag
+    DisableInternalBinLog : bool
+
+    /// corresponds to the msbuild option <c>/fl</c>
+    FileLoggers : MSBuildFileLoggerConfig list option
+
+    /// corresponds to the msbuild option <c>/bl</c>
+    BinaryLoggers : string list option
+
+    /// corresponds to the msbuild option <c>/l</c>
+    Loggers : MSBuildLoggerConfig list option
+
+    /// corresponds to the msbuild option <c>/dl</c>
+    DistributedLoggers : (MSBuildLoggerConfig * MSBuildLoggerConfig option) list option
+
+    Environment : Map<string, string>
+} with
+
+    /// Defines a default for MSBuild task parameters
+    static member Create () = {
+        ToolPath = MSBuildExe.msBuildExe
+        Targets = []
+        WorkingDirectory = Directory.GetCurrentDirectory ()
+        Properties = []
+        MaxCpuCount = Some None
+        DoRestore = false
+        NoLogo = false
+        NodeReuse = false
+        ToolsVersion = None
+        Verbosity = None
+        NoConsoleLogger = false
+        WarnAsError = None
+        NoWarn = None
+        RestorePackagesFlag = false
+        DisableInternalBinLog = false
+        ConsoleLogParameters =
+            if BuildServer.ansiColorSupport then
+                [ ForceConsoleColor ]
+            else
+                []
+        FileLoggers = None
+        BinaryLoggers = None
+        DistributedLoggers = None
+        Loggers = None
+        Environment =
+            Process.createEnvironmentMap ()
+            |> Map.remove "MSBUILD_EXE_PATH"
+            |> Map.remove "MSBuildExtensionsPath"
+            |> Map.remove "MSBuildLoadMicrosoftTargetsReadOnly"
+            |> Map.remove "MSBuildSDKsPath"
+    }
+
+    /// Sets the current environment variables.
+    member x.WithEnvironment map = { x with Environment = map }
+
+/// <summary>
+/// Contains tasks which allow to use MSBuild (or xBuild on Linux/Unix) to build .NET project files or solution files.
+/// </summary>
+[<RequireQualifiedAccess>]
+module MSBuild =
+    /// <summary>
+    /// A type for MSBuild task parameters
+    /// </summary>
+    type CliArguments = {
         /// The list of targets to use
-        Targets: string list
+        Targets : string list
 
-        /// The list of properties to pass to MSBuild
-        Properties: (string * string) list
+        /// Set or override the specified project-level properties
+        Properties : (string * string) list
 
         /// <summary>
         /// corresponds to the msbuild option <c>/m</c>:
@@ -390,215 +525,101 @@ type MSBuildParams =
         /// </item>
         /// </list>
         /// </summary>
-        MaxCpuCount: int option option
+        MaxCpuCount : int option option
 
         /// Execute a restore before executing the targets (<c>/restore</c> flag)
-        DoRestore: bool
+        DoRestore : bool
 
         /// Don't display the startup banner or the copyright message.
-        NoLogo: bool
+        NoLogo : bool
 
         /// Enable or disable the re-use of MSBuild nodes. You can specify the following values
-        NodeReuse: bool
-
-        /// mark if to restore the packages or not
-        RestorePackagesFlag: bool
+        NodeReuse : bool
 
         /// Specifies the version of the Toolset to use to build the project
-        ToolsVersion: string option
+        ToolsVersion : string option
 
         /// Specifies the amount of information to display in the build log. Each logger displays events based on
         /// the verbosity level that you set for that logger
-        Verbosity: MSBuildVerbosity option
+        Verbosity : MSBuildVerbosity option
 
         /// Disable the default console logger, and don't log events to the console.
-        NoConsoleLogger: bool
+        NoConsoleLogger : bool
 
         /// The list of warnings to treat as errors
-        WarnAsError: string list option
+        WarnAsError : string list option
 
         /// The list of warning to ignore
-        NoWarn: string list option
-
-        /// corresponds to the msbuild option <c>/consoleloggerparameters</c>
-        ConsoleLogParameters: MSBuildLogParameter list
+        NoWarn : string list option
 
         /// Fake attaches a binlog-logger in order to report errors and warnings. You can disable this behavior
         /// with this flag
-        DisableInternalBinLog: bool
+        DisableInternalBinLog : bool
 
         /// corresponds to the msbuild option <c>/fl</c>
-        FileLoggers: MSBuildFileLoggerConfig list option
+        FileLoggers : MSBuildFileLoggerConfig list option
 
         /// corresponds to the msbuild option <c>/bl</c>
-        BinaryLoggers: string list option
+        BinaryLoggers : string list option
+
+        /// corresponds to the msbuild option <c>/consoleloggerparameters</c>
+        ConsoleLogParameters : MSBuildLogParameter list
 
         /// corresponds to the msbuild option <c>/l</c>
-        Loggers: MSBuildLoggerConfig list option
+        Loggers : MSBuildLoggerConfig list option
 
         /// corresponds to the msbuild option <c>/dl</c>
-        DistributedLoggers: (MSBuildLoggerConfig * MSBuildLoggerConfig option) list option
+        DistributedLoggers : (MSBuildLoggerConfig * MSBuildLoggerConfig option) list option
+    } with
 
-        Environment: Map<string, string>
-    }
-
-    /// Defines a default for MSBuild task parameters
-    static member Create() =
-        { ToolPath = MSBuildExe.msBuildExe
-          Targets = []
-          WorkingDirectory = Directory.GetCurrentDirectory()
-          Properties = []
-          MaxCpuCount = Some None
-          DoRestore = false
-          NoLogo = false
-          NodeReuse = false
-          ToolsVersion = None
-          Verbosity = None
-          NoConsoleLogger = false
-          WarnAsError = None
-          NoWarn = None
-          RestorePackagesFlag = false
-          DisableInternalBinLog = false
-          ConsoleLogParameters =
-            if BuildServer.ansiColorSupport then
-                [ ForceConsoleColor ]
-            else
-                []
-          FileLoggers = None
-          BinaryLoggers = None
-          DistributedLoggers = None
-          Loggers = None
-          Environment =
-            Process.createEnvironmentMap ()
-            |> Map.remove "MSBUILD_EXE_PATH"
-            |> Map.remove "MSBuildExtensionsPath"
-            |> Map.remove "MSBuildLoadMicrosoftTargetsReadOnly"
-            |> Map.remove "MSBuildSDKsPath" }
-
-    /// Sets the current environment variables.
-    member x.WithEnvironment map = { x with Environment = map }
-
-/// <summary>
-/// Contains tasks which allow to use MSBuild (or xBuild on Linux/Unix) to build .NET project files or solution files.
-/// </summary>
-[<RequireQualifiedAccess>]
-module MSBuild =
-    /// <summary>
-    /// A type for MSBuild task parameters
-    /// </summary>
-    type CliArguments =
-        {
-            /// The list of targets to use
-            Targets: string list
-
-            /// Set or override the specified project-level properties
-            Properties: (string * string) list
-
-            /// <summary>
-            /// corresponds to the msbuild option <c>/m</c>:
-            /// <list type="number">
-            /// <item>
-            /// <c>None</c> will omit the option.
-            /// </item>
-            /// <item>
-            /// <c>Some None</c> will emit <c>/m</c>.
-            /// </item>
-            /// <item>
-            /// <c>Some 2</c> will emit <c>/m:2</c>.
-            /// </item>
-            /// </list>
-            /// </summary>
-            MaxCpuCount: int option option
-
-            /// Execute a restore before executing the targets (<c>/restore</c> flag)
-            DoRestore: bool
-
-            /// Don't display the startup banner or the copyright message.
-            NoLogo: bool
-
-            /// Enable or disable the re-use of MSBuild nodes. You can specify the following values
-            NodeReuse: bool
-
-            /// Specifies the version of the Toolset to use to build the project
-            ToolsVersion: string option
-
-            /// Specifies the amount of information to display in the build log. Each logger displays events based on
-            /// the verbosity level that you set for that logger
-            Verbosity: MSBuildVerbosity option
-
-            /// Disable the default console logger, and don't log events to the console.
-            NoConsoleLogger: bool
-
-            /// The list of warnings to treat as errors
-            WarnAsError: string list option
-
-            /// The list of warning to ignore
-            NoWarn: string list option
-
-            /// Fake attaches a binlog-logger in order to report errors and warnings. You can disable this behavior
-            /// with this flag
-            DisableInternalBinLog: bool
-
-            /// corresponds to the msbuild option <c>/fl</c>
-            FileLoggers: MSBuildFileLoggerConfig list option
-
-            /// corresponds to the msbuild option <c>/bl</c>
-            BinaryLoggers: string list option
-
-            /// corresponds to the msbuild option <c>/consoleloggerparameters</c>
-            ConsoleLogParameters: MSBuildLogParameter list
-
-            /// corresponds to the msbuild option <c>/l</c>
-            Loggers: MSBuildLoggerConfig list option
-
-            /// corresponds to the msbuild option <c>/dl</c>
-            DistributedLoggers: (MSBuildLoggerConfig * MSBuildLoggerConfig option) list option
-        }
-
-        static member Create() : CliArguments =
-            { Targets = []
-              Properties = []
-              MaxCpuCount = None
-              DoRestore = false
-              NoLogo = false
-              NodeReuse = false
-              ToolsVersion = None
-              Verbosity = None
-              NoConsoleLogger = false
-              WarnAsError = None
-              NoWarn = None
-              DisableInternalBinLog = false
-              ConsoleLogParameters =
+        static member Create () : CliArguments = {
+            Targets = []
+            Properties = []
+            MaxCpuCount = None
+            DoRestore = false
+            NoLogo = false
+            NodeReuse = false
+            ToolsVersion = None
+            Verbosity = None
+            NoConsoleLogger = false
+            WarnAsError = None
+            NoWarn = None
+            DisableInternalBinLog = false
+            ConsoleLogParameters =
                 if BuildServer.ansiColorSupport then
                     [ ForceConsoleColor ]
                 else
                     []
-              FileLoggers = None
-              BinaryLoggers = None
-              DistributedLoggers = None
-              Loggers = None }
+            FileLoggers = None
+            BinaryLoggers = None
+            DistributedLoggers = None
+            Loggers = None
+        }
 
-    let internal asCliArguments (x: MSBuildParams) : CliArguments =
-        { Targets = x.Targets
-          Properties = ("RestorePackages", x.RestorePackagesFlag.ToString()) :: x.Properties
-          MaxCpuCount = x.MaxCpuCount
-          NoLogo = x.NoLogo
-          NodeReuse = x.NodeReuse
-          DoRestore = x.DoRestore
-          ToolsVersion = x.ToolsVersion
-          Verbosity = x.Verbosity
-          NoConsoleLogger = x.NoConsoleLogger
-          WarnAsError = x.WarnAsError
-          NoWarn = x.NoWarn
-          DisableInternalBinLog = x.DisableInternalBinLog
-          ConsoleLogParameters = x.ConsoleLogParameters
-          FileLoggers = x.FileLoggers
-          Loggers = x.Loggers
-          BinaryLoggers = x.BinaryLoggers
-          DistributedLoggers = x.DistributedLoggers }
+    let internal asCliArguments (x : MSBuildParams) : CliArguments = {
+        Targets = x.Targets
+        Properties =
+            ("RestorePackages", x.RestorePackagesFlag.ToString ())
+            :: x.Properties
+        MaxCpuCount = x.MaxCpuCount
+        NoLogo = x.NoLogo
+        NodeReuse = x.NodeReuse
+        DoRestore = x.DoRestore
+        ToolsVersion = x.ToolsVersion
+        Verbosity = x.Verbosity
+        NoConsoleLogger = x.NoConsoleLogger
+        WarnAsError = x.WarnAsError
+        NoWarn = x.NoWarn
+        DisableInternalBinLog = x.DisableInternalBinLog
+        ConsoleLogParameters = x.ConsoleLogParameters
+        FileLoggers = x.FileLoggers
+        Loggers = x.Loggers
+        BinaryLoggers = x.BinaryLoggers
+        DistributedLoggers = x.DistributedLoggers
+    }
 
-    let internal withCliArguments (oldObj: MSBuildParams) (x: CliArguments) =
-        { oldObj with
+    let internal withCliArguments (oldObj : MSBuildParams) (x : CliArguments) = {
+        oldObj with
             Targets = x.Targets
             Properties = x.Properties
             MaxCpuCount = x.MaxCpuCount
@@ -621,12 +642,13 @@ module MSBuild =
             ConsoleLogParameters = x.ConsoleLogParameters
             FileLoggers = x.FileLoggers
             BinaryLoggers = x.BinaryLoggers
-            DistributedLoggers = x.DistributedLoggers }
+            DistributedLoggers = x.DistributedLoggers
+    }
 
     type MSBuildParams with
 
         member internal x.CliArguments = asCliArguments x
-        member internal oldObj.WithCliArguments(x: CliArguments) = withCliArguments oldObj x
+        member internal oldObj.WithCliArguments (x : CliArguments) = withCliArguments oldObj x
 
     /// <summary>
     /// Exposing MSBuild executable
@@ -638,19 +660,18 @@ module MSBuild =
     let msbuildNamespace = "http://schemas.microsoft.com/developer/msbuild/2003"
 
     /// [omit]
-    let xName name = XName.Get(name, msbuildNamespace)
+    let xName name = XName.Get (name, msbuildNamespace)
 
     /// [omit]
-    let loadProject (projectFileName: string) : MSBuildProject =
-        MSBuildProject.Load(projectFileName, LoadOptions.PreserveWhitespace)
+    let loadProject (projectFileName : string) : MSBuildProject = MSBuildProject.Load (projectFileName, LoadOptions.PreserveWhitespace)
 
     // See: http://msdn.microsoft.com/en-us/library/ms228186.aspx
     let internal unescapeMSBuildSpecialChars s =
-        let replExpr = Text.RegularExpressions.Regex("%..")
+        let replExpr = Text.RegularExpressions.Regex ("%..")
 
-        replExpr.Replace(
+        replExpr.Replace (
             s,
-            Text.RegularExpressions.MatchEvaluator(fun _match ->
+            Text.RegularExpressions.MatchEvaluator (fun _match ->
                 match _match.Value with
                 | "%24" -> "$"
                 | "%25" -> "%"
@@ -662,22 +683,24 @@ module MSBuild =
                 | _ -> _match.Value)
         )
 
-    let internal getReferenceElements elementName projectFileName (doc: XDocument) =
+    let internal getReferenceElements elementName projectFileName (doc : XDocument) =
         let fi = FileInfo.ofPath projectFileName
 
         doc
             .Descendants(xName "Project")
             .Descendants(xName "ItemGroup")
-            .Descendants(xName elementName)
+            .Descendants (xName elementName)
         |> Seq.map (fun e ->
-            let a = e.Attribute(XName.Get "Include")
+            let a = e.Attribute (XName.Get "Include")
 
             let value =
-                a.Value |> unescapeMSBuildSpecialChars |> Path.convertWindowsToCurrentPath
+                a.Value
+                |> unescapeMSBuildSpecialChars
+                |> Path.convertWindowsToCurrentPath
 
             let fileName =
                 if
-                    value.StartsWith(".." + Path.directorySeparator)
+                    value.StartsWith (".." + Path.directorySeparator)
                     || (not <| value.Contains Path.directorySeparator)
                 then
                     fi.Directory.FullName @@ value
@@ -687,11 +710,11 @@ module MSBuild =
             a, fileName |> Path.getFullName)
 
     let internal quoteString str =
-        StringBuilder()
+        StringBuilder ()
         |> StringBuilder.appendQuotedIfNotNull Some str
         |> StringBuilder.toText
 
-    let rec private getProjectReferences (projectFileName: string) =
+    let rec private getProjectReferences (projectFileName : string) =
         match projectFileName.EndsWith ".sln" with
         | true -> Set.empty
         | false ->
@@ -707,7 +730,7 @@ module MSBuild =
             |> Seq.append references
             |> Set.ofSeq
 
-    let internal fromCliArguments (p: CliArguments) =
+    let internal fromCliArguments (p : CliArguments) =
         let verbosityName v =
             match v with
             | Quiet -> "q"
@@ -719,10 +742,16 @@ module MSBuild =
         let targets =
             match p.Targets with
             | [] -> None
-            | t -> Some("t", t |> Seq.map (String.replace "." "_") |> String.separated ";")
+            | t ->
+                Some (
+                    "t",
+                    t
+                    |> Seq.map (String.replace "." "_")
+                    |> String.separated ";"
+                )
 
         // see https://github.com/fsharp/FAKE/issues/2112
-        let escapePropertyValue (v: string) =
+        let escapePropertyValue (v : string) =
             // https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild-special-characters?view=vs-2017
             v
                 .Replace("%", "%25")
@@ -734,50 +763,50 @@ module MSBuild =
                 .Replace("@", "%40")
                 .Replace("'", "%27")
                 .Replace("?", "%3F")
-                .Replace("*", "%2A")
+                .Replace ("*", "%2A")
 
         let properties =
             p.Properties
-            |> List.map (fun (k, v) -> Some("p", sprintf "%s=%s" k (escapePropertyValue v)))
+            |> List.map (fun (k, v) -> Some ("p", sprintf "%s=%s" k (escapePropertyValue v)))
 
         let maxCpu =
             match p.MaxCpuCount with
             | None -> None
             | Some x ->
-                Some(
+                Some (
                     "m",
                     match x with
-                    | Some v -> v.ToString()
+                    | Some v -> v.ToString ()
                     | _ -> ""
                 )
 
-        let restoreFlag = if p.DoRestore then Some("restore", "") else None
+        let restoreFlag = if p.DoRestore then Some ("restore", "") else None
 
-        let noLogo = if p.NoLogo then Some("nologo", "") else None
+        let noLogo = if p.NoLogo then Some ("nologo", "") else None
 
-        let nodeReuse = if p.NodeReuse then None else Some("nodeReuse", "False")
+        let nodeReuse = if p.NodeReuse then None else Some ("nodeReuse", "False")
 
         let tools =
             match p.ToolsVersion with
             | None -> None
-            | Some t -> Some("tv", t)
+            | Some t -> Some ("tv", t)
 
         let verbosity =
             match p.Verbosity with
             | None -> None
-            | Some v -> Some("v", verbosityName v)
+            | Some v -> Some ("v", verbosityName v)
 
-        let noConsoleLogger = if p.NoConsoleLogger then Some("noconlog", "") else None
+        let noConsoleLogger = if p.NoConsoleLogger then Some ("noconlog", "") else None
 
         let warnAsError =
             match p.WarnAsError with
             | None -> None
-            | Some w -> Some("warnaserror", w |> String.concat ";")
+            | Some w -> Some ("warnaserror", w |> String.concat ";")
 
         let nowarn =
             match p.NoWarn with
             | None -> None
-            | Some w -> Some("nowarn", w |> String.concat ";")
+            | Some w -> Some ("nowarn", w |> String.concat ";")
 
         let loggerParams paramList =
             let logParams param =
@@ -799,12 +828,14 @@ module MSBuild =
                 | EnableMPLogging -> "EnableMPLogging"
                 | LogParameter o -> o
 
-            paramList |> List.map (logParams >> (sprintf "%s")) |> String.concat ";"
+            paramList
+            |> List.map (logParams >> (sprintf "%s"))
+            |> String.concat ";"
 
         let consoleLogParams =
             match p.ConsoleLogParameters with
             | [] -> None
-            | ps -> Some("clp", loggerParams ps)
+            | ps -> Some ("clp", loggerParams ps)
 
         let fileLoggers =
             let serializeLogger fl =
@@ -822,14 +853,16 @@ module MSBuild =
 
             match p.FileLoggers with
             | None -> []
-            | Some fls -> fls |> List.map (fun fl -> Some("flp" + (string fl.Number), serializeLogger fl))
+            | Some fls ->
+                fls
+                |> List.map (fun fl -> Some ("flp" + (string fl.Number), serializeLogger fl))
 
         let binaryLoggers =
             match p.BinaryLoggers with
             | None -> []
-            | Some bls -> bls |> List.map (fun bl -> Some("bl", bl))
+            | Some bls -> bls |> List.map (fun bl -> Some ("bl", bl))
 
-        let serializeLogger (dLogger: MSBuildLoggerConfig) =
+        let serializeLogger (dLogger : MSBuildLoggerConfig) =
             sprintf
                 "%s%s%s"
                 (match dLogger.ClassName with
@@ -846,7 +879,7 @@ module MSBuild =
         let loggers =
             match p.Loggers with
             | None -> []
-            | Some ls -> ls |> List.map (fun l -> Some("l", serializeLogger l))
+            | Some ls -> ls |> List.map (fun l -> Some ("l", serializeLogger l))
 
         let distributedFileLoggers =
             let createLoggerString cl fl =
@@ -856,39 +889,43 @@ module MSBuild =
 
             match p.DistributedLoggers with
             | None -> []
-            | Some dfls -> dfls |> List.map (fun (cl, fl) -> Some("dl", createLoggerString cl fl))
+            | Some dfls ->
+                dfls
+                |> List.map (fun (cl, fl) -> Some ("dl", createLoggerString cl fl))
 
-        [ yield restoreFlag
-          yield targets
-          if not Environment.isUnix then
-              yield maxCpu
-              yield noLogo
-              yield nodeReuse
-          yield tools
-          yield verbosity
-          yield noConsoleLogger
-          yield warnAsError
-          yield nowarn
-          yield consoleLogParams
-          yield! fileLoggers
-          yield! binaryLoggers
-          yield! loggers
-          yield! distributedFileLoggers
-          yield! properties ]
+        [
+            yield restoreFlag
+            yield targets
+            if not Environment.isUnix then
+                yield maxCpu
+                yield noLogo
+                yield nodeReuse
+            yield tools
+            yield verbosity
+            yield noConsoleLogger
+            yield warnAsError
+            yield nowarn
+            yield consoleLogParams
+            yield! fileLoggers
+            yield! binaryLoggers
+            yield! loggers
+            yield! distributedFileLoggers
+            yield! properties
+        ]
         |> Seq.choose id
         |> Seq.map (fun (k, v) -> "/" + k + (if String.isNullOrEmpty v then "" else ":" + v))
         |> Args.toWindowsCommandLine
 
     /// [omit]
-    let buildArgs (setParams: MSBuildParams -> MSBuildParams) =
-        let p = MSBuildParams.Create() |> setParams
+    let buildArgs (setParams : MSBuildParams -> MSBuildParams) =
+        let p = MSBuildParams.Create () |> setParams
         p, fromCliArguments p.CliArguments
 
 
     let internal getVersion =
-        let cache = System.Collections.Concurrent.ConcurrentDictionary<string, Version>()
+        let cache = System.Collections.Concurrent.ConcurrentDictionary<string, Version> ()
 
-        fun (exePath: string) (callMsbuildExe: string -> string) ->
+        fun (exePath : string) (callMsbuildExe : string -> string) ->
             let getFromCall () =
                 try
                     let result =
@@ -898,33 +935,30 @@ module MSBuild =
 
                     let line =
                         if result.Contains "DOTNET_CLI_TELEMETRY_OPTOUT" then
-                            result.Split('\n') |> Seq.filter (String.IsNullOrWhiteSpace >> not) |> Seq.last
+                            result.Split ('\n')
+                            |> Seq.filter (String.IsNullOrWhiteSpace >> not)
+                            |> Seq.last
                         else
                             result
 
-                    Version.Parse(line)
+                    Version.Parse (line)
                 with e ->
                     Trace.traceFAKE "Could not detect msbuild version from '%s': %O" exePath e
-                    Version(13, 0, 0, 0)
+                    Version (13, 0, 0, 0)
 
-            cache.GetOrAdd(exePath, System.Func<string, _>(fun _ -> getFromCall ()))
+            cache.GetOrAdd (exePath, System.Func<string, _> (fun _ -> getFromCall ()))
 
-    let private versionToUseBinLog = Version("15.3")
-    let private versionToUseStructuredLogger = Version("14.0")
+    let private versionToUseBinLog = Version ("15.3")
+    let private versionToUseStructuredLogger = Version ("14.0")
 
-    let internal addBinaryLogger
-        (exePath: string)
-        (callMsbuildExe: string -> string)
-        (args: string)
-        (disableFakeBinLogger: bool)
-        =
+    let internal addBinaryLogger (exePath : string) (callMsbuildExe : string -> string) (args : string) (disableFakeBinLogger : bool) =
 #if !NO_MSBUILD_BINLOG
         if disableFakeBinLogger then
             None, args
         else
             let argList = Args.fromWindowsCommandLine args |> Seq.toList
-            let path = Path.GetTempFileName()
-            File.Delete(path)
+            let path = Path.GetTempFileName ()
+            File.Delete (path)
             let path = path + ".binlog"
             //let path = Path.GetFullPath <| sprintf "fake-msbuild-%s.binlog" (System.Guid.NewGuid().ToString())
             let v = getVersion exePath callMsbuildExe
@@ -934,15 +968,18 @@ module MSBuild =
             elif v >= versionToUseStructuredLogger then
                 let assemblyPath =
                     let currentPath = MSBuildBinLog.structuredLogAssemblyPath
-                    let libFolder = Path.GetDirectoryName(Path.GetDirectoryName currentPath)
+                    let libFolder = Path.GetDirectoryName (Path.GetDirectoryName currentPath)
 
                     if exePath.EndsWith " msbuild" then
                         currentPath
                     else
-                        Path.Combine(libFolder, "net46", "StructuredLogger.dll")
+                        Path.Combine (libFolder, "net46", "StructuredLogger.dll")
 
                 Some path,
-                Args.toWindowsCommandLine (argList @ [ sprintf "/logger:BinaryLogger,%s;%s" assemblyPath path ])
+                Args.toWindowsCommandLine (
+                    argList
+                    @ [ sprintf "/logger:BinaryLogger,%s;%s" assemblyPath path ]
+                )
             else
                 Trace.traceFAKE
                     "msbuild version '%O' doesn't support binary logger, please set the msbuild argument 'DisableInternalBinLog' to 'true' to disable this warning."
@@ -962,7 +999,7 @@ module MSBuild =
                     let r = MSBuildBinLog.getErrorsAndWarnings f
 
                     try
-                        File.Delete(f)
+                        File.Delete (f)
                     with e ->
                         Trace.traceFAKE "Could not delete '%s': %O" f e
 
@@ -981,17 +1018,17 @@ module MSBuild =
 #endif
         if exitCode <> 0 then
             let errors =
-                msgs |> List.choose (fun m -> if m.IsError then Some m.Message else None)
+                msgs
+                |> List.choose (fun m -> if m.IsError then Some m.Message else None)
 
-            let errorMessage =
-                sprintf "'%s %s' failed with exit code %d." command project exitCode
+            let errorMessage = sprintf "'%s %s' failed with exit code %d." command project exitCode
 
-            raise (MSBuildException(errorMessage, errors))
+            raise (MSBuildException (errorMessage, errors))
 
     // used for detection
     let private callMsBuildExe msBuildParams args =
 
-        let results = System.Collections.Generic.List<string>()
+        let results = System.Collections.Generic.List<string> ()
 
         let errorF msg = results.Add msg
 
@@ -1008,7 +1045,7 @@ module MSBuild =
         if processResult.ExitCode <> 0 then
             failwithf "msbuild failed with exit code '%d'" processResult.ExitCode
 
-        String.Join("\n", results)
+        String.Join ("\n", results)
 
     /// <summary>
     /// Run MSBuild and collect output results and return it.
@@ -1022,27 +1059,21 @@ module MSBuild =
         let args = quoteString (project + " " + argsString)
 
         let binlogPath, args =
-            addBinaryLogger
-                msBuildParams.ToolPath
-                (callMsBuildExe msBuildParams)
-                args
-                msBuildParams.DisableInternalBinLog
+            addBinaryLogger msBuildParams.ToolPath (callMsBuildExe msBuildParams) args msBuildParams.DisableInternalBinLog
 
         let wd =
-            if msBuildParams.WorkingDirectory = Directory.GetCurrentDirectory() then
+            if msBuildParams.WorkingDirectory = Directory.GetCurrentDirectory () then
                 ""
             else
                 sprintf "%s>" msBuildParams.WorkingDirectory
 
         Trace.tracefn "%s%s %s" wd msBuildParams.ToolPath args
 
-        let results = System.Collections.Generic.List<ConsoleMessage>()
+        let results = System.Collections.Generic.List<ConsoleMessage> ()
 
-        let errorF msg =
-            results.Add(ConsoleMessage.CreateError msg)
+        let errorF msg = results.Add (ConsoleMessage.CreateError msg)
 
-        let messageF msg =
-            results.Add(ConsoleMessage.CreateOut msg)
+        let messageF msg = results.Add (ConsoleMessage.CreateOut msg)
 
         let processResult =
             CreateProcess.fromRawCommandLine msBuildParams.ToolPath args
@@ -1091,14 +1122,10 @@ module MSBuild =
         let args = quoteString (project + " " + argsString)
 
         let binlogPath, args =
-            addBinaryLogger
-                msBuildParams.ToolPath
-                (callMsBuildExe msBuildParams)
-                args
-                msBuildParams.DisableInternalBinLog
+            addBinaryLogger msBuildParams.ToolPath (callMsBuildExe msBuildParams) args msBuildParams.DisableInternalBinLog
 
         let wd =
-            if msBuildParams.WorkingDirectory = Directory.GetCurrentDirectory() then
+            if msBuildParams.WorkingDirectory = Directory.GetCurrentDirectory () then
                 ""
             else
                 sprintf "%s>" msBuildParams.WorkingDirectory
@@ -1113,7 +1140,7 @@ module MSBuild =
             |> Proc.run
 
         handleAfterRun "msbuild" binlogPath processResult.ExitCode project
-        __.MarkSuccess()
+        __.MarkSuccess ()
 
     /// <summary>
     /// Builds the given project files and collects the output files.
@@ -1125,17 +1152,17 @@ module MSBuild =
     /// <param name="properties">A list with tuples of property name and property values.</param>
     /// <param name="projects">A list of project or solution files.</param>
     let runWithProperties
-        (setParams: MSBuildParams -> MSBuildParams)
+        (setParams : MSBuildParams -> MSBuildParams)
         outputPath
-        (targets: string)
-        (properties: string -> (string * string) list)
+        (targets : string)
+        (properties : string -> (string * string) list)
         projects
         =
         let projects = projects |> Seq.toList
 
         let output =
             match String.liftString outputPath with
-            | Some path -> Some(Path.getFullName path)
+            | Some path -> Some (Path.getFullName path)
             | None -> None
 
         let properties =
@@ -1150,11 +1177,16 @@ module MSBuild =
 
         let setBuildParam project defaultParams =
             let projectParams = setParams defaultParams
-            let targets = targets |> String.split ';' |> List.filter String.isNotNullOrEmpty
+            let targets =
+                targets
+                |> String.split ';'
+                |> List.filter String.isNotNullOrEmpty
 
-            { projectParams with
-                Targets = projectParams.Targets @ targets
-                Properties = projectParams.Properties @ properties project }
+            {
+                projectParams with
+                    Targets = projectParams.Targets @ targets
+                    Properties = projectParams.Properties @ properties project
+            }
 
         projects
         |> List.filter (fun project -> not <| Set.contains project dependencies)
@@ -1174,8 +1206,7 @@ module MSBuild =
     /// <param name="targets">A string with the target names which should be run by MSBuild.</param>
     /// <param name="properties">A list with tuples of property name and property values.</param>
     /// <param name="projects">A list of project or solution files.</param>
-    let run setParams outputPath targets properties projects =
-        runWithProperties setParams outputPath targets (fun _ -> properties) projects
+    let run setParams outputPath targets properties projects = runWithProperties setParams outputPath targets (fun _ -> properties) projects
 
     /// <summary>
     /// Builds the given project files or solution files and collects the output files.
@@ -1185,8 +1216,7 @@ module MSBuild =
     /// <param name="outputPath">If it is null or empty then the project settings are used.</param>
     /// <param name="targets">A string with the target names which should be run by MSBuild.</param>
     /// <param name="projects">A list of project or solution files.</param>
-    let runDebug setParams outputPath targets projects =
-        run setParams outputPath targets [ "Configuration", "Debug" ] projects
+    let runDebug setParams outputPath targets projects = run setParams outputPath targets [ "Configuration", "Debug" ] projects
 
     /// <summary>
     /// Builds the given project files or solution files and collects the output files.
@@ -1196,8 +1226,7 @@ module MSBuild =
     /// <param name="outputPath">If it is null or empty then the project settings are used.</param>
     /// <param name="targets">A string with the target names which should be run by MSBuild.</param>
     /// <param name="projects">A list of project or solution files.</param>
-    let runRelease setParams outputPath targets projects =
-        run setParams outputPath targets [ "Configuration", "Release" ] projects
+    let runRelease setParams outputPath targets projects = run setParams outputPath targets [ "Configuration", "Release" ] projects
 
     /// <summary>
     /// Builds the given project files or solution files in release mode to the default outputs.
@@ -1205,8 +1234,7 @@ module MSBuild =
     ///
     /// <param name="targets">A string with the target names which should be run by MSBuild.</param>
     /// <param name="projects">A list of project or solution files.</param>
-    let runWithDefaults targets projects =
-        run id null targets [ "Configuration", "Release" ] projects
+    let runWithDefaults targets projects = run id null targets [ "Configuration", "Release" ] projects
 
     /// <summary>
     /// Builds the given project files or solution files in release mode and collects the output files.
@@ -1229,12 +1257,14 @@ module MSBuild =
     /// <param name="outputPath">The output path.</param>
     /// <param name="configuration">MSBuild configuration.</param>
     /// <param name="projectFile">The project file path.</param>
-    let buildWebsiteConfig setParams (outputPath: string) configuration projectFile =
+    let buildWebsiteConfig setParams (outputPath : string) configuration projectFile =
         use __ = Trace.traceTask "BuildWebsite" projectFile
         let projectName = Path.GetFileNameWithoutExtension projectFile
 
-        let slashes (dir: string) =
-            dir.Replace("\\", "/").TrimEnd('/') |> Seq.filter ((=) '/') |> Seq.length
+        let slashes (dir : string) =
+            dir.Replace("\\", "/").TrimEnd ('/')
+            |> Seq.filter ((=) '/')
+            |> Seq.length
 
         let currentDir = (DirectoryInfo.ofPath ".").FullName
         let projectDir = (FileInfo.ofPath projectFile).Directory.FullName
@@ -1250,20 +1280,17 @@ module MSBuild =
         run setParams null "Build" [ "Configuration", configuration ] [ projectFile ]
         |> ignore
 
-        run
-            setParams
-            null
-            "_CopyWebApplication;_BuiltWebOutputGroupOutput"
-            [ "Configuration", configuration
-              "OutDir", prefix + outputPath
-              "WebProjectOutputDir", prefix + outputPath + "/" + projectName ]
-            [ projectFile ]
+        run setParams null "_CopyWebApplication;_BuiltWebOutputGroupOutput" [
+            "Configuration", configuration
+            "OutDir", prefix + outputPath
+            "WebProjectOutputDir", prefix + outputPath + "/" + projectName
+        ] [ projectFile ]
         |> ignore
 
         !!(projectDir + "/bin/*.*")
         |> Shell.copy (outputPath + "/" + projectName + "/bin/")
 
-        __.MarkSuccess()
+        __.MarkSuccess ()
 
     /// <summary>
     /// Builds the given web project file with debug configuration and copies it to the given outputPath.
@@ -1271,8 +1298,7 @@ module MSBuild =
     ///
     /// <param name="outputPath">The output path.</param>
     /// <param name="projectFile">The project file path.</param>
-    let buildWebsite outputPath projectFile =
-        buildWebsiteConfig id outputPath "Debug" projectFile
+    let buildWebsite outputPath projectFile = buildWebsiteConfig id outputPath "Debug" projectFile
 
     /// <summary>
     /// Builds the given web project files in specified configuration and copies them to the given outputPath.
@@ -1291,12 +1317,11 @@ module MSBuild =
     ///
     /// <param name="outputPath">The output path.</param>
     /// <param name="projectFiles">The project file paths.</param>
-    let buildWebsites outputPath projectFiles =
-        buildWebsitesConfig outputPath "Debug" projectFiles
+    let buildWebsites outputPath projectFiles = buildWebsitesConfig outputPath "Debug" projectFiles
 
 [<AutoOpen>]
 module internal MSBuildParamExtensions =
     type MSBuildParams with
 
         member internal x.CliArguments = MSBuild.asCliArguments x
-        member internal oldObj.WithCliArguments(x: MSBuild.CliArguments) = MSBuild.withCliArguments oldObj x
+        member internal oldObj.WithCliArguments (x : MSBuild.CliArguments) = MSBuild.withCliArguments oldObj x

--- a/build/NuGet.fs
+++ b/build/NuGet.fs
@@ -1,0 +1,1302 @@
+namespace Fake.DotNet.NuGet
+
+/// <summary>
+/// Contains helper functions and task which allow to inspect, create and publish
+/// <a href="https://www.nuget.org/">NuGet</a> packages.
+/// There is also a tutorial about <a href="/dotnet-nuget.html">nuget package creating</a> available.
+/// </summary>
+module NuGet =
+
+    open Fake.IO
+    open Fake.IO.FileSystemOperators
+    open Fake.Core
+    open System
+    open System.IO
+    open System.Text
+    open System.Xml.Linq
+    open Fake.DotNet.NuGet.Restore
+
+    type NugetDependencies = (string * string) list
+
+    type NugetFrameworkDependencies = { FrameworkVersion : string; Dependencies : NugetDependencies }
+
+    type NugetReferences = string list
+
+    type NugetFrameworkReferences = { FrameworkVersion : string; References : NugetReferences }
+
+    type NugetFrameworkAssemblyReferences = { FrameworkVersions : string list; AssemblyName : string }
+
+    /// Specifies that the package contains sources and symbols.
+    type NugetSymbolPackage =
+        /// Do not build symbol packages
+        | None = 0
+        /// Build a symbol package using a project file, if provided
+        | ProjectFile = 1
+        /// Build a symbol package using the nuspec file
+        | Nuspec = 2
+
+    type internal ToolOptions = {
+        /// The NuGet executable path
+        ToolPath : string
+
+        /// The NuGet command to execute
+        Command : string
+
+        /// The working directory to execute the command in
+        WorkingDir : string
+
+        /// Mark if to use full framework or not
+        IsFullFramework : bool
+    } with
+
+        static member Create toolPath command workingDir isFullFramework = {
+            ToolPath = toolPath
+            Command = command
+            WorkingDir = workingDir
+            IsFullFramework = isFullFramework
+        }
+
+    /// <summary>
+    /// Nuget base parameter type
+    /// </summary>
+    type NuGetParams = {
+        /// The path to the NuGet executable
+        ToolPath : string
+
+        /// The timeout to use to restrict NuGet command run time
+        TimeOut : TimeSpan
+
+        /// The package version
+        Version : string
+
+        /// The list of authors of the package
+        Authors : string list
+
+        /// The project name of the package
+        Project : string
+
+        /// The package title
+        Title : string
+
+        /// The summary description of the package
+        Summary : string
+
+        /// The descriptive text of the package
+        Description : string
+
+        /// Tags referring to the package
+        Tags : string
+
+        /// The release notes file path of the package
+        ReleaseNotes : string
+
+        /// The copyright text of the package
+        Copyright : string
+
+        /// The working directory to execute command in
+        WorkingDir : string
+
+        /// Sets the base path of the files defined in the .nuspec file.
+        BasePath : string option
+
+        /// Specifies the folder in which the created package is stored. If no folder is specified,
+        /// the current folder is used.
+        OutputPath : string
+
+        /// Specifies the server URL. NuGet identifies a UNC or local folder source and simply
+        /// copies the file there instead of pushing it using HTTP
+        PublishUrl : string
+
+        /// NuGet API access key
+        AccessKey : string
+
+        /// Specifies the symbol server URL.
+        SymbolPublishUrl : string
+
+        /// NuGet symbol API access key
+        SymbolAccessKey : string
+
+        /// Prevents default exclusion of NuGet package files and files and folders starting with a dot,
+        /// such as <c>.svn</c> and <c>.gitignore</c>.
+        NoDefaultExcludes : bool
+
+        /// Specifies that pack should not run package analysis after building the package.
+        NoPackageAnalysis : bool
+
+        /// The project file to use
+        ProjectFile : string
+
+        /// The list of dependencies of the package. <c>dependencies</c>
+        Dependencies : NugetDependencies
+
+        /// The list of dependencies of the package grouped by Framework. <c>dependencies</c>
+        DependenciesByFramework : NugetFrameworkDependencies list
+
+        /// The list of packages that reference the package. <c>references</c>
+        References : NugetReferences
+
+        /// The list of packages that reference the package grouped by Framework. <c>references</c>
+        ReferencesByFramework : NugetFrameworkReferences list
+
+        /// The list of <c>frameworkAssemblies</c>
+        FrameworkAssemblies : NugetFrameworkAssemblyReferences list
+
+        /// Mark if to include list of projects that reference the package
+        IncludeReferencedProjects : bool
+
+        /// mark if to publish a trial version of the package
+        PublishTrials : int
+
+        /// mark if to publish the package or not
+        Publish : bool
+
+        /// `NugetSymbolPackage` parameters
+        SymbolPackage : NugetSymbolPackage
+
+        /// Should appear last on the command line after other options. Specifies a list of properties
+        /// that override values in the project file
+        Properties : list<string * string>
+
+        /// The list of files to include or exclude. <c>files</c>
+        Files : list<string * string option * string option>
+
+        /// The list of content files to include or exclude. <c>contentFiles</c>
+        ContentFiles : list<string * string option * string option * bool option * bool option>
+
+        /// The package language. <c>language</c>
+        Language : string
+    }
+
+    /// NuGet default parameters
+    let NuGetDefaults () = {
+        ToolPath = findNuget (Shell.pwd () @@ "tools" @@ "NuGet")
+        TimeOut = TimeSpan.FromMinutes 5.
+        Version =
+            if not BuildServer.isLocalBuild then
+                BuildServer.buildVersion
+            else
+                "0.1.0.0"
+        Authors = []
+        Project = ""
+        Title = ""
+        Summary = null
+        ProjectFile = null
+        Description = null
+        Tags = null
+        ReleaseNotes = null
+        Copyright = null
+        Dependencies = []
+        DependenciesByFramework = []
+        References = []
+        ReferencesByFramework = []
+        FrameworkAssemblies = []
+        IncludeReferencedProjects = false
+        BasePath = None
+        OutputPath = "./NuGet"
+        WorkingDir = "./NuGet"
+        PublishUrl = "https://www.nuget.org/api/v2/package"
+        AccessKey = null
+        SymbolPublishUrl = null
+        SymbolAccessKey = null
+        NoDefaultExcludes = false
+        NoPackageAnalysis = false
+        PublishTrials = 5
+        Publish = false
+        SymbolPackage = NugetSymbolPackage.ProjectFile
+        Properties = []
+        Files = []
+        ContentFiles = []
+        Language = null
+    }
+
+    /// <summary>
+    /// Creates a string which tells NuGet that you require exactly this package version.
+    /// </summary>
+    ///
+    /// <param name="version">The exact version to require</param>
+    let RequireExactly version = sprintf "[%s]" version
+
+    /// NuGet package versioning breaking changes point
+    type BreakingPoint =
+        /// Breaking on major component of SemVer
+        | SemVer
+        /// Breaking on minor component of SemVer
+        | Minor
+        /// Breaking on patch component of SemVer
+        | Patch
+
+    /// <summary>
+    /// Require a version by given breaking point and version
+    /// See <a href="https://docs.nuget.org/create/versioning">NuGet Versioning</a>
+    /// </summary>
+    ///
+    /// <param name="breakingPoint">The breaking point for version range. See <c>BreakingPoint</c> type</param>
+    /// <param name="version">The version to use to find the range</param>
+    let RequireRange breakingPoint version =
+        let v = SemVer.parse version
+
+        match breakingPoint with
+        | SemVer -> sprintf "[%s,%d.0)" version (v.Major + 1u)
+        | Minor -> // Like Semver but we assume that the increase of a minor version is already breaking
+            sprintf "[%s,%d.%d)" version v.Major (v.Minor + 1u)
+        | Patch -> // Every update breaks
+            version |> RequireExactly
+
+    let private packageFileName parameters = sprintf "%s.%s.nupkg" parameters.Project parameters.Version
+
+    /// <summary>
+    /// Gets the version no. for a given package in the deployments folder
+    /// </summary>
+    ///
+    /// <param name="deploymentsDir">The deployment directory to look into</param>
+    /// <param name="package">The package id to look for</param>
+    let GetPackageVersion deploymentsDir package =
+        try
+            if Directory.Exists deploymentsDir |> not then
+                failwithf "Package %s was not found, because the deployment directory %s doesn't exist." package deploymentsDir
+
+            let version =
+                let dirs = Directory.GetDirectories (deploymentsDir, sprintf "%s*" package)
+
+                if Seq.isEmpty dirs then
+                    failwithf "Package %s was not found." package
+
+                let folder = Seq.head dirs
+                let index = folder.LastIndexOf package + package.Length + 1
+
+                if index < folder.Length then
+                    folder.Substring index
+                else
+                    let nuspec =
+                        Directory.GetFiles (folder, sprintf "%s.nuspec" package)
+                        |> Seq.head
+                    let doc = XDocument.Load (nuspec)
+                    let vers = doc.Descendants (XName.Get ("version", doc.Root.Name.NamespaceName))
+                    (Seq.head vers).Value
+
+            Trace.logfn "Version %s found for package %s" version package
+            version
+        with exn ->
+            Exception ("Could not detect package version for " + package, exn)
+            |> raise
+
+    let private createNuSpecFromTemplate parameters (templateNuSpec : FileInfo) =
+        let specFile =
+            parameters.WorkingDir
+            @@ (templateNuSpec.Name.Replace ("nuspec", "")
+                + parameters.Version
+                + ".nuspec")
+            |> Path.getFullName
+
+        Trace.tracefn "Creating .nuspec file at %s" specFile
+
+        templateNuSpec.CopyTo (specFile, true) |> ignore
+
+        let getFrameworkGroup (frameworkTags : (string * string) seq) =
+            frameworkTags
+            |> Seq.map (fun (frameworkVersion, tags) ->
+                if String.isNullOrEmpty frameworkVersion then
+                    sprintf "<group>%s</group>" tags
+                else
+                    sprintf "<group targetFramework=\"%s\">%s</group>" frameworkVersion tags)
+            |> String.toLines
+
+        let getGroup items toTags =
+            if items = [] then
+                ""
+            else
+                sprintf "<group>%s</group>" (items |> toTags)
+
+        let getReferencesTags references =
+            references
+            |> Seq.map (fun assembly -> sprintf "<reference file=\"%s\" />" assembly)
+            |> String.toLines
+
+        let references = getGroup parameters.References getReferencesTags
+
+        let referencesByFramework =
+            parameters.ReferencesByFramework
+            |> Seq.map (fun x -> (x.FrameworkVersion, getReferencesTags x.References))
+            |> getFrameworkGroup
+
+        let referencesXml = sprintf "<references>%s</references>" (references + referencesByFramework)
+
+        let getFrameworkAssemblyTags references =
+            references
+            |> Seq.map (fun x ->
+                if x.FrameworkVersions = [] then
+                    sprintf "<frameworkAssembly assemblyName=\"%s\" />" x.AssemblyName
+                else
+                    sprintf
+                        "<frameworkAssembly assemblyName=\"%s\" targetFramework=\"%s\" />"
+                        x.AssemblyName
+                        (x.FrameworkVersions |> String.separated ", "))
+            |> String.toLines
+
+        let frameworkAssembliesXml =
+            if parameters.FrameworkAssemblies = [] then
+                ""
+            else
+                sprintf "<frameworkAssemblies>%s</frameworkAssemblies>" (parameters.FrameworkAssemblies |> getFrameworkAssemblyTags)
+
+        let getDependenciesTags dependencies =
+            dependencies
+            |> Seq.map (fun (package, version) -> sprintf "<dependency id=\"%s\" version=\"%s\" />" package version)
+            |> String.toLines
+
+        let dependencies = getGroup parameters.Dependencies getDependenciesTags
+
+        let dependenciesByFramework =
+            parameters.DependenciesByFramework
+            |> Seq.map (fun x -> (x.FrameworkVersion, getDependenciesTags x.Dependencies))
+            |> getFrameworkGroup
+
+        let dependenciesXml = sprintf "<dependencies>%s</dependencies>" (dependencies + dependenciesByFramework)
+
+        let contentFilesTags =
+            parameters.ContentFiles
+            |> Seq.map (fun (incl, exclArg, buildActionArg, copyToOutputArg, flattenArg) ->
+                let excl =
+                    match exclArg with
+                    | Some x -> sprintf " exclude=\"%s\"" x
+                    | _ -> String.Empty
+
+                let buildAction =
+                    match buildActionArg with
+                    | Some x -> sprintf " buildAction=\"%s\"" x
+                    | _ -> String.Empty
+
+                let copyToOutput =
+                    match copyToOutputArg with
+                    | Some x -> sprintf " copyToOutput=\"%b\"" x
+                    | _ -> String.Empty
+
+                let flatten =
+                    match flattenArg with
+                    | Some x -> sprintf " flatten=\"%b\"" x
+                    | _ -> String.Empty
+
+                sprintf "<files include=\"%s\"%s%s%s%s />" incl excl buildAction copyToOutput flatten)
+            |> String.toLines
+
+        let contentFilesXml = sprintf "<contentFiles>%s</contentFiles>" contentFilesTags
+
+        let filesTags =
+            parameters.Files
+            |> Seq.map (fun (source, target, exclude) ->
+                let excludeStr =
+                    if exclude.IsSome then
+                        sprintf " exclude=\"%s\"" exclude.Value
+                    else
+                        String.Empty
+
+                let targetStr =
+                    if target.IsSome then
+                        sprintf " target=\"%s\"" target.Value
+                    else
+                        String.Empty
+
+                sprintf "<file src=\"%s\"%s%s />" source targetStr excludeStr)
+            |> String.toLines
+
+        let filesXml = sprintf "<files>%s</files>" filesTags
+
+        let xmlEncode (notEncodedText : string) =
+            if String.IsNullOrWhiteSpace notEncodedText then
+                ""
+            else
+                XText(notEncodedText).ToString().Replace ("�", "&szlig;")
+
+        let toSingleLine (text : string) =
+            if text = null then
+                null
+            else
+                text.Replace("\r", "").Replace("\n", "").Replace ("  ", " ")
+
+        let replacements =
+            [
+                "@build.number@", parameters.Version
+                "@title@", parameters.Title
+                "@authors@", parameters.Authors |> String.separated ", "
+                "@project@", parameters.Project
+                "@summary@", parameters.Summary |> toSingleLine
+                "@description@", parameters.Description |> toSingleLine
+                "@tags@", parameters.Tags
+                "@releaseNotes@", parameters.ReleaseNotes
+                "@copyright@", parameters.Copyright
+                "@language@", parameters.Language
+            ]
+            |> List.map (fun (placeholder, replacement) -> placeholder, xmlEncode replacement)
+            |> List.append [
+                "@dependencies@", dependenciesXml
+                "@references@", referencesXml
+                "@frameworkAssemblies@", frameworkAssembliesXml
+                "@contentFiles@", contentFilesXml
+                "@files@", filesXml
+            ]
+
+        Templates.replaceInFiles replacements [ specFile ]
+        Trace.tracefn "Created nuspec file %s" specFile
+        specFile
+
+    let private createNuSpecFromTemplateIfNotProjFile parameters nuSpecOrProjFile =
+        let nuSpecOrProjFileInfo = FileInfo.ofPath nuSpecOrProjFile
+
+        match nuSpecOrProjFileInfo.Extension.ToLower().EndsWith ("proj") with
+        | true -> None
+        | false -> Some (createNuSpecFromTemplate parameters nuSpecOrProjFileInfo)
+
+
+    let private propertiesParam =
+        function
+        | [] -> ""
+        | lst ->
+            "-Properties "
+            + (lst
+               |> List.map (fun p -> (fst p) + "=\"" + (snd p) + "\"")
+               |> String.concat ";")
+
+    /// Creates a NuGet package without templating (including symbols package if enabled)
+    let private pack parameters nuspecFile =
+        if String.isNotNullOrEmpty parameters.AccessKey then
+            TraceSecrets.register "<NuGetKey>" parameters.AccessKey
+
+        if String.isNotNullOrEmpty parameters.SymbolAccessKey then
+            TraceSecrets.register "<NuGetSymbolKey>" parameters.SymbolAccessKey
+
+        let nuspecFile = Path.getFullName nuspecFile
+        let properties = propertiesParam parameters.Properties
+
+        let basePath =
+            parameters.BasePath
+            |> Option.map (sprintf "-BasePath \"%s\"")
+            |> Option.defaultValue ""
+
+        let outputPath = (Path.getFullName (parameters.OutputPath.TrimEnd('\\').TrimEnd ('/')))
+
+        let packageAnalysis =
+            if parameters.NoPackageAnalysis then
+                "-NoPackageAnalysis"
+            else
+                ""
+
+        let defaultExcludes =
+            if parameters.NoDefaultExcludes then
+                "-NoDefaultExcludes"
+            else
+                ""
+
+        let includeReferencedProjects =
+            if parameters.IncludeReferencedProjects then
+                "-IncludeReferencedProjects"
+            else
+                ""
+
+        if Directory.Exists parameters.OutputPath |> not then
+            failwithf "OutputDir %s does not exist." parameters.OutputPath
+
+        let execute args =
+            let errorResults = System.Collections.Generic.List<string> ()
+            let outputResults = System.Collections.Generic.List<string> ()
+
+            let errorF msg = errorResults.Add msg
+
+            let messageF msg = outputResults.Add msg
+
+            let processResult =
+                CreateProcess.fromRawCommandLine parameters.ToolPath args
+                |> CreateProcess.withTimeout parameters.TimeOut
+                |> CreateProcess.withFramework
+                |> CreateProcess.withWorkingDirectory (Path.getFullName parameters.WorkingDir)
+                |> CreateProcess.redirectOutput
+                |> CreateProcess.withOutputEventsNotNull messageF errorF
+                |> Proc.run
+
+            if processResult.ExitCode <> 0 || errorResults.Count > 0 then
+                failwithf "Error during NuGet package creation. %s %s\r\n%s" parameters.ToolPath args (String.toLines errorResults)
+
+        match parameters.SymbolPackage with
+        | NugetSymbolPackage.ProjectFile ->
+            if not (String.isNullOrEmpty parameters.ProjectFile) then
+                sprintf
+                    "pack -Symbols -Version %s -OutputDirectory \"%s\" \"%s\" %s %s %s %s %s"
+                    parameters.Version
+                    outputPath
+                    (Path.getFullName parameters.ProjectFile)
+                    packageAnalysis
+                    defaultExcludes
+                    includeReferencedProjects
+                    properties
+                    basePath
+                |> execute
+
+            sprintf
+                "pack -Version %s -OutputDirectory \"%s\" \"%s\" %s %s %s %s %s"
+                parameters.Version
+                outputPath
+                nuspecFile
+                packageAnalysis
+                defaultExcludes
+                includeReferencedProjects
+                properties
+                basePath
+            |> execute
+        | NugetSymbolPackage.Nuspec ->
+            sprintf
+                "pack -Symbols -Version %s -OutputDirectory \"%s\" \"%s\" %s %s %s %s %s"
+                parameters.Version
+                outputPath
+                nuspecFile
+                packageAnalysis
+                defaultExcludes
+                includeReferencedProjects
+                properties
+                basePath
+            |> execute
+        | _ ->
+            sprintf
+                "pack -Version %s -OutputDirectory \"%s\" \"%s\" %s %s %s %s %s"
+                parameters.Version
+                outputPath
+                nuspecFile
+                packageAnalysis
+                defaultExcludes
+                includeReferencedProjects
+                properties
+                basePath
+            |> execute
+
+    /// <summary>
+    /// dotnet nuget push command options
+    /// </summary>
+    type NuGetPushParams = {
+        /// Disables buffering when pushing to an HTTP(S) server to reduce memory usage.
+        DisableBuffering : bool
+
+        /// When pushing multiple packages to an HTTP(S) server,
+        /// treats any 409 Conflict response as a warning so that other pushes can continue. (<c>--skip-duplicate</c>)
+        SkipDuplicate : bool
+
+        /// The API key for the server
+        ApiKey : string option
+
+        /// Doesn't push symbols (even if present).
+        NoSymbols : bool
+
+        /// Doesn't append "api/v2/package" to the source URL.
+        NoServiceEndpoint : bool
+
+        /// Specifies the server URL. This option is required unless DefaultPushSource config value is set in
+        /// the NuGet config file.
+        Source : string option
+
+        /// The API key for the symbol server.
+        SymbolApiKey : string option
+
+        /// Specifies the symbol server URL.
+        SymbolSource : string option
+
+        /// Specifies the timeout for pushing to a server.
+        Timeout : TimeSpan option
+
+        /// Number of times to retry pushing the package
+        PushTrials : int
+    } with
+
+        static member Create () = {
+            DisableBuffering = false
+            SkipDuplicate = false
+            ApiKey = None
+            NoSymbols = false
+            NoServiceEndpoint = false
+            Source = None
+            SymbolApiKey = None
+            SymbolSource = None
+            Timeout = None
+            PushTrials = 5
+        }
+
+    type NuGetParams with
+
+        member internal x.NuGetPushOptions =
+            let normalize str = if String.isNullOrEmpty str then None else Some str
+
+            {
+                DisableBuffering = false
+                SkipDuplicate = false
+                ApiKey = normalize x.AccessKey
+                NoSymbols = false
+                NoServiceEndpoint = false
+                Source = normalize x.PublishUrl
+                SymbolApiKey = normalize x.SymbolAccessKey
+                SymbolSource = normalize x.SymbolPublishUrl
+                Timeout = Some x.TimeOut
+                PushTrials = x.PublishTrials
+            }
+
+        member internal x.ToolOptions = ToolOptions.Create x.ToolPath "push" x.WorkingDir true
+        member internal x.Nupkg = (x.OutputPath @@ packageFileName x |> Path.getFullName)
+
+    let internal toPushCliArgs param =
+        let toSeconds (t : TimeSpan) = t.TotalSeconds |> int |> string
+
+        let stringToArg name values = values |> List.collect (fun v -> [ "-" + name; v ])
+
+        let boolToArg name value =
+            match value with
+            | true -> [ sprintf "-%s" name ]
+            | false -> []
+
+        [
+            param.ApiKey |> Option.toList |> stringToArg "ApiKey"
+            param.DisableBuffering |> boolToArg "DisableBuffering"
+            param.NoSymbols |> boolToArg "NoSymbols"
+            param.NoServiceEndpoint |> boolToArg "NoServiceEndpoint"
+            param.Source |> Option.toList |> stringToArg "Source"
+            param.SymbolApiKey
+            |> Option.toList
+            |> stringToArg "SymbolApiKey"
+            param.SymbolSource
+            |> Option.toList
+            |> stringToArg "SymbolSource"
+            param.Timeout
+            |> Option.map toSeconds
+            |> Option.toList
+            |> stringToArg "Timeout"
+        ]
+        |> List.concat
+        |> List.filter (not << String.IsNullOrEmpty)
+
+    let rec private push (options : ToolOptions) (parameters : NuGetPushParams) nupkg =
+        parameters.ApiKey
+        |> Option.iter (fun key -> TraceSecrets.register "<NuGetKey>" key)
+
+        parameters.SymbolApiKey
+        |> Option.iter (fun key -> TraceSecrets.register "<NuGetSymbolKey>" key)
+
+        let pushArgs = parameters |> toPushCliArgs |> Args.toWindowsCommandLine
+        let args = sprintf "%s \"%s\" %s" options.Command nupkg pushArgs
+
+        sprintf "%s %s in WorkingDir: %s Trials left: %d" options.ToolPath args (Path.getFullName options.WorkingDir) parameters.PushTrials
+        |> TraceSecrets.guardMessage
+        |> Trace.trace
+
+        try
+            let result =
+                CreateProcess.fromRawCommandLine options.ToolPath args
+                |> CreateProcess.withWorkingDirectory options.WorkingDir
+                |> CreateProcess.withTimeout (
+                    parameters.Timeout
+                    |> Option.defaultValue (TimeSpan.FromMinutes 5.0)
+                )
+                |> (fun p ->
+                    if options.IsFullFramework then
+                        p |> CreateProcess.withFramework
+                    else
+                        p)
+                |> Proc.run
+
+            if result.ExitCode <> 0 then
+                sprintf "Error during NuGet push. %s %s" options.ToolPath args
+                |> TraceSecrets.guardMessage
+                |> failwith
+
+        with _ when parameters.PushTrials > 0 ->
+            push options { parameters with PushTrials = parameters.PushTrials - 1 } nupkg
+
+    let private publish (parameters : NuGetParams) = push parameters.ToolOptions parameters.NuGetPushOptions parameters.Nupkg
+
+    /// push package to symbol server (and try again if something fails)
+    let rec private publishSymbols parameters =
+        let args =
+            sprintf "push -source %s \"%s\" %s" parameters.PublishUrl (packageFileName parameters) parameters.AccessKey
+
+        Trace.tracefn
+            "%s %s in WorkingDir: %s Trials left: %d"
+            parameters.ToolPath
+            args
+            (Path.getFullName parameters.WorkingDir)
+            parameters.PublishTrials
+
+        try
+            let result =
+                let tracing = Process.shouldEnableProcessTracing ()
+
+                try
+                    Process.setEnableProcessTracing false
+
+                    let processResult =
+                        CreateProcess.fromRawCommandLine parameters.ToolPath args
+                        |> CreateProcess.withTimeout parameters.TimeOut
+                        |> CreateProcess.withFramework
+                        |> CreateProcess.withWorkingDirectory (Path.getFullName parameters.WorkingDir)
+                        |> Proc.run
+
+                    processResult.ExitCode
+                finally
+                    Process.setEnableProcessTracing tracing
+
+            if result <> 0 then
+                sprintf "Error during NuGet symbol push. %s %s" parameters.ToolPath args
+                |> TraceSecrets.guardMessage
+                |> failwith
+        with _ when parameters.PublishTrials > 0 ->
+            publish { parameters with PublishTrials = parameters.PublishTrials - 1 }
+
+    /// <summary>
+    /// Creates a new NuGet package based on the given .nuspec or project file.
+    /// The .nuspec / projectfile is passed as-is (no templating is performed)
+    /// </summary>
+    ///
+    /// <param name="setParams">Function used to manipulate the default NuGet parameters.</param>
+    /// <param name="nuspecOrProjectFile">The .nuspec or project file name.</param>
+    let NuGetPackDirectly setParams nuspecOrProjectFile =
+        use __ = Trace.traceTask "NuGetPackDirectly" nuspecOrProjectFile
+        let parameters = NuGetDefaults () |> setParams
+
+        try
+            pack parameters nuspecOrProjectFile
+        with exn ->
+            (if not (isNull exn.InnerException) then
+                 exn.Message + "\r\n" + exn.InnerException.Message
+             else
+                 exn.Message)
+            |> TraceSecrets.guardMessage
+            |> failwith
+
+        __.MarkSuccess ()
+
+    /// <summary>
+    /// Creates a new NuGet package based on the given .nuspec or project file.
+    /// Template parameter substitution is performed when passing a .nuspec
+    /// </summary>
+    ///
+    /// <param name="setParams">Function used to manipulate the default NuGet parameters.</param>
+    /// <param name="nuspecOrProjectFile">The .nuspec or project file name.</param>
+    let NuGetPack setParams nuspecOrProjectFile =
+        use __ = Trace.traceTask "NuGetPack" nuspecOrProjectFile
+        let parameters = NuGetDefaults () |> setParams
+
+        try
+            match (createNuSpecFromTemplateIfNotProjFile parameters nuspecOrProjectFile) with
+            | Some nuspecTemplateFile ->
+                pack parameters nuspecTemplateFile
+                File.delete nuspecTemplateFile
+            | None -> pack parameters nuspecOrProjectFile
+        with exn ->
+            (if not (isNull exn.InnerException) then
+                 exn.Message + "\r\n" + exn.InnerException.Message
+             else
+                 exn.Message)
+            |> TraceSecrets.guardMessage
+            |> failwith
+
+        __.MarkSuccess ()
+
+    /// <summary>
+    /// Publishes a NuGet package to the nuget server.
+    /// </summary>
+    ///
+    /// <param name="setParams">Function used to manipulate the default NuGet parameters.</param>
+    let NuGetPublish setParams =
+        let parameters = NuGetDefaults () |> setParams
+        use __ = Trace.traceTask "NuGet-Push" (packageFileName parameters)
+
+        try
+            publish parameters
+        with exn ->
+            if not (isNull exn.InnerException) then
+                exn.Message + "\r\n" + exn.InnerException.Message
+            else
+                exn.Message
+            |> TraceSecrets.guardMessage
+            |> failwith
+
+        __.MarkSuccess ()
+
+    /// <summary>
+    /// Creates a new NuGet package, and optionally publishes it.
+    /// Template parameter substitution is performed when passing a .nuspec
+    /// </summary>
+    ///
+    /// <param name="setParams">Function used to manipulate the default NuGet parameters.</param>
+    /// <param name="nuspecOrProjectFile">The .nuspec file name.</param>
+    let NuGet setParams nuspecOrProjectFile =
+        use __ = Trace.traceTask "NuGet" nuspecOrProjectFile
+        let parameters = NuGetDefaults () |> setParams
+
+        try
+            match (createNuSpecFromTemplateIfNotProjFile parameters nuspecOrProjectFile) with
+            | Some nuspecTemplateFile ->
+                pack parameters nuspecTemplateFile
+                File.delete nuspecTemplateFile
+            | None -> pack parameters nuspecOrProjectFile
+
+            if parameters.Publish then
+                publish parameters
+
+                if not (isNull parameters.ProjectFile) then
+                    publishSymbols parameters
+        with exn ->
+            (if not (isNull exn.InnerException) then
+                 exn.Message + "\r\n" + exn.InnerException.Message
+             else
+                 exn.Message)
+            |> TraceSecrets.guardMessage
+            |> failwith
+
+        __.MarkSuccess ()
+
+    /// <summary>
+    /// NuSpec metadata type Please see
+    /// <a href="https://docs.microsoft.com/en-us/nuget/reference/nuspec">NuSpec reference</a>
+    /// </summary>
+    type NuSpecPackage = {
+        /// The case-insensitive package identifier
+        Id : string
+
+        /// The version of the package, following the major.minor.patch pattern. Version numbers may
+        /// include a pre-release suffix
+        Version : string
+
+        /// A comma-separated list of packages authors, matching the profile names on nuget.org.
+        Authors : string
+
+        /// A comma-separated list of the package creators using profile names on nuget.org.
+        Owners : string
+
+        /// A URL for the package's home page, often shown in UI displays as well as nuget.org.
+        Url : string
+
+        /// Holds if the package is the latest version published or not
+        IsLatestVersion : bool
+
+        /// The creation date of the package
+        Created : DateTime
+
+        /// The published date of the package
+        Published : DateTime
+
+        /// The unique hash of the package
+        PackageHash : string
+
+        /// The package hash algorithm used
+        PackageHashAlgorithm : string
+
+        /// package license URL
+        LicenseUrl : string
+
+        /// The package project URL
+        ProjectUrl : string
+
+        /// Mark if the package need usage acceptance before using it by license
+        RequireLicenseAcceptance : bool
+
+        /// The package description
+        Description : string
+
+        /// The package language
+        Language : string
+
+        /// The release notes file of the package
+        ReleaseNotes : string
+
+        /// tags referencing the package
+        Tags : string
+    } with
+
+        member x.Name = sprintf "%s %s" x.Id x.Version
+        override x.ToString () = x.Name
+        member x.DirectoryName = sprintf "%s.%s" x.Id x.Version
+        member x.FileName = sprintf "%s.%s.nupkg" x.Id x.Version
+
+    /// <summary>
+    /// Parses nuspec metadata from a nuspec file.
+    /// </summary>
+    ///
+    /// <param name="nuspec">The .nuspec file content.</param>
+    let getNuspecProperties (nuspec : string) =
+        let doc = Xml.createDoc nuspec
+
+        let namespaces = [
+            "x", "http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"
+            "y", "http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd"
+            "default", ""
+            "inDoc", doc.DocumentElement.NamespaceURI
+        ]
+
+        let getValue name =
+            let getWith ns =
+                try
+                    doc
+                    |> Xml.selectXPathValue (sprintf "%s:metadata/%s:%s" ns ns name) namespaces
+                    |> Some
+                with exn ->
+                    None
+
+            namespaces
+            |> Seq.map fst
+            |> Seq.tryPick (fun ns -> getWith ns)
+            |> (fun x -> if x.IsSome then x.Value else "")
+
+        {
+            Id = getValue "id"
+            Version = getValue "version"
+            Authors = getValue "authors"
+            Owners = getValue "owners"
+            LicenseUrl = getValue "licenseUrl"
+            ProjectUrl = getValue "projectUrl"
+            RequireLicenseAcceptance = (getValue "requireLicenseAcceptance").ToLower () = "true"
+            Description = getValue "description"
+            Language = getValue "language"
+            Tags = getValue "tags"
+            ReleaseNotes = getValue "releaseNotes"
+            Url = String.Empty
+            IsLatestVersion = false
+            Created = DateTime.MinValue
+            Published = DateTime.MinValue
+            PackageHash = String.Empty
+            PackageHashAlgorithm = String.Empty
+        }
+
+    /// <summary>
+    /// NuGet package information
+    /// </summary>
+    type NugetPackageInfo = {
+        /// The case-insensitive package identifier
+        Id : string
+
+        /// The version of the package, following the major.minor.patch pattern. Version numbers may
+        /// include a pre-release suffix
+        Version : string
+
+        /// The package description
+        Description : string
+
+        /// The package summary notes
+        Summary : string
+
+        /// Holds if the package is the latest version published or not
+        IsLatestVersion : bool
+
+        /// A comma-separated list of packages authors, matching the profile names on nuget.org.
+        Authors : string
+
+        /// A comma-separated list of the package creators using profile names on nuget.org.
+        Owners : string
+
+        /// tags referencing the package
+        Tags : string
+
+        /// The package project URL
+        ProjectUrl : string
+
+        /// package license URL
+        LicenseUrl : string
+
+        /// The package title
+        Title : string
+    }
+
+    /// Default NuGet feed. Using V3 feed: <c>https://api.nuget.org/v3/index.json</c>
+    let galleryV3 = "https://api.nuget.org/v3/index.json"
+
+#if NETSTANDARD
+    open System.Net.Http
+    open Newtonsoft.Json.Linq
+
+    type WebClient = HttpClient
+
+    type HttpClient with
+
+        member x.DownloadFileTaskAsync (uri : Uri, filePath : string) =
+            async {
+                let! response = x.GetAsync (uri) |> Async.AwaitTask
+
+                use fileStream = new FileStream (filePath, FileMode.Create, FileAccess.Write, FileShare.None)
+
+                do! response.Content.CopyToAsync (fileStream) |> Async.AwaitTask
+                fileStream.Flush ()
+            }
+            |> Async.StartAsTask
+
+        member x.DownloadFileTaskAsync (uri : string, filePath : string) = x.DownloadFileTaskAsync (Uri uri, filePath)
+
+        member x.DownloadFile (uri : string, filePath : string) = x.DownloadFileTaskAsync(uri, filePath).GetAwaiter().GetResult ()
+
+        member x.DownloadFile (uri : Uri, filePath : string) = x.DownloadFileTaskAsync(uri, filePath).GetAwaiter().GetResult ()
+
+        member x.DownloadStringTaskAsync (uri : Uri) =
+            async {
+                let! response = x.GetAsync (uri) |> Async.AwaitTask
+                let! result = response.Content.ReadAsStringAsync () |> Async.AwaitTask
+                return result
+            }
+            |> Async.StartAsTask
+
+        member x.DownloadStringTaskAsync (uri : string) = x.DownloadStringTaskAsync (Uri uri)
+
+        member x.DownloadString (uri : string) = x.DownloadStringTaskAsync(uri).GetAwaiter().GetResult ()
+
+        member x.DownloadString (uri : Uri) = x.DownloadStringTaskAsync(uri).GetAwaiter().GetResult ()
+
+        member x.DownloadDataTaskAsync (uri : Uri) =
+            async {
+                let! response = x.GetAsync (uri) |> Async.AwaitTask
+                let! result = response.Content.ReadAsByteArrayAsync () |> Async.AwaitTask
+                return result
+            }
+            |> Async.StartAsTask
+
+        member x.DownloadDataTaskAsync (uri : string) = x.DownloadDataTaskAsync (Uri uri)
+
+        member x.DownloadData (uri : string) = x.DownloadDataTaskAsync(uri).GetAwaiter().GetResult ()
+
+        member x.DownloadData (uri : Uri) = x.DownloadDataTaskAsync(uri).GetAwaiter().GetResult ()
+
+        member x.UploadFileAsMultipart (url : Uri) filename =
+            let fileTemplate =
+                "--{0}\r\nContent-Disposition: form-data; name=\"{1}\"; filename=\"{2}\"\r\nContent-Type: {3}\r\n\r\n"
+
+            let boundary =
+                "---------------------------"
+                + DateTime.Now.Ticks.ToString ("x", System.Globalization.CultureInfo.InvariantCulture)
+
+            let fileInfo = FileInfo (Path.GetFullPath (filename))
+
+            let fileHeaderBytes =
+                String.Format (
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    fileTemplate,
+                    boundary,
+                    "package",
+                    "package",
+                    "application/octet-stream"
+                )
+                |> Encoding.UTF8.GetBytes
+
+            let newlineBytes = Environment.NewLine |> Encoding.UTF8.GetBytes
+
+            let trailerBytes =
+                String.Format (System.Globalization.CultureInfo.InvariantCulture, "--{0}--", boundary)
+                |> Encoding.UTF8.GetBytes
+
+            x.DefaultRequestHeaders.Add ("ContentType", "multipart/form-data; boundary=" + boundary)
+            use stream = new MemoryStream () // x.OpenWrite(url, "PUT")
+            stream.Write (fileHeaderBytes, 0, fileHeaderBytes.Length)
+            use fileStream = File.OpenRead fileInfo.FullName
+            fileStream.CopyTo (stream, (4 * 1024))
+            stream.Write (newlineBytes, 0, newlineBytes.Length)
+            stream.Write (trailerBytes, 0, trailerBytes.Length)
+            stream.Write (newlineBytes, 0, newlineBytes.Length)
+            stream.Position <- 0L
+            x.PutAsync(url, new StreamContent (stream)).GetAwaiter().GetResult ()
+
+    let internal addAcceptHeader (client : HttpClient) (contentType : string) =
+        for headerVal in contentType.Split ([| ',' |], StringSplitOptions.RemoveEmptyEntries) do
+            client.DefaultRequestHeaders.Accept.Add (System.Net.Http.Headers.MediaTypeWithQualityHeaderValue (headerVal))
+
+    let internal addHeader (client : HttpClient) (headerKey : string) (headerVal : string) = client.DefaultRequestHeaders.Add (headerKey, headerVal)
+#else
+
+    open Newtonsoft.Json.Linq
+    open System.Net
+
+    type WebClient with
+
+        member x.UploadFileAsMultipart (url : Uri) filename =
+            let fileTemplate =
+                "--{0}\r\nContent-Disposition: form-data; name=\"{1}\"; filename=\"{2}\"\r\nContent-Type: {3}\r\n\r\n"
+
+            let boundary =
+                "---------------------------"
+                + DateTime.Now.Ticks.ToString ("x", System.Globalization.CultureInfo.InvariantCulture)
+
+            let fileInfo = (new FileInfo (Path.GetFullPath (filename)))
+
+            let fileHeaderBytes =
+                System.String.Format (
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    fileTemplate,
+                    boundary,
+                    "package",
+                    "package",
+                    "application/octet-stream"
+                )
+                |> Encoding.UTF8.GetBytes
+            // we use a windows-style newline rather than Environment.NewLine for compatibility
+            let newlineBytes = "\r\n" |> Encoding.UTF8.GetBytes
+
+            let trailerbytes =
+                String.Format (System.Globalization.CultureInfo.InvariantCulture, "--{0}--", boundary)
+                |> Encoding.UTF8.GetBytes
+
+            x.Headers.Add (HttpRequestHeader.ContentType, "multipart/form-data; boundary=" + boundary)
+            use stream = x.OpenWrite (url, "PUT")
+            stream.Write (fileHeaderBytes, 0, fileHeaderBytes.Length)
+            use fileStream = File.OpenRead fileInfo.FullName
+            fileStream.CopyTo (stream, (4 * 1024))
+            stream.Write (newlineBytes, 0, newlineBytes.Length)
+            stream.Write (trailerbytes, 0, trailerbytes.Length)
+            stream.Write (newlineBytes, 0, newlineBytes.Length)
+            ()
+
+    type WebClient = System.Net.WebClient
+
+    let internal addAcceptHeader (client : WebClient) contentType = client.Headers.Add (HttpRequestHeader.Accept, contentType)
+
+    let internal addHeader (client : WebClient) (headerKey : string) (headerVal : string) = client.Headers.Add (headerKey, headerVal)
+
+#endif
+
+    let private webClient = new WebClient ()
+
+    /// [omit]
+    let discoverRepoUrl =
+        lazy
+            (let resp = webClient.DownloadString (galleryV3)
+             let json = JObject.Parse resp
+
+             let nugetSearchResource =
+                 (json.Item ("resources") :?> JArray)
+                 |> Seq.find (fun resource -> resource.Item("@type").ToString () = "SearchQueryService")
+                 :?> JObject
+
+             nugetSearchResource.Item("@id").ToString ())
+
+    /// [omit]
+    let getRepoUrl () = discoverRepoUrl.Force ()
+
+    /// [omit]
+    let extractFeedPackageFromJson (data : JObject) isLatestVersion = {
+        Id = data["id"].ToString ()
+        Version = data["version"].ToString ()
+        Description = data["description"].ToString ()
+        Summary = data["summary"].ToString ()
+        IsLatestVersion = isLatestVersion
+        Authors = String.Join (",", data["authors"] :?> JArray)
+        Owners = String.Join (",", data["authors"] :?> JArray)
+        Tags = String.Join (",", data["tags"] :?> JArray)
+        ProjectUrl = data["projectUrl"].ToString ()
+        LicenseUrl = data["licenseUrl"].ToString ()
+        Title = data["title"].ToString ()
+    }
+
+    /// <summary>
+    /// Gets a Package information from NuGet feed by package id.
+    /// </summary>
+    ///
+    /// <param name="repoUrl">Query endpoint of NuGet search service</param>
+    /// <param name="packageName">The package to get</param>
+    /// <param name="version">The specific version to get</param>
+    let getPackage (repoUrl : string) (packageName : string) (version : string) =
+        let url : string =
+            repoUrl.TrimEnd ('/')
+            + "?q=packageid:"
+            + packageName
+            + "&take=1"
+        let resp = webClient.DownloadString (url)
+        let json = JObject.Parse resp
+        let data = (json["data"] :?> JArray)[0] :?> JObject
+        let packageVersions = (data["versions"] :?> JArray).ToObject<List<JObject>> ()
+
+        let versionExists =
+            packageVersions
+            |> List.exists (fun listedVersion -> listedVersion["version"].ToString () = version)
+
+        if not versionExists then
+            failwithf "Requested %s for package %s is not registered on NuGet" version packageName
+
+        let isLatest = (data["version"].ToString () = version)
+        // set the requested version instead of latest.
+        data["version"] <- JValue version
+        extractFeedPackageFromJson data isLatest
+
+    /// <summary>
+    /// Gets the latest published package from NuGet feed by package id.
+    /// </summary>
+    ///
+    /// <param name="repoUrl">Query endpoint of NuGet search service</param>
+    /// <param name="packageName">The package to get</param>
+    let getLatestPackage (repoUrl : string) packageName =
+        let url : string =
+            repoUrl.TrimEnd ('/')
+            + "?q=packageid:"
+            + packageName
+            + "&take=1"
+        let resp = webClient.DownloadString (url)
+        let json = JObject.Parse resp
+        let data = (json["data"] :?> JArray)[0] :?> JObject
+        extractFeedPackageFromJson data true
+
+    /// <summary>
+    /// Search NuGet query endpoint for packages matching given name by title
+    /// </summary>
+    ///
+    /// <param name="repoUrl">Query endpoint of NuGet search service</param>
+    /// <param name="packageName">The package to search for</param>
+    let searchByTitle (repoUrl : string) (packageName : string) =
+        let url : string = repoUrl.TrimEnd ('/') + "?q=title:" + packageName
+        let resp = webClient.DownloadString (url)
+        let json = JObject.Parse resp
+        let data = (json["data"] :?> JArray).ToObject<List<JObject>> ()
+        data
+        |> List.map (fun datum -> extractFeedPackageFromJson datum false)
+
+    /// [omit]
+    let downloadPackage targetDir (package : NuSpecPackage) =
+        Directory.ensure targetDir
+        let targetFileName = targetDir @@ package.FileName
+
+        Trace.tracefn "Downloading package %s %s from %s and saving it to %s" package.Id package.Version package.Url targetFileName
+
+        webClient.DownloadFile (package.Url, targetFileName)
+        targetFileName
+
+    /// [omit]
+    let argList name values =
+        values
+        |> Seq.collect (fun v -> [ "-" + name; sprintf @"""%s""" v ])
+        |> String.concat " "
+
+    /// <summary>
+    /// Holds data for NuGet dependencies of a package
+    /// </summary>
+    type NuGetDependency = {
+        /// The package Id
+        Id : string
+
+        /// The package version
+        Version : SemVerInfo
+
+        /// Mark if the dependency is a development (dev) dependency or not
+        IsDevelopmentDependency : bool
+    }
+
+    /// <summary>
+    /// Returns the dependencies from specified packages.config file
+    /// </summary>
+    ///
+    /// <param name="packagesFile">The packages file to use</param>
+    let getDependencies (packagesFile : string) =
+        let xName = XName.op_Implicit
+
+        let attribute name (e : XElement) =
+            match e.Attribute (xName name) with
+            | null -> ""
+            | a -> a.Value
+
+        let isDevDependency package =
+            let value = attribute "developmentDependency" package
+            String.Equals (value, bool.TrueString, StringComparison.OrdinalIgnoreCase)
+
+        let doc = XDocument.Load packagesFile
+
+        [
+            for package in doc.Descendants (xName "package") ->
+                {
+                    Id = attribute "id" package
+                    Version = SemVer.parse (attribute "version" package)
+                    IsDevelopmentDependency = isDevDependency package
+                }
+        ]

--- a/build/Properties/launchSettings.json
+++ b/build/Properties/launchSettings.json
@@ -1,8 +1,15 @@
 {
   "profiles": {
-    "Build": {
-      "commandName": "Project"//,
-      //"commandLineArgs": "--target Clean"
+    "BuildAndTest": {
+      "commandName": "Project"
+    },
+    "PackAndPush": {
+      "commandName": "Project",
+      "commandLineArgs": "--target PackAndPush"
+    },
+    "GenerateDocs": {
+      "commandName": "Project",
+      "commandLineArgs": "--target GenerateDocs"
     }
   }
 }

--- a/src/FSharp.Data.GraphQL.Server.Relay/FSharp.Data.GraphQL.Server.Relay.fsproj
+++ b/src/FSharp.Data.GraphQL.Server.Relay/FSharp.Data.GraphQL.Server.Relay.fsproj
@@ -19,6 +19,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Condition="$(IsNuget) != ''" Include="FSharp.Data.GraphQL.Shared" VersionOverride="$(Version)" />
+    <ProjectReference Condition="$(IsNuget) == ''" Include="..\FSharp.Data.GraphQL.Shared\FSharp.Data.GraphQL.Shared.fsproj" />
     <PackageReference Condition="$(IsNuget) != ''" Include="FSharp.Data.GraphQL.Server" VersionOverride="$(Version)" />
     <ProjectReference Condition="$(IsNuget) == ''" Include="..\FSharp.Data.GraphQL.Server\FSharp.Data.GraphQL.Server.fsproj" />
   </ItemGroup>

--- a/tests/FSharp.Data.GraphQL.IntegrationTests/introspection.json
+++ b/tests/FSharp.Data.GraphQL.IntegrationTests/introspection.json
@@ -1,5 +1,5 @@
 {
-  "documentId": 1444123434,
+  "documentId": 1360354553,
   "data": {
     "__schema": {
       "queryType": {
@@ -15,7 +15,7 @@
         {
           "kind": "SCALAR",
           "name": "Int",
-          "description": "The \u0060Int\u0060 scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.",
+          "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -25,7 +25,7 @@
         {
           "kind": "SCALAR",
           "name": "String",
-          "description": "The \u0060String\u0060 scalar type represents textual data, represented as UTF-8 character sequences. The \u0060String\u0060 type is most often used by GraphQL to represent free-form human-readable text.",
+          "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The `String` type is most often used by GraphQL to represent free-form human-readable text.",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -35,7 +35,7 @@
         {
           "kind": "SCALAR",
           "name": "Boolean",
-          "description": "The \u0060Boolean\u0060 scalar type represents \u0060true\u0060 or \u0060false\u0060.",
+          "description": "The `Boolean` scalar type represents `true` or `false`.",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -45,7 +45,7 @@
         {
           "kind": "SCALAR",
           "name": "Float",
-          "description": "The \u0060Float\u0060 scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).",
+          "description": "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -55,7 +55,7 @@
         {
           "kind": "SCALAR",
           "name": "ID",
-          "description": "The \u0060ID\u0060 scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The \u0060ID\u0060 type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as \u0060\u00224\u0022\u0060) or integer (such as \u00604\u0060) input value will be accepted as an ID.",
+          "description": "The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The `ID` type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `\"4\"`) or integer (such as `4`) input value will be accepted as an ID.",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -65,7 +65,7 @@
         {
           "kind": "SCALAR",
           "name": "DateTimeOffset",
-          "description": "The \u0060DateTimeOffset\u0060 scalar type represents a Date value with Time component. The \u0060DateTimeOffset\u0060 type appears in a JSON response as a String representation compatible with ISO-8601 format.",
+          "description": "The `DateTimeOffset` scalar type represents a Date value with Time component. The `DateTimeOffset` type appears in a JSON response as a String representation compatible with ISO-8601 format.",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -75,7 +75,7 @@
         {
           "kind": "SCALAR",
           "name": "DateOnly",
-          "description": "The \u0060DateOnly\u0060 scalar type represents a Date value without Time component. The \u0060DateOnly\u0060 type appears in a JSON response as a \u0060String\u0060 representation of full-date value as specified by [IETF 3339](https://www.ietf.org/rfc/rfc3339.txt).",
+          "description": "The `DateOnly` scalar type represents a Date value without Time component. The `DateOnly` type appears in a JSON response as a `String` representation of full-date value as specified by [IETF 3339](https://www.ietf.org/rfc/rfc3339.txt).",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -85,7 +85,7 @@
         {
           "kind": "SCALAR",
           "name": "URI",
-          "description": "The \u0060URI\u0060 scalar type represents a string resource identifier compatible with URI standard. The \u0060URI\u0060 type appears in a JSON response as a String.",
+          "description": "The `URI` scalar type represents a string resource identifier compatible with URI standard. The `URI` type appears in a JSON response as a String.",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -194,7 +194,7 @@
         {
           "kind": "OBJECT",
           "name": "__Directive",
-          "description": "A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document. In some cases, you need to provide options to alter GraphQL\u2019s execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.",
+          "description": "A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document. In some cases, you need to provide options to alter GraphQL’s execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.",
           "fields": [
             {
               "name": "args",
@@ -396,7 +396,7 @@
         {
           "kind": "OBJECT",
           "name": "__Type",
-          "description": "The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the \u0060__TypeKind\u0060 enum. Depending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.",
+          "description": "The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum. Depending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.",
           "fields": [
             {
               "name": "description",
@@ -422,7 +422,7 @@
                     "name": "Boolean",
                     "ofType": null
                   },
-                  "defaultValue": "False"
+                  "defaultValue": "false"
                 }
               ],
               "type": {
@@ -453,7 +453,7 @@
                     "name": "Boolean",
                     "ofType": null
                   },
-                  "defaultValue": "False"
+                  "defaultValue": "false"
                 }
               ],
               "type": {
@@ -768,43 +768,43 @@
             },
             {
               "name": "OBJECT",
-              "description": "Indicates this type is an object. \u0060fields\u0060 and \u0060interfaces\u0060 are valid fields.",
+              "description": "Indicates this type is an object. `fields` and `interfaces` are valid fields.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "INTERFACE",
-              "description": "Indicates this type is an interface. \u0060fields\u0060 and \u0060possibleTypes\u0060 are valid fields.",
+              "description": "Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "UNION",
-              "description": "Indicates this type is a union. \u0060possibleTypes\u0060 is a valid field.",
+              "description": "Indicates this type is a union. `possibleTypes` is a valid field.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "ENUM",
-              "description": "Indicates this type is an enum. \u0060enumValues\u0060 is a valid field.",
+              "description": "Indicates this type is an enum. `enumValues` is a valid field.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "INPUT_OBJECT",
-              "description": "Indicates this type is an input object. \u0060inputFields\u0060 is a valid field.",
+              "description": "Indicates this type is an input object. `inputFields` is a valid field.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "LIST",
-              "description": "Indicates this type is a list. \u0060ofType\u0060 is a valid field.",
+              "description": "Indicates this type is a list. `ofType` is a valid field.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "NON_NULL",
-              "description": "Indicates this type is a non-null. \u0060ofType\u0060 is a valid field.",
+              "description": "Indicates this type is a non-null. `ofType` is a valid field.",
               "isDeprecated": false,
               "deprecationReason": null
             }
@@ -1275,7 +1275,7 @@
             },
             {
               "name": "totalCount",
-              "description": "A count of the total number of objects in this connection, ignoring pagination. This allows a client to fetch the first five objects by passing \\\u00225\\\u0022 as the argument to \u0060first\u0060, then fetch the total count so it could display \\\u00225 of 83\\\u0022, for example. In cases where we employ infinite scrolling or don\u0027t have an exact count of entries, this field will return \u0060null\u0060.",
+              "description": "A count of the total number of objects in this connection, ignoring pagination. This allows a client to fetch the first five objects by passing \\\"5\\\" as the argument to `first`, then fetch the total count so it could display \\\"5 of 83\\\", for example. In cases where we employ infinite scrolling or don't have an exact count of entries, this field will return `null`.",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -1655,7 +1655,7 @@
         {
           "kind": "SCALAR",
           "name": "ObjectListFilter",
-          "description": "The \u0060Filter\u0060 scalar type represents a filter on one or more fields of an object in an object list. The filter is represented by a JSON object where the fields are the complemented by specific suffixes to represent a query.",
+          "description": "The `Filter` scalar type represents a filter on one or more fields of an object in an object list. The filter is represented by a JSON object where the fields are the complemented by specific suffixes to represent a query.",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -1666,7 +1666,7 @@
       "directives": [
         {
           "name": "include",
-          "description": "Directs the executor to include this field or fragment only when the \u0060if\u0060 argument is true.",
+          "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
           "locations": [
             "FIELD",
             "FRAGMENT_SPREAD",
@@ -1691,7 +1691,7 @@
         },
         {
           "name": "skip",
-          "description": "Directs the executor to skip this field or fragment when the \u0060if\u0060 argument is true.",
+          "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
           "locations": [
             "FIELD",
             "FRAGMENT_SPREAD",


### PR DESCRIPTION
1. Fixed `The 'NoBuild' property was set to true but the 'Build' target was invoked. ` error for the `Relay` project
2. Fixed ability to skip already published packages and continue with not yet published using `--skip-duplicate` parameter