### PR TITLE
Added `launchSettings.json` to benchmarks project

### DIFF
--- a/tests/FSharp.Data.GraphQL.Benchmarks/FSharp.Data.GraphQL.Benchmarks.fsproj
+++ b/tests/FSharp.Data.GraphQL.Benchmarks/FSharp.Data.GraphQL.Benchmarks.fsproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -17,6 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Include="Properties\launchSettings.json" />
     <Compile Include="Prolog.fs" />
     <Compile Include="Schema.fs" />
     <Compile Include="AsyncSchema.fs" />

--- a/tests/FSharp.Data.GraphQL.Benchmarks/Properties/launchSettings.json
+++ b/tests/FSharp.Data.GraphQL.Benchmarks/Properties/launchSettings.json
@@ -1,0 +1,24 @@
+{
+  "profiles": {
+    "All": {
+      "commandName": "Project",
+      "commandLineArgs": "--filter *"
+    },
+    "AsyncVal": {
+      "commandName": "Project",
+      "commandLineArgs": "--filter *AsyncValBenchmark*"
+    },
+    "Simple execution": {
+      "commandName": "Project",
+      "commandLineArgs": "--filter *SimpleExecutionBenchmark*"
+    },
+    "Simple execution with middlewares": {
+      "commandName": "Project",
+      "commandLineArgs": "--filter *SimpleExecutionWithMiddlewaresBenchmark*"
+    },
+    "Parsing": {
+      "commandName": "Project",
+      "commandLineArgs": "--filter *ParsingBenchmark*"
+    }
+  }
+}


### PR DESCRIPTION
For history purposes

| Method                         | Mean      | Error    | StdDev   | Min       | Max       | Op/s     | Gen0    | Gen1   | Allocated |
|------------------------------- |----------:|---------:|---------:|----------:|----------:|---------:|--------:|-------:|----------:|
| BenchmarkSimpleQueryUnparsed   |  83.25 us | 1.649 us | 1.543 us |  81.07 us |  87.04 us | 12,011.6 |  2.3193 |      - |     19 KB |
| BenchmarkSimpleQueryParsed     |  68.27 us | 1.306 us | 1.282 us |  66.59 us |  70.87 us | 14,647.6 |  1.0986 |      - |   9.56 KB |
| BenchmarkSimpleQueryPlanned    |  29.32 us | 0.535 us | 0.418 us |  28.60 us |  30.07 us | 34,111.6 |  0.9155 |      - |   7.58 KB |
| BenchmarkFlatQueryUnparsed     | 233.03 us | 2.654 us | 2.482 us | 228.53 us | 235.83 us |  4,291.2 |  7.3242 |      - |  63.07 KB |
| BenchmarkFlatQueryParsed       | 210.31 us | 2.704 us | 2.529 us | 206.20 us | 214.19 us |  4,755.0 |  5.6152 | 0.2441 |  47.11 KB |
| BenchmarkFlatQueryPlanned      | 162.98 us | 1.722 us | 1.610 us | 161.00 us | 165.93 us |  6,135.8 |  5.1270 | 0.2441 |  43.77 KB |
| BenchmarkNestedQueryUnparsed   | 398.08 us | 2.335 us | 1.950 us | 394.31 us | 401.22 us |  2,512.1 | 20.5078 | 0.4883 | 169.34 KB |
| BenchmarkNestedQueryParsed     | 350.29 us | 3.153 us | 2.633 us | 347.09 us | 356.82 us |  2,854.8 | 14.6484 | 0.4883 | 120.07 KB |
| BenchmarkNestedQueryPlanned    | 299.97 us | 2.615 us | 2.184 us | 295.74 us | 303.87 us |  3,333.7 | 13.1836 |      - | 109.41 KB |
| BenchmarkFilteredQueryUnparsed | 173.42 us | 2.713 us | 2.538 us | 169.62 us | 177.50 us |  5,766.2 |  6.8359 |      - |  56.48 KB |
| BenchmarkFilteredQueryParsed   | 140.57 us | 2.723 us | 2.913 us | 135.77 us | 146.48 us |  7,114.0 |  3.4180 |      - |  29.16 KB |
| BenchmarkFilteredQueryPlanned  |  92.81 us | 1.503 us | 1.332 us |  90.71 us |  95.11 us | 10,774.7 |  2.8076 |      - |  23.67 KB |
