### PR TITLE
Double coercion and error messages fixes

### DIFF
--- a/src/FSharp.Data.GraphQL.Server.Middleware/MiddlewareDefinitions.fs
+++ b/src/FSharp.Data.GraphQL.Server.Middleware/MiddlewareDefinitions.fs
@@ -90,6 +90,7 @@ type internal ObjectListFilterMiddleware<'ObjectType, 'ListType>(reportToMetadat
                         match x.Name with
                         | "filter" -> ObjectListFilter.CoerceInput (InlineConstant x.Value)
                         | _ -> Ok NoFilter)
+                    |> Seq.toList
                 match filterResults |> splitSeqErrorsList with
                 | Error errs -> Error errs
                 | Ok filters ->

--- a/src/FSharp.Data.GraphQL.Server.Middleware/SchemaDefinitions.fs
+++ b/src/FSharp.Data.GraphQL.Server.Middleware/SchemaDefinitions.fs
@@ -69,7 +69,8 @@ module SchemaDefinitions =
 
         let rec mapFilter (name : string, value : InputValue) =
             let mapFilters fields =
-                let coerceResults = fields |> Seq.map coerceObjectListFilterInput |> splitSeqErrorsList
+                let coerceResults =
+                    fields |> Seq.map coerceObjectListFilterInput |> Seq.toList |> splitSeqErrorsList
                 match coerceResults with
                 | Error errs -> Error errs
                 | Ok coerced -> coerced |> removeNoFilter |> Seq.toList |> Ok
@@ -95,7 +96,8 @@ module SchemaDefinitions =
             | _ -> Ok NoFilter
 
         and mapInput value =
-            let filterResults = value |> Map.toSeq |> Seq.map mapFilter |> splitSeqErrorsList
+            let filterResults =
+                value |> Map.toSeq |> Seq.map mapFilter |> Seq.toList |> splitSeqErrorsList
             match filterResults with
             | Error errs -> Error errs
             | Ok filters ->

--- a/src/FSharp.Data.GraphQL.Server/ErrorsProcessing.fs
+++ b/src/FSharp.Data.GraphQL.Server/ErrorsProcessing.fs
@@ -11,10 +11,10 @@ open FsToolkit.ErrorHandling
 
 let getObjectErrors (object: IReadOnlyDictionary<string, Result<'t, IGQLError>>) =
     object
-    |> Seq.choose (fun kvp ->
+    |> Seq.vchoose (fun kvp ->
         match kvp.Value with
-        | Ok _ -> None
-        | Error err -> Some err)
+        | Ok _ -> ValueNone
+        | Error err -> ValueSome err)
     |> Seq.toList
 
 let getObjectValues (object: IReadOnlyDictionary<string, Result<'t, IGQLError>>) =
@@ -30,7 +30,7 @@ let getObjectValues (object: IReadOnlyDictionary<string, Result<'t, IGQLError>>)
 let splitObjectErrors (object: IReadOnlyDictionary<string, Result<'t, IGQLError>>) =
     let errors = object |> getObjectErrors
 
-    if not <| List.isEmpty errors then
+    if not errors.IsEmpty then
         Error errors
     else
         let values = object |> getObjectValues
@@ -38,10 +38,11 @@ let splitObjectErrors (object: IReadOnlyDictionary<string, Result<'t, IGQLError>
 
 let getObjectErrorsList (object: IReadOnlyDictionary<string, Result<'t, IGQLError list>>) =
     object
-    |> Seq.choose (fun kvp ->
+    |> Seq.vchoose (fun kvp ->
         match kvp.Value with
-        | Ok _ -> None
-        | Error err -> Some err)
+        | Ok _ -> ValueNone
+        | Error err -> ValueSome err)
+    |> Seq.collect id
     |> Seq.toList
 
 let getObjectValuesList (object: IReadOnlyDictionary<string, Result<'t, IGQLError list>>) =
@@ -57,18 +58,18 @@ let getObjectValuesList (object: IReadOnlyDictionary<string, Result<'t, IGQLErro
 let splitObjectErrorsList (object: IReadOnlyDictionary<string, Result<'t, IGQLError list>>) =
     let errors = object |> getObjectErrorsList
 
-    if not <| List.isEmpty errors then
-        Error (errors |> List.collect id)
+    if not errors.IsEmpty then
+        Error errors
     else
         let values = object |> getObjectValuesList
         Ok values
 
 let getSeqErrors (items: Result<'t, IGQLError> seq) =
     items
-    |> Seq.choose (fun result ->
+    |> Seq.vchoose (fun result ->
         match result with
-        | Ok _ -> None
-        | Error err -> Some err)
+        | Ok _ -> ValueNone
+        | Error err -> ValueSome err)
     |> Seq.toList
 
 let getSeqValues (items: Result<'t, IGQLError> seq) =
@@ -79,10 +80,10 @@ let getSeqValues (items: Result<'t, IGQLError> seq) =
         | Error _ -> raise <| ArgumentException())
     |> Seq.toArray
 
-let splitSeqErrors (items: Result<'t, IGQLError> seq) =
+let splitSeqErrors (items: Result<'t, IGQLError> list) =
     let errors = items |> getSeqErrors
 
-    if not <| List.isEmpty errors then
+    if not errors.IsEmpty then
         Error errors
     else
         let values = items |> getSeqValues
@@ -90,10 +91,11 @@ let splitSeqErrors (items: Result<'t, IGQLError> seq) =
 
 let getSeqErrorsList (items: Result<'t, IGQLError list> seq) =
     items
-    |> Seq.choose (fun result ->
+    |> Seq.vchoose (fun result ->
         match result with
-        | Ok _ -> None
-        | Error err -> Some err)
+        | Ok _ -> ValueNone
+        | Error err -> ValueSome err)
+    |> Seq.collect id
     |> Seq.toList
 
 let getSeqValuesList (items: Result<'t, IGQLError list> seq) =
@@ -104,11 +106,11 @@ let getSeqValuesList (items: Result<'t, IGQLError list> seq) =
         | Error _ -> raise <| ArgumentException())
     |> Seq.toArray
 
-let splitSeqErrorsList (items: Result<'t, IGQLError list> seq) =
+let splitSeqErrorsList (items: Result<'t, IGQLError list> list) =
     let errors = items |> getSeqErrorsList
 
-    if not <| List.isEmpty errors then
-        Error (errors |> List.collect id)
+    if not errors.IsEmpty then
+        Error errors
     else
         let values = items |> getSeqValuesList
         Ok values

--- a/src/FSharp.Data.GraphQL.Server/ReflectionHelper.fs
+++ b/src/FSharp.Data.GraphQL.Server/ReflectionHelper.fs
@@ -149,7 +149,7 @@ module internal ReflectionHelper =
             ty.GetGenericArguments().[0]
         else ty
 
-    let isAssignableWithUnwrap (from: Type) (``to``: Type) =
+    let rec isAssignableWithUnwrap (from: Type) (``to``: Type) =
 
         let checkCollections (from: Type) (``to``: Type) =
             if
@@ -176,17 +176,16 @@ module internal ReflectionHelper =
                 from.GetGenericArguments()[0]
             else from
         let actualTo =
-            if ``to``.FullName.StartsWith OptionTypeName || ``to``.FullName.StartsWith ValueOptionTypeName then
+            if ``to``.FullName.StartsWith OptionTypeName ||
+               ``to``.FullName.StartsWith ValueOptionTypeName
+            then
                 ``to``.GetGenericArguments()[0]
             else ``to``
 
         let result = actualFrom.IsAssignableTo actualTo || checkCollections actualFrom actualTo
-        if result then result
-        else
-            if actualFrom.FullName.StartsWith OptionTypeName || actualFrom.FullName.StartsWith ValueOptionTypeName then
-                let actualFrom = actualFrom.GetGenericArguments()[0]
-                actualFrom.IsAssignableTo actualTo || checkCollections actualFrom actualTo
-            else result
+        if result then true
+        elif actualFrom <> from || actualTo <> ``to`` then isAssignableWithUnwrap actualFrom actualTo
+        else false
 
     let matchConstructor (t: Type) (fields: string []) =
         if FSharpType.IsRecord(t, true) then FSharpValue.PreComputeRecordConstructorInfo(t, true)

--- a/src/FSharp.Data.GraphQL.Server/Values.fs
+++ b/src/FSharp.Data.GraphQL.Server/Values.fs
@@ -147,20 +147,20 @@ let rec internal compileByType
 
         let exceptions : exn list =  [
             if missingParameters.Any () then
-                InvalidInputTypeException (
-                    $"Input object '%s{objDef.Name}' refers to type '%O{objtype}', but mandatory constructor parameters '%A{missingParameters}' don't match any of the defined input fields",
-                    missingParameters.ToImmutableHashSet ()
-                )
+                let message =
+                    let ``params`` = String.Join ("', '", missingParameters)
+                    $"Input object '%s{objDef.Name}' refers to type '%O{objtype}', but mandatory constructor parameters '%s{``params``}' don't match any of the defined GraphQL input fields"
+                InvalidInputTypeException (message, missingParameters.ToImmutableHashSet ())
             if nullableMismatchParameters.Any () then
-                InvalidInputTypeException (
-                    $"Input object %s{objDef.Name} refers to type '%O{objtype}', but optional fields '%A{missingParameters}' are not optional parameters of the constructor",
-                    nullableMismatchParameters.ToImmutableHashSet ()
-                )
+                let message =
+                    let ``params`` = String.Join ("', '", nullableMismatchParameters)
+                    $"Input object %s{objDef.Name} refers to type '%O{objtype}', but constructor parameters for optional GraphQL fields '%s{``params``}' are not optional"
+                InvalidInputTypeException (message, nullableMismatchParameters.ToImmutableHashSet ())
             if typeMismatchParameters.Any () then
-                InvalidInputTypeException (
-                    $"Input object %s{objDef.Name} refers to type '%O{objtype}', but fields '%A{typeMismatchParameters}' have different types than constructor parameters",
-                    typeMismatchParameters.ToImmutableHashSet ()
-                )
+                let message =
+                    let ``params`` = String.Join ("', '", typeMismatchParameters)
+                    $"Input object %s{objDef.Name} refers to type '%O{objtype}', but GraphQL fields '%s{``params``}' have different types than constructor parameters"
+                InvalidInputTypeException (message, typeMismatchParameters.ToImmutableHashSet ())
         ]
         match exceptions with
         | [] -> ()

--- a/src/FSharp.Data.GraphQL.Server/Values.fs
+++ b/src/FSharp.Data.GraphQL.Server/Values.fs
@@ -208,6 +208,7 @@ let rec internal compileByType
                                 |> Result.map (normalizeOptional param.ParameterType)
                                 |> attachErrorExtensionsIfScalar inputSource inputObjectPath originalInputDef field
                         | ValueNone -> Ok <| wrapOptionalNone param.ParameterType typeof<obj>)
+                    |> Seq.toList
 
                 let! args = argResults |> splitSeqErrorsList
 
@@ -237,6 +238,7 @@ let rec internal compileByType
                                     return normalizeOptional param.ParameterType value
                                 | ValueNone -> return wrapOptionalNone param.ParameterType typeof<obj>
                             })
+                            |> Seq.toList
 
                         let! args = argResults |> splitSeqErrorsList
 
@@ -280,6 +282,7 @@ let rec internal compileByType
                 let! mappedValues =
                     list
                     |> Seq.mapi (fun i value -> inner i value variables)
+                    |> Seq.toList
                     |> splitSeqErrorsList
                 let mappedValues =
                     mappedValues
@@ -430,6 +433,7 @@ let rec internal coerceVariableValue
                             input.EnumerateArray ()
                             |> Seq.mapi (fun i elem ->
                                 coerceVariableValue areItemsNullable ((box i) :: inputObjectPath) ValueNone (originalTypeDef, innerDef) varDef elem)
+                            |> Seq.toList
                             |> splitSeqErrorsList
                         if areItemsNullable then
                             let some, none, _ = ReflectionHelper.optionOfType innerDef.Type.GenericTypeArguments[0]

--- a/src/FSharp.Data.GraphQL.Shared/Helpers/ObjAndStructConversions.fs
+++ b/src/FSharp.Data.GraphQL.Shared/Helpers/ObjAndStructConversions.fs
@@ -27,3 +27,7 @@ module internal Seq =
 module internal List =
 
     let vchoose mapping list = list |> Seq.vchoose mapping |> List.ofSeq
+
+module internal Array =
+
+    let vchoose mapping array = array |> Seq.vchoose mapping |> Array.ofSeq

--- a/tests/FSharp.Data.GraphQL.Tests/Variables and Inputs/OptionalsNormalizationTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/Variables and Inputs/OptionalsNormalizationTests.fs
@@ -99,11 +99,11 @@ module Address =
 
     open Scalars
 
-    let Line1Type = Define.ValidStringScalar<AddressLine1>("AddressLine1", createLine1, "Address line 1")
-    let Line2Type = Define.ValidStringScalar<AddressLine2>("AddressLine2", createLine2, "Address line 2")
-    let ZipCodeType = Define.ValidStringScalar<ZipCode>("AddressZipCode", createZipCode, "Address zip code")
-    let CityType = Define.ValidStringScalar<City>("City", createCity)
-    let StateType = Define.ValidStringScalar<State>("State", State.createOrWhitespace)
+    let Line1Type = Define.ValidStringScalar<AddressLine1>("AddressLine1", createLine1, ValidString.value, "Address line 1")
+    let Line2Type = Define.ValidStringScalar<AddressLine2>("AddressLine2", createLine2, ValidString.value, "Address line 2")
+    let ZipCodeType = Define.ValidStringScalar<ZipCode>("AddressZipCode", createZipCode, ValidString.value, "Address zip code")
+    let CityType = Define.ValidStringScalar<City>("City", createCity, ValidString.value)
+    let StateType = Define.ValidStringScalar<State>("State", State.createOrWhitespace, ValidString.value)
 
 let InputAddressRecordType =
     Define.InputObject<AddressRecord>(


### PR DESCRIPTION
1. Because coercion collections were of type `seq` the error-splitting logic called them twice causing double execution
2. Because collections passed to input object fields mismatch validation were not F# collections their string values used to not appear in the exception message.