### PR TITLE
Implemented the ability to recognize if an input field is null or not present at all

### DIFF
--- a/src/FSharp.Data.GraphQL.Server/Planning.fs
+++ b/src/FSharp.Data.GraphQL.Server/Planning.fs
@@ -31,6 +31,7 @@ let TypeMetaFieldDef =
         args = [
             { Name = "name"
               Description = None
+              IsSkippable = false
               TypeDef = StringType
               DefaultValue = None
               ExecuteInput = variableOrElse(InlineConstant >> coerceStringInput >> Result.map box) }

--- a/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
+++ b/src/FSharp.Data.GraphQL.Shared/TypeSystem.fs
@@ -1637,6 +1637,8 @@ and InputFieldDef =
         abstract Name : string
         /// Optional input field / argument description.
         abstract Description : string option
+        /// Not applied to input object if field is missing but does not allow null.
+        abstract IsSkippable : bool
         /// GraphQL type definition of the input type.
         abstract TypeDef : InputDef
         /// Optional default input value - used when no input was provided.
@@ -1654,6 +1656,8 @@ and [<CustomEquality; NoComparison>] InputFieldDefinition<'In> = {
     Name : string
     /// Optional input field / argument description.
     Description : string option
+    /// Not applied to input object if field is missing but does not allow null.
+    IsSkippable : bool
     /// GraphQL type definition of the input type.
     TypeDef : InputDef<'In>
     /// Optional default input value - used when no input was provided.
@@ -1666,6 +1670,7 @@ and [<CustomEquality; NoComparison>] InputFieldDefinition<'In> = {
     interface InputFieldDef with
         member x.Name = x.Name
         member x.Description = x.Description
+        member x.IsSkippable = x.IsSkippable
         member x.TypeDef = upcast x.TypeDef
         member x.DefaultValue = x.DefaultValue |> Option.map (fun x -> upcast x)
 

--- a/tests/FSharp.Data.GraphQL.Tests/FSharp.Data.GraphQL.Tests.fsproj
+++ b/tests/FSharp.Data.GraphQL.Tests/FSharp.Data.GraphQL.Tests.fsproj
@@ -53,6 +53,7 @@
     <Compile Include="Variables and Inputs\CoercionTests.fs" />
     <Compile Include="Variables and Inputs\OptionalsNormalizationTests.ValidString.fs" />
     <Compile Include="Variables and Inputs\OptionalsNormalizationTests.fs" />
+    <Compile Include="Variables and Inputs\SkippablesNormalizationTests.fs" />
     <Compile Include="Variables and Inputs\InputRecordTests.fs" />
     <Compile Include="Variables and Inputs\InputObjectValidatorTests.fs" />
     <Compile Include="Variables and Inputs\InputScalarAndAutoFieldScalarTests.fs" />

--- a/tests/FSharp.Data.GraphQL.Tests/Variables and Inputs/SkippablesNormalizationTests.fs
+++ b/tests/FSharp.Data.GraphQL.Tests/Variables and Inputs/SkippablesNormalizationTests.fs
@@ -1,0 +1,359 @@
+// The MIT License (MIT)
+
+[<CompilationRepresentation (CompilationRepresentationFlags.ModuleSuffix)>]
+module FSharp.Data.GraphQL.Tests.SkippablesNormalizationTests
+
+#nowarn "25"
+
+open Xunit
+open System
+open System.Collections.Immutable
+open System.Text.Json
+open System.Text.Json.Serialization
+
+open FSharp.Data.GraphQL
+open FSharp.Data.GraphQL.Types
+open FSharp.Data.GraphQL.Parser
+
+open FSharp.Data.GraphQL.Tests.OptionalsNormalizationTests
+
+type AddressRecord = {
+    Line1: AddressLine1 Skippable
+    Line2: AddressLine2 voption Skippable
+    City: City Skippable
+    State: State Skippable
+    ZipCode: ZipCode Skippable
+} with
+    member r.VerifyAllSkip =
+        Assert.True r.Line1.isSkip
+        Assert.True r.Line2.isSkip
+        Assert.True r.City.isSkip
+        Assert.True r.State.isSkip
+        Assert.True r.ZipCode.isSkip
+    member r.VerifySkipAndIncludeNull =
+        Assert.True r.Line1.isSkip
+        match r.Line2 with
+        | Skip -> fail "Expected Line2 to be 'Include ValueNone'"
+        | Include ValueNone -> ()
+        | Include _ -> fail "Expected Line2 to be 'Include ValueNone'"
+        Assert.True r.City.isSkip
+        Assert.True r.State.isSkip
+        Assert.True r.ZipCode.isSkip
+
+type AddressClass(zipCode, city, state, line1, line2) =
+    member _.Line1 : AddressLine1 Skippable = line1
+    member _.Line2 : AddressLine2 voption Skippable = line2
+    member _.City : City Skippable = city
+    member _.State : State Skippable = state
+    member _.ZipCode : ZipCode Skippable = zipCode
+
+    member _.VerifyAllSkip =
+        Assert.True line1.isSkip
+        Assert.True line2.isSkip
+        Assert.True city.isSkip
+        Assert.True state.isSkip
+        Assert.True zipCode.isSkip
+    member _.VerifySkipAndIncludeNull =
+        Assert.True line1.isSkip
+        match line2 with
+        | Skip -> fail "Expected Line2 to be 'Include ValueNone'"
+        | Include ValueNone -> ()
+        | Include _ -> fail "Expected Line2 to be 'Include ValueNone'"
+        Assert.True city.isSkip
+        Assert.True state.isSkip
+        Assert.True zipCode.isSkip
+
+[<Struct>]
+type AddressStruct (
+    zipCode : ZipCode Skippable,
+    city : City Skippable,
+    state : State Skippable,
+    line1 : AddressLine1 Skippable,
+    line2 : AddressLine2 voption Skippable
+) =
+    member _.Line1 = line1
+    member _.Line2 = line2
+    member _.City = city
+    member _.State = state
+    member _.ZipCode = zipCode
+
+    member _.VerifyAllSkip =
+        Assert.True line1.isSkip
+        Assert.True line2.isSkip
+        Assert.True city.isSkip
+        Assert.True state.isSkip
+        Assert.True zipCode.isSkip
+    member _.VerifySkipAndIncludeNull =
+        Assert.True line1.isSkip
+        match line2 with
+        | Skip -> fail "Expected Line2 to be 'Include ValueNone'"
+        | Include ValueNone -> ()
+        | Include _ -> fail "Expected Line2 to be 'Include ValueNone'"
+        Assert.True city.isSkip
+        Assert.True state.isSkip
+        Assert.True zipCode.isSkip
+
+
+open Validus
+open FSharp.Data.GraphQL.Tests.OptionalsNormalizationTests.String
+open FSharp.Data.GraphQL.Tests.OptionalsNormalizationTests.Operators
+
+[<RequireQualifiedAccess>]
+module State =
+
+    open ValidString
+    open Validus.Operators
+
+    let create : Validator<string, State> =
+        (Check.String.lessThanLen 100 <+> validateStringCharacters) *|* ValidString
+
+    let createOrWhitespace : Validator<string, State voption> =
+        (allowEmpty ?=> (Check.String.lessThanLen 100 <+> validateStringCharacters)) *|* ValueOption.map ValidString
+
+module Address =
+
+    open ValidString
+    open Validus.Operators
+
+    let createLine1 : Validator<string, AddressLine1> =
+        (Check.String.lessThanLen 1000 <+> validateStringCharacters) *|* ValidString
+
+    let createLine2 : Validator<string, AddressLine2 voption> =
+        (allowEmpty ?=> (Check.String.lessThanLen 1000 <+> validateStringCharacters)) *|* ValueOption.map ValidString
+
+    let createZipCode : Validator<string, ZipCode> =
+        (Check.String.lessThanLen 100 <+> validateStringCharacters) *|* ValidString
+
+    let createCity : Validator<string, City> =
+        (Check.String.lessThanLen 100 <+> validateStringCharacters) *|* ValidString
+
+
+    open Scalars
+
+    let Line1Type = Define.ValidStringScalar<AddressLine1>("AddressLine1", createLine1, ValidString.value, "Address line 1")
+    let Line2Type = Define.ValidStringScalar<AddressLine2>("AddressLine2", createLine2, ValidString.value, "Address line 2")
+    let ZipCodeType = Define.ValidStringScalar<ZipCode>("AddressZipCode", createZipCode, ValidString.value, "Address zip code")
+    let CityType = Define.ValidStringScalar<City>("City", createCity, ValidString.value)
+    let StateType = Define.ValidStringScalar<State>("State", State.createOrWhitespace, ValidString.value)
+
+let InputAddressRecordType =
+    Define.InputObject<AddressRecord>(
+        name = "InputAddressRecord",
+        fields = [
+            Define.SkippableInput("line1", Address.Line1Type)
+            Define.SkippableInput("line2", Nullable Address.Line2Type)
+            Define.SkippableInput("zipCode", Address.ZipCodeType)
+            Define.SkippableInput("city", Address.CityType)
+            Define.SkippableInput("state", Address.StateType)
+        ]
+    )
+
+let InputAddressClassType =
+    Define.InputObject<AddressClass>(
+        name = "InputAddressObject",
+        fields = [
+            Define.SkippableInput("line1", Address.Line1Type)
+            Define.SkippableInput("line2", Nullable Address.Line2Type)
+            Define.SkippableInput("zipCode", Address.ZipCodeType)
+            Define.SkippableInput("city", Address.CityType)
+            Define.SkippableInput("state", Address.StateType)
+        ]
+    )
+
+let InputAddressStructType =
+    Define.InputObject<AddressStruct>(
+        name = "InputAddressStruct",
+        fields = [
+            Define.SkippableInput("line1", Address.Line1Type)
+            Define.SkippableInput("line2", Nullable Address.Line2Type)
+            Define.SkippableInput("zipCode", Address.ZipCodeType)
+            Define.SkippableInput("city", Address.CityType)
+            Define.SkippableInput("state", Address.StateType)
+        ]
+    )
+
+open FSharp.Data.GraphQL.Execution
+open FSharp.Data.GraphQL.Validation
+open FSharp.Data.GraphQL.Validation.ValidationResult
+open ErrorHelpers
+
+let createSingleError message =
+    [{ new IGQLError with member _.Message = message }]
+
+type InputRecordNested = { HomeAddress : AddressRecord; WorkAddress : AddressRecord Skippable; MailingAddress : AddressRecord Skippable }
+
+let InputRecordNestedType =
+    Define.InputObject<InputRecordNested> (
+        "InputRecordNested",
+        [ Define.Input ("homeAddress", InputAddressRecordType)
+          Define.SkippableInput ("workAddress", InputAddressRecordType)
+          Define.SkippableInput ("mailingAddress", InputAddressRecordType) ],
+        fun inputRecord ->
+            match inputRecord.MailingAddress, inputRecord.WorkAddress with
+            | Skip, Skip -> ValidationError <| createSingleError "MailingAddress or WorkAddress must be provided"
+            | _ -> Success
+            @@
+            if inputRecord.MailingAddress.isInclude && inputRecord.HomeAddress = (inputRecord.MailingAddress |> Skippable.toValueOption).Value then
+                ValidationError <| createSingleError "HomeAddress and MailingAddress must be different"
+            else
+                Success
+    )
+
+type Verify =
+    | Nothing
+    | Skip
+    | SkipAndIncludeNull
+
+let schema verify =
+    let schema =
+        Schema (
+            query =
+                Define.Object (
+                    "Query",
+                    [ Define.Field (
+                          "recordInputs",
+                          StringType,
+                          [ Define.Input ("record", InputAddressRecordType)
+                            Define.Input ("recordOptional", Nullable InputAddressRecordType)
+                            Define.Input ("recordNested", Nullable InputRecordNestedType) ],
+                            (fun ctx name ->
+                                let record = ctx.Arg<AddressRecord>("record")
+                                let recordOptional = ctx.TryArg<AddressRecord>("recordOptional")
+                                let recordNested = ctx.Arg<InputRecordNested>("recordNested")
+                                match verify with
+                                | Nothing -> ()
+                                | Skip ->
+                                    record.VerifyAllSkip
+                                    recordOptional |> Option.iter _.VerifyAllSkip
+                                    recordNested.HomeAddress.VerifyAllSkip
+                                | SkipAndIncludeNull ->
+                                    record.VerifySkipAndIncludeNull
+                                    recordOptional |> Option.iter _.VerifySkipAndIncludeNull
+                                    recordNested.HomeAddress.VerifySkipAndIncludeNull
+                                stringifyInput ctx name
+                            )
+                      ) // TODO: add all args stringificaiton
+                      Define.Field (
+                          "objectInputs",
+                          StringType,
+                          [ Define.Input ("object", InputAddressClassType)
+                            Define.Input ("objectOptional", Nullable InputAddressClassType) ],
+                            (fun ctx name ->
+                                let obj = ctx.Arg<AddressClass>("object")
+                                let objOptional = ctx.TryArg<AddressClass>("objectOptional")
+                                match verify with
+                                | Nothing -> ()
+                                | Skip ->
+                                    obj.VerifyAllSkip
+                                    objOptional |> Option.iter _.VerifyAllSkip
+                                | SkipAndIncludeNull ->
+                                    obj.VerifySkipAndIncludeNull
+                                    objOptional |> Option.iter _.VerifySkipAndIncludeNull
+                                stringifyInput ctx name
+                            )
+                      ) // TODO: add all args stringificaiton
+                      Define.Field (
+                          "structInputs",
+                          StringType,
+                          [ Define.Input ("struct", InputAddressStructType)
+                            Define.Input ("structOptional", Nullable InputAddressStructType) ],
+                            (fun ctx name ->
+                                let obj = ctx.Arg<AddressStruct>("struct")
+                                let objOptional = ctx.TryArg<AddressStruct>("structOptional")
+                                match verify with
+                                | Nothing -> ()
+                                | Skip ->
+                                    obj.VerifyAllSkip
+                                    objOptional |> Option.iter _.VerifyAllSkip
+                                | SkipAndIncludeNull ->
+                                    obj.VerifySkipAndIncludeNull
+                                    objOptional |> Option.iter _.VerifySkipAndIncludeNull
+                                stringifyInput ctx name
+                            )
+                      ) ] // TODO: add all args stringificaiton
+                )
+        )
+
+    Executor schema
+
+
+[<Fact>]
+let ``Execute handles validation of valid inline input records with all fields`` () =
+    let query =
+        """{
+      recordInputs(
+        record: { zipCode: "12345", city: "Miami" },
+        recordOptional: { zipCode: "12345", city: "Miami" },
+        recordNested: { homeAddress: { zipCode: "12345", city: "Miami" }, workAddress: { zipCode: "67890", city: "Miami" } }
+      )
+      objectInputs(
+        object: { zipCode: "12345", city: "Miami" },
+        objectOptional: { zipCode: "12345", city: "Miami" }
+      )
+      structInputs(
+        struct: { zipCode: "12345", city: "Miami" },
+        structOptional: { zipCode: "12345", city: "Miami" }
+      )
+    }"""
+    let result = sync <| (schema Nothing).AsyncExecute(parse query)
+    ensureDirect result <| fun data errors -> empty errors
+
+[<Fact>]
+let ``Execute handles validation of valid inline input records with mandatory-only fields`` () =
+    let query =
+        """{
+      recordInputs(
+        record: { zipCode: "12345", city: "Miami" },
+        recordNested: { homeAddress: { zipCode: "12345", city: "Miami" }, workAddress: { zipCode: "67890", city: "Miami" } }
+      )
+      objectInputs(
+        object: { zipCode: "12345", city: "Miami" },
+      )
+      structInputs(
+        struct: { zipCode: "12345", city: "Miami" },
+      )
+    }"""
+    let result = sync <| (schema Nothing).AsyncExecute(parse query)
+    ensureDirect result <| fun data errors -> empty errors
+
+[<Fact>]
+let ``Execute handles validation of valid inline input records with null mandatory skippable fields`` () =
+    let query =
+        """{
+      recordInputs(
+        record: { zipCode: null, city: null },
+        recordOptional: { zipCode: null, city: null },
+        recordNested: { homeAddress: { zipCode: null, city: null }, workAddress: { zipCode: null, city: null } }
+      )
+      objectInputs(
+        object: { zipCode: null, city: null },
+        objectOptional: { zipCode: null, city: null }
+      )
+      structInputs(
+        struct: { zipCode: null, city: null },
+        structOptional: { zipCode: null, city: null }
+      )
+    }"""
+    let result = sync <| (schema Skip).AsyncExecute(parse query)
+    ensureDirect result <| fun data errors -> empty errors
+
+[<Fact>]
+let ``Execute handles validation of valid inline input records with null optional field`` () =
+    let query =
+        """{
+      recordInputs(
+        record: { line2: null },
+        recordOptional: { line2: null },
+        recordNested: { homeAddress: { line2: null }, workAddress: { line2: null }, mailingAddress: { line1: "", line2: null } }
+      )
+      objectInputs(
+        object: { line2: null },
+        objectOptional: { line2: null }
+      )
+      structInputs(
+        struct: { line2: null },
+        structOptional: { line2: null }
+      )
+    }"""
+    let result = sync <| (schema SkipAndIncludeNull).AsyncExecute(parse query)
+    ensureDirect result <| fun data errors -> empty errors


### PR DESCRIPTION
Imagine you have an address
``` F#
type AddressRecord = {
    Line1: AddressLine1 Skippable
    Line2: AddressLine2 voption Skippable
    City: City Skippable
    State: State Skippable
    ZipCode: ZipCode Skippable
}
```
and you want to patch it (apply changes to only particular fields keeping the other untouched).

Then you can send such an input object
``` JSON
{
  "line1": "New value"
  "line2": null // means clear value
  // skip other properties, means do not change them
}
```

To support this approach we need to be able to recognize if a field is null or missing and to support converting input values into `System.Text.Json.Serialization.Skippable` where missing value is `Skip`, `null` value is `Include None`/`Include ValueNone` (when class constructor parameter is `Option`/`ValueOption` and `Skip` otherwise) and `value` is `Include value`

See StarWarsApi for usage sample