### PR TITLE
Executor: allow overriding AsyncExecute

### DIFF
--- a/src/FSharp.Data.GraphQL.Server/Executor.fs
+++ b/src/FSharp.Data.GraphQL.Server/Executor.fs
@@ -14,7 +14,7 @@ open FSharp.Data.GraphQL.Parser
 open FSharp.Data.GraphQL.Planning
 
 /// A function signature that represents a middleware for schema compile phase.
-/// I takes two arguments: A schema compile context, containing all the data used for the
+/// It takes two arguments: A schema compile context, containing all the data used for the
 /// compilation phase, and another function that can be called to pass
 /// the execution for the next middleware.
 type SchemaCompileMiddleware =


### PR DESCRIPTION
Type `Executor<'Root>` is said to be *"The standard schema executor"*  
however there's no way to change it, as all functions taking an Executor are accepting only instances of this type and thus execution process can not be overridden.

I needed to provide my own `AsyncExecute` that intercepts cases where `result.Content = GQLExecutionResult.RequestError _` and in some cases defers execution elsewhere.

So I made AsyncExecute abstract in order to be able to override it.

After applying this pull request, I can now:
```fsharp
type CustomExecutor<'Root>(schema,middleware) =
    inherit Executor<'Root>(schema, middleware)
    override _.AsyncExecute(executionPlan: ExecutionPlan, ?data: 'Root, ?variables: ImmutableDictionary<string, JsonElement>): Async<GQLExecutionResult> =
        let result = base.AsyncExecute(executionPlan, ?data=data, ?variables=variables)
        async {
            let! result = result
            match result.Content with
            | (* ... fiddle with result *)
        }
```