### PR TITLE
Fix `TimeSpan.FromMilliseconds` ambiguity with .NET 10

### DIFF
--- a/src/FSharp.Data.GraphQL.Server.AspNetCore/GraphQLOptions.fs
+++ b/src/FSharp.Data.GraphQL.Server.AspNetCore/GraphQLOptions.fs
@@ -13,7 +13,7 @@ module GraphQLOptionsDefaults =
 
     let [<Literal>] ReadBufferSize = 4096
     let [<Literal>] WebSocketEndpoint = "/ws"
-    let [<Literal>] WebSocketConnectionInitTimeoutInMs = 3000
+    let [<Literal>] WebSocketConnectionInitTimeoutInMs = 3000.0
 
 module GraphQLOptions =
 


### PR DESCRIPTION
When trying to build for .NET 10, I'm getting

> FSharp.Data.GraphQL/src/FSharp.Data.GraphQL.Server.AspNetCore/ServiceCollectionExtensions.fs(23,37): error FS0041: A unique overload for method 'FromMilliseconds' could not be determined based on type information prior to this program point. A type annotation may be needed.Known type of argument: intCandidates: - TimeSpan.FromMilliseconds(milliseconds: int64) : TimeSpan - TimeSpan.FromMilliseconds(value: float) : TimeSpan [/src/submodules/FSharp.Data.GraphQL/src/FSharp.Data.GraphQL.Server.AspNetCore/FSharp.Data.GraphQL.Server.AspNetCore.fsproj::TargetFramework=net10.0]

The reason is that in .NET 9.0 TimeSpan.FromMilliseconds had 2 overloads:
- FromMilliseconds(Int64, Int64)
- FromMilliseconds(Double)

In .NET 10.0 there are now 3 overloads:
- FromMilliseconds(Int64, Int64)
- FromMilliseconds(Double)
- FromMilliseconds(Int64)

... and F# doesn't know whether it should convert the provided int32 into an int64 or double.

This patch defaults to double which makes it compile with both .NET 9 and 10.