### PR TITLE
Tiny code clean-up

### DIFF
--- a/src/FSharp.Data.GraphQL.Server.AspNetCore/GraphQLSubscriptionsManagement.fs
+++ b/src/FSharp.Data.GraphQL.Server.AspNetCore/GraphQLSubscriptionsManagement.fs
@@ -19,9 +19,11 @@ let executeOnUnsubscribeAndDispose (id : SubscriptionId) (subscription : Subscri
             unsubscriber.Dispose ()
 
 let removeSubscription (id : SubscriptionId) (subscriptions : SubscriptionsDict) =
-    if subscriptions.ContainsKey (id) then
-        subscriptions.[id] |> executeOnUnsubscribeAndDispose id
+    match subscriptions.TryGetValue id with
+    | true, sub ->
+        sub |> executeOnUnsubscribeAndDispose id
         subscriptions.Remove (id) |> ignore
+    | false, _ -> ()
 
 let removeAllSubscriptions (subscriptions : SubscriptionsDict) =
     subscriptions

--- a/src/FSharp.Data.GraphQL.Shared/Helpers/Reflection.fs
+++ b/src/FSharp.Data.GraphQL.Shared/Helpers/Reflection.fs
@@ -79,7 +79,7 @@ module internal ReflectionHelper =
         let some =
             let createSome = optionType.GetDeclaredMethod "Some"
             fun value ->
-                if value <> null
+                if not (isNull value)
                 then
                     let valueType = value.GetType().GetTypeInfo()
                     if valueType = optionType
@@ -91,7 +91,7 @@ module internal ReflectionHelper =
         let value =
             let x = optionType.GetDeclaredProperty "Value"
             fun input ->
-                if input <> null
+                if not (isNull input)
                 then
                     let valueType = input.GetType().GetTypeInfo()
                     if valueType = optionType
@@ -113,7 +113,7 @@ module internal ReflectionHelper =
         let some =
             let createSome = optionType.GetDeclaredMethod "Some"
             fun value ->
-                if value <> null
+                if not (isNull value)
                 then
                     let valueType = value.GetType().GetTypeInfo()
                     if valueType = optionType
@@ -125,7 +125,7 @@ module internal ReflectionHelper =
         let value =
             let x = optionType.GetDeclaredProperty "Value"
             fun input ->
-                if input <> null
+                if not (isNull input)
                 then
                     let valueType = input.GetType().GetTypeInfo()
                     if valueType = optionType

--- a/src/FSharp.Data.GraphQL.Shared/SchemaDefinitions.fs
+++ b/src/FSharp.Data.GraphQL.Shared/SchemaDefinitions.fs
@@ -169,7 +169,7 @@ module SchemaDefinitions =
 
     /// Check if provided obj value is an Option and extract its wrapped value as object if possible
     let private (|Option|_|) (x : obj) =
-        if x = null then None
+        if isNull x then None
         else
             let t = x.GetType().GetTypeInfo()
             if t.IsGenericType && t.GetGenericTypeDefinition() = typedefof<option<_>> then

--- a/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
+++ b/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
@@ -515,9 +515,9 @@ and FieldExecuteMap (compiler : FieldExecuteCompiler) =
     /// <param name="fieldName">The field name of the object that has the field that needs to be executed.</param>
     member _.GetExecute (typeName : string, fieldName : string) =
         let key = getKey typeName fieldName
-        if map.ContainsKey (key) then
-            fst map.[key]
-        else
+        match map.TryGetValue key with
+        | true, mapv -> fst mapv
+        | false, _ ->
             Unchecked.defaultof<ExecuteField>
 
     /// <summary>


### PR DESCRIPTION
Tiny code clean-up:

- Avoid dictionary double lookups
- Use isNull instead of "= null"

However, this doesn't affect the execution time performance or memory consumption on any significant manner, because the code-changes are basically on design-time files.
